### PR TITLE
feat(plannotator): add plannotator plan review module

### DIFF
--- a/modules/apps/cli/plannotator/build/default.nix
+++ b/modules/apps/cli/plannotator/build/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  pkgs,
+  versions,
+}:
+
+let
+  v = versions.cli.plannotator;
+  mainBin = pkgs.fetchurl {
+    url = "https://github.com/${v.repo}/releases/download/v${v.version}/plannotator-linux-x64";
+    inherit (v) hash;
+  };
+  pasteBin = pkgs.fetchurl {
+    url = "https://github.com/${v.repo}/releases/download/v${v.version}/plannotator-paste-linux-x64";
+    hash = v.pasteHash;
+  };
+in
+pkgs.stdenv.mkDerivation {
+  pname = "plannotator";
+  inherit (v) version;
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ pkgs.autoPatchelfHook ];
+  buildInputs = [ pkgs.stdenv.cc.cc.lib ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${mainBin} $out/bin/plannotator
+    cp ${pasteBin} $out/bin/plannotator-paste
+    chmod +x $out/bin/plannotator $out/bin/plannotator-paste
+  '';
+
+  meta = {
+    description = "Interactive plan review system for AI coding agents";
+    homepage = "https://github.com/backnotprop/plannotator";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = [ ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "plannotator";
+  };
+}

--- a/modules/apps/cli/plannotator/commands/plannotator-annotate.md
+++ b/modules/apps/cli/plannotator/commands/plannotator-annotate.md
@@ -1,0 +1,12 @@
+---
+description: Open interactive annotation UI for a markdown file
+allowed-tools: Bash(plannotator:*)
+---
+
+## Markdown Annotations
+
+!`plannotator annotate $ARGUMENTS`
+
+## Your task
+
+Address the annotation feedback above. The user has reviewed the markdown file and provided specific annotations and comments.

--- a/modules/apps/cli/plannotator/commands/plannotator-review.md
+++ b/modules/apps/cli/plannotator/commands/plannotator-review.md
@@ -1,0 +1,12 @@
+---
+description: Open interactive code review for current changes
+allowed-tools: Bash(plannotator:*)
+---
+
+## Code Review Feedback
+
+!`plannotator review`
+
+## Your task
+
+Address the code review feedback above. The user has reviewed your changes in the Plannotator UI and provided specific annotations and comments.

--- a/modules/apps/cli/plannotator/default.nix
+++ b/modules/apps/cli/plannotator/default.nix
@@ -1,0 +1,30 @@
+{
+  pkgs,
+  config,
+  lib,
+  globals,
+  versions,
+  ...
+}:
+
+let
+  cfg = config.apps.cli.plannotator;
+  plannotator = pkgs.callPackage ./build { inherit versions; };
+in
+{
+  options = {
+    apps.cli.plannotator.enable = lib.mkEnableOption "plannotator interactive plan review for AI coding agents";
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ plannotator ];
+
+    home-manager.users.${globals.user.name} = {
+      home.file = {
+        ".claude/commands/plannotator-review.md".text = builtins.readFile ./commands/plannotator-review.md;
+        ".claude/commands/plannotator-annotate.md".text =
+          builtins.readFile ./commands/plannotator-annotate.md;
+      };
+    };
+  };
+}

--- a/modules/suites/ai/default.nix
+++ b/modules/suites/ai/default.nix
@@ -34,6 +34,7 @@ in
           ];
         };
       };
+      plannotator.enable = true;
       ollama = {
         enable = false;
         loadModels = [ "glm-5:cloud" ];

--- a/settings/versions.nix
+++ b/settings/versions.nix
@@ -82,6 +82,15 @@
       vendorHash = "sha256-/6DyRRvfyShQUSFmpmuSxrd1bhBh6Km8kaMutA4xrH4=";
     };
 
+    plannotator = {
+      source = "github-release";
+      repo = "backnotprop/plannotator";
+      version = "0.11.4";
+      tagPrefix = "v";
+      hash = "sha256-J/Jp7lM85Yl8VXV+UynOdFmc6m45vAV6lDYc0Xl40yA=";
+      pasteHash = "sha256-9tyfjE4gkdrTuwkgldyRxwdHIcag8wYL3zJ/BJ9mA/g=";
+    };
+
     lazyrestic = {
       source = "github-commit";
       repo = "craigderington/lazyrestic";


### PR DESCRIPTION
## Summary
- Packages plannotator (v0.11.4) as a NixOS module with prebuilt binaries from GitHub releases
- Uses `autoPatchelfHook` for NixOS dynamic linking compatibility
- Includes both `plannotator` and `plannotator-paste` binaries
- Declaratively installs Claude Code slash commands (`/plannotator-review`, `/plannotator-annotate`)
- Adds version pin to `settings/versions.nix` with SRI hashes
- Enables in the AI suite

## Test plan
- [x] `nixos-rebuild switch` succeeds
- [x] `which plannotator` resolves to `/run/current-system/sw/bin/plannotator`
- [x] `which plannotator-paste` resolves correctly
- [x] Slash command files present at `~/.claude/commands/plannotator-*.md`

Closes #9