### PR TITLE
Install Komikku and comics-downloader

### DIFF
--- a/modules/apps/gui/comics/build/default.nix
+++ b/modules/apps/gui/comics/build/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versions,
+}:
+
+let
+  v = versions.gui.comics-downloader;
+in
+buildGoModule rec {
+  pname = "comics-downloader";
+  inherit (v) version;
+
+  src = fetchFromGitHub {
+    owner = "Girbons";
+    repo = "comics-downloader";
+    rev = "v${version}";
+    inherit (v) hash;
+  };
+
+  inherit (v) vendorHash;
+
+  subPackages = [ "cmd/downloader" ];
+
+  doCheck = false;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = with lib; {
+    description = "Tool to download comics and manga from various sites";
+    homepage = "https://github.com/Girbons/comics-downloader";
+    license = licenses.mit;
+    maintainers = [ ];
+    mainProgram = "comics-downloader";
+  };
+}

--- a/modules/apps/gui/comics/default.nix
+++ b/modules/apps/gui/comics/default.nix
@@ -1,0 +1,30 @@
+{
+  pkgs,
+  config,
+  lib,
+  versions,
+  ...
+}:
+
+let
+  cfg = config.apps.gui.comics;
+  comics-downloader = pkgs.callPackage ./build { inherit versions; };
+in
+{
+  options = {
+    apps.gui.comics.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable comics suite with Komikku manga reader and comics-downloader.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      # keep-sorted start case=no numeric=yes
+      comics-downloader # download comics and manga from various sites
+      pkgs.komikku # manga reader for GNOME
+      # keep-sorted end
+    ];
+  };
+}

--- a/modules/suites/av/default.nix
+++ b/modules/suites/av/default.nix
@@ -21,6 +21,7 @@ in
     apps.gui = {
       affinity.enable = true;
       cameractrls.enable = true;
+      comics.enable = true;
     };
 
     apps.cli = {

--- a/settings/versions.nix
+++ b/settings/versions.nix
@@ -121,6 +121,15 @@
   };
 
   gui = {
+    comics-downloader = {
+      source = "github-release";
+      repo = "Girbons/comics-downloader";
+      version = "0.33.9";
+      tagPrefix = "v";
+      hash = "sha256-/Y7m7D7l2j42eErkD5+YNw01w/hJ3k3K4JEDKmCPw0w=";
+      vendorHash = "sha256-aVDe+SFszKQPXeOdkh9l7iO0yfdIcVQp+rXqkDUY92U=";
+    };
+
     insomnia = {
       source = "github-release";
       repo = "Kong/insomnia";


### PR DESCRIPTION
## Summary
Closes #33: Install Komikku and comics-downloader

- feat(comics): ✨ add comics module with komikku and comics-downloader

- Merge pull request #35 from bashfulrobot/feat/31-lossless-cut-install
  lossless-cut Install
- feat(av): ✨ add lossless-cut to av suite

- Merge pull request #34 from bashfulrobot/feat/30-llmfit-install-via-flake
  llmfit Install via flake
- feat(llmfit): ✨ install llmfit TUI via flake input in ai suite