### PR TITLE
feat(wayscriber): add wayscriber screen annotation tool

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,11 @@
       url = "github:zed-industries/zed";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    wayscriber = {
+      url = "github:devmobasa/wayscriber";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/modules/apps/gui/wayscriber/default.nix
+++ b/modules/apps/gui/wayscriber/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  config,
+  inputs,
+  ...
+}:
+
+let
+  cfg = config.apps.gui.wayscriber;
+in
+{
+  options = {
+    apps.gui.wayscriber.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable Wayscriber real-time screen annotation tool for Wayland.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      inputs.wayscriber.packages.x86_64-linux.default
+    ];
+  };
+}

--- a/modules/suites/offcomms/default.nix
+++ b/modules/suites/offcomms/default.nix
@@ -26,6 +26,7 @@ in
       signal.enable = true;
       typora.enable = true;
       typora.nautilusIntegration = true;
+      wayscriber.enable = true;
     };
 
     # Web apps for office reference desktop


### PR DESCRIPTION
## Summary
- Add wayscriber GUI module (`modules/apps/gui/wayscriber/`) with flake input from `devmobasa/wayscriber`
- Enable wayscriber in the offcomms suite so all workstation hosts get it
- Add `wayscriber` flake input with nixpkgs follows

## Test plan
- [ ] `nix flake lock --update-input wayscriber` succeeds
- [ ] `nixos-rebuild switch` builds without errors
- [ ] `wayscriber` launches on a Wayland session

Closes #5