### PR TITLE
feat(jwtx): add jwtx terminal JWT decoder/encoder TUI

### DIFF
--- a/modules/apps/cli/jwtx/build/default.nix
+++ b/modules/apps/cli/jwtx/build/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versions,
+}:
+
+let
+  v = versions.cli.jwtx;
+in
+buildGoModule rec {
+  pname = "jwtx";
+  inherit (v) version;
+
+  src = fetchFromGitHub {
+    owner = "gurleensethi";
+    repo = "jwtx";
+    rev = version;
+    inherit (v) hash;
+  };
+
+  inherit (v) vendorHash;
+
+  doCheck = false;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = with lib; {
+    description = "A terminal JWT decoder/encoder TUI";
+    homepage = "https://github.com/gurleensethi/jwtx";
+    license = licenses.mit;
+    maintainers = [ ];
+    mainProgram = "jwtx";
+  };
+}

--- a/modules/apps/cli/jwtx/default.nix
+++ b/modules/apps/cli/jwtx/default.nix
@@ -1,0 +1,25 @@
+{
+  pkgs,
+  config,
+  lib,
+  versions,
+  ...
+}:
+
+let
+  cfg = config.apps.cli.jwtx;
+  jwtx = pkgs.callPackage ./build { inherit versions; };
+in
+{
+  options = {
+    apps.cli.jwtx.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable jwtx terminal JWT decoder/encoder TUI.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ jwtx ];
+  };
+}

--- a/modules/suites/infrastructure/default.nix
+++ b/modules/suites/infrastructure/default.nix
@@ -21,6 +21,9 @@ in
     # Enable Docker
     apps.cli.docker.enable = true;
 
+    # JWT tools
+    apps.cli.jwtx.enable = true;
+
     # Infrastructure and cloud tools
     environment.systemPackages = with pkgs; [
       # Cloud utilities

--- a/settings/versions.nix
+++ b/settings/versions.nix
@@ -73,6 +73,15 @@
       hash = "sha256-8jP6I2zsDt57STtuq4F9mcsckrjvaCE5lavqKTjhNT0=";
     };
 
+    jwtx = {
+      source = "github-release";
+      repo = "gurleensethi/jwtx";
+      version = "0.5.0";
+      tagPrefix = "";
+      hash = "sha256-DtgZRrF5s0SMEZnMYp5a8zkDptYbB6h0ihuP8PpGgWY=";
+      vendorHash = "sha256-/6DyRRvfyShQUSFmpmuSxrd1bhBh6Km8kaMutA4xrH4=";
+    };
+
     lazyrestic = {
       source = "github-commit";
       repo = "craigderington/lazyrestic";


### PR DESCRIPTION
## Summary
- Add jwtx module with local build directory pattern using `buildGoModule`
- Pin version 0.5.0 in `settings/versions.nix` with source and vendor hashes
- Enable in infrastructure suite

## Test plan
- [x] `just quiet-rebuild` succeeds
- [x] `which jwtx` resolves to `/run/current-system/sw/bin/jwtx`
- [x] Run `jwtx` to confirm TUI launches correctly

Closes #7