### PR TITLE
Install gurk-rs via home manager

### DIFF
--- a/modules/apps/cli/gurk/build/default.nix
+++ b/modules/apps/cli/gurk/build/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  pkgs,
+  versions,
+  ...
+}:
+
+let
+  v = versions.cli.gurk;
+in
+pkgs.stdenv.mkDerivation {
+  name = "gurk";
+
+  src = pkgs.fetchurl {
+    url = "https://github.com/boxdot/gurk-rs/releases/download/v${v.version}/gurk-x86_64-unknown-linux-gnu.tar.gz";
+    inherit (v) hash;
+  };
+
+  nativeBuildInputs = [ pkgs.autoPatchelfHook ];
+
+  buildInputs = [
+    pkgs.stdenv.cc.cc.lib
+    pkgs.openssl
+  ];
+
+  sourceRoot = ".";
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp gurk $out/bin/gurk
+    chmod +x $out/bin/gurk
+  '';
+
+  meta = with lib; {
+    description = "Signal Messenger client for terminal - https://github.com/boxdot/gurk-rs";
+    homepage = "https://github.com/boxdot/gurk-rs";
+    license = licenses.agpl3Only;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "gurk";
+    maintainers = [ ];
+  };
+}

--- a/modules/apps/cli/gurk/default.nix
+++ b/modules/apps/cli/gurk/default.nix
@@ -1,0 +1,25 @@
+{
+  pkgs,
+  config,
+  lib,
+  versions,
+  ...
+}:
+
+let
+  cfg = config.apps.cli.gurk;
+  gurk = pkgs.callPackage ./build { inherit versions; };
+in
+{
+  options = {
+    apps.cli.gurk.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable gurk-rs, a Signal Messenger TUI client.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ gurk ];
+  };
+}

--- a/modules/suites/offcomms/default.nix
+++ b/modules/suites/offcomms/default.nix
@@ -40,6 +40,7 @@ in
       };
 
       cli = {
+        gurk.enable = true;
         meetsum.enable = true;
         pandoc.enable = true;
         percollate.enable = true;

--- a/settings/versions.nix
+++ b/settings/versions.nix
@@ -110,6 +110,14 @@
       pasteHash = "sha256-9tyfjE4gkdrTuwkgldyRxwdHIcag8wYL3zJ/BJ9mA/g=";
     };
 
+    gurk = {
+      source = "github-release";
+      repo = "boxdot/gurk-rs";
+      version = "0.9.0";
+      tagPrefix = "v";
+      hash = "sha256-ZTT1wJvNuYjd1QYjw5lVC2C+MZNu0NBmeEi5eOO+f5c=";
+    };
+
     lazyrestic = {
       source = "github-commit";
       repo = "craigderington/lazyrestic";


### PR DESCRIPTION
## Summary
Closes #32: Install gurk-rs via home manager

- feat(gurk): ✨ add gurk-rs signal TUI client to offcomms suite