### PR TITLE
feat(stop-slop): add stop-slop AI writing pattern detection skill

### DIFF
--- a/modules/apps/cli/stop-slop/default.nix
+++ b/modules/apps/cli/stop-slop/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  pkgs,
+  config,
+  globals,
+  ...
+}:
+let
+  cfg = config.apps.cli.stop-slop;
+
+  stop-slop-src = pkgs.fetchFromGitHub {
+    owner = "hardikpandya";
+    repo = "stop-slop";
+    rev = "65d52b35d7243427ac646e83eae5a9b0709aa191";
+    hash = "sha256-NcwN37kSKOO+4QIhIEVafFtg15KCufmxTJiX3AGQRh0=";
+  };
+in
+{
+  options = {
+    apps.cli.stop-slop.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable stop-slop Claude Code skill for detecting AI writing patterns.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home-manager.users.${globals.user.name} = {
+      # Uses home.file directly (matching what programs.claude-code.skills
+      # does internally for directory paths) because fetchFromGitHub returns
+      # a derivation, not a Nix path literal that lib.types.path requires.
+      home.file.".claude/skills/stop-slop" = {
+        source = stop-slop-src;
+        recursive = true;
+      };
+    };
+  };
+}

--- a/modules/suites/ai/default.nix
+++ b/modules/suites/ai/default.nix
@@ -35,6 +35,7 @@ in
         };
       };
       plannotator.enable = true;
+      stop-slop.enable = true;
       ollama = {
         enable = false;
         loadModels = [ "glm-5:cloud" ];


### PR DESCRIPTION
## Summary

- Adds new `apps.cli.stop-slop` NixOS module that fetches the [stop-slop](https://github.com/hardikpandya/stop-slop) Claude Code skill via `fetchFromGitHub`
- Registers the skill directory (SKILL.md + references/) using `home.file` with `recursive = true`, matching what `programs.claude-code.skills` does internally for directory paths
- Enables stop-slop in the AI suite

Closes #8

## Test plan

- [x] `just qr` rebuild succeeds
- [x] `~/.claude/skills/stop-slop/SKILL.md` exists with correct content
- [x] `~/.claude/skills/stop-slop/references/` contains all reference files (examples.md, phrases.md, structures.md)