### PR TITLE
feat(worktree-flow): overhaul github-issue lifecycle for autonomous operation

### DIFF
--- a/modules/apps/cli/worktree-flow/scripts/github-issue.sh
+++ b/modules/apps/cli/worktree-flow/scripts/github-issue.sh
@@ -6,24 +6,27 @@ if [[ "${1:-}" == "--help" ]] || [[ "${1:-}" == "-h" ]]; then
   info "Usage: github-issue <subcommand> [args]"
   info ""
   info "Subcommands:"
-  info "  setup <number>                          -- create worktree + state file"
+  info "  setup <number> [--base <ref>]           -- create worktree pinned to base (default origin/main)"
   info "  status <number>                         -- detect lifecycle state"
-  info "  push <number>                           -- push branch + create/update PR"
-  info "  audit                                   -- scan all issue worktrees"
-  info "  cleanup <number>                        -- remove worktree + branches"
-  info "  transition <number> <step> [--detail-json '<json>']"
-  info "                                          -- advance workflow state"
+  info "  push <number>                           -- silent pre-push rebase, push branch, create/update PR, propagate labels"
+  info "  auto-merge <number>                     -- enable GitHub auto-merge (squash) on the PR"
+  info "  audit                                   -- scan worktrees, surface overlap and blocker-ordered merge queue"
+  info "  cleanup <number>                        -- remove worktree + branches, rebase overlapping worktrees"
+  info "  transition <number> <step> --note '...' [--detail-json '<json>']"
+  info "                                          -- advance workflow state (note is required)"
   info "  validate-cwd <number>                   -- check working directory"
   info "  check-ci <number>                       -- check PR CI status"
   info "  review-feedback <number>                -- fetch PR review comments"
+  info "  post-mortem <number>                    -- gather close-context for agent synthesis"
   exit 0
 fi
 
-# ── State v2 constants ────────────────────────────────────────────────────────
+# ── State v3 constants ────────────────────────────────────────────────────────
 
-VALID_STEPS=(setup assess design plan implement verify push review_dev review_security waiting revamp "done" closed)
+VALID_STEPS=(setup assess design plan implement verify push review_dev review_security waiting revamp ci_fix "done" closed)
 
 # Transition whitelist: from -> space-separated valid targets
+# ci_fix is post-push CI failure (distinct from revamp which is review feedback)
 declare -A VALID_TRANSITIONS=(
   [setup]="assess"
   [assess]="design plan implement"
@@ -31,11 +34,12 @@ declare -A VALID_TRANSITIONS=(
   [plan]="implement"
   [implement]="verify"
   [verify]="implement push waiting"
-  [push]="review_dev waiting"
+  [push]="review_dev ci_fix waiting"
   [review_dev]="review_security"
   [review_security]="waiting"
-  [waiting]="done revamp closed"
+  [waiting]="done revamp ci_fix closed"
   [revamp]="verify"
+  [ci_fix]="verify"
   [done]=""
   [closed]=""
 )
@@ -113,7 +117,7 @@ build_branch_name() {
   printf '%s/%s-%s' "$branch_type" "$issue_number" "$slug"
 }
 
-# ── State v2 helpers ─────────────────────────────────────────────────────────
+# ── State v3 helpers ─────────────────────────────────────────────────────────
 
 create_issue_state() {
   local branch="$1"
@@ -121,20 +125,24 @@ create_issue_state() {
   local issue_number="$3"
   local issue_title="$4"
   local issue_body="$5"
+  local base_ref="$6"
+  local blockers_json="${7:-[]}"
   local timestamp
   timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   local json
   json="$(jq -n \
-    --argjson version 2 \
+    --argjson version 3 \
     --arg type "issue" \
     --arg issue_number "$issue_number" \
     --arg issue_title "$issue_title" \
     --arg issue_body "$issue_body" \
     --arg branch "$branch" \
+    --arg base_ref "$base_ref" \
     --arg wt_path "$wt_path" \
     --arg pr_url "" \
     --arg session_id "" \
     --arg workflow_step "assess" \
+    --argjson blockers "$blockers_json" \
     --arg started_at "$timestamp" \
     --arg updated_at "$timestamp" \
     '{
@@ -144,12 +152,13 @@ create_issue_state() {
       issue_title: $issue_title,
       issue_body: $issue_body,
       branch: $branch,
+      base_ref: $base_ref,
       wt_path: $wt_path,
       pr_url: $pr_url,
       session_id: $session_id,
       workflow_step: $workflow_step,
-      workflow_detail: {complexity: null, plan_file: null, review_stage: null, revamp_round: 0, blocker: null},
-      step_history: [{step: "setup", completed_at: $started_at}],
+      workflow_detail: {complexity: null, plan_file: null, review_stage: null, revamp_round: 0, blockers: $blockers, open_threads: []},
+      step_history: [{step: "setup", completed_at: $started_at, note: "Worktree created from \($base_ref)."}],
       started_at: $started_at,
       updated_at: $updated_at
     }')"
@@ -175,60 +184,106 @@ is_valid_transition() {
   return 1
 }
 
-# Migrate v1 state files (no version field) to v2
-migrate_v1_state() {
+# Migrate state files forward: v1 (no version) -> v2 -> v3.
+# v1 lacks `version`; v2 has version=2; v3 has version=3 plus base_ref, per-step
+# notes, workflow_detail.blockers (array), workflow_detail.open_threads.
+migrate_state() {
   local wt_path="$1"
   local state_file="${wt_path}/.worktree-state.json"
 
-  # Already v2
   local version
   version="$(jq -r '.version // empty' "$state_file" 2>/dev/null)" || version=""
-  if [[ "$version" == "2" ]]; then
-    return 0
+
+  # v1 -> v2: synthesize version+workflow_step from legacy phase
+  if [[ -z "$version" ]]; then
+    local phase
+    phase="$(jq -r '.phase // "setup"' "$state_file")"
+    local workflow_step
+    case "$phase" in
+      setup) workflow_step="assess" ;;
+      claude_running | claude_exited) workflow_step="implement" ;;
+      pushing) workflow_step="push" ;;
+      pr_created) workflow_step="waiting" ;;
+      *) workflow_step="assess" ;;
+    esac
+
+    local timestamp current updated
+    timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    current="$(cat "$state_file")"
+    updated="$(printf '%s' "$current" | jq \
+      --argjson version 2 \
+      --arg workflow_step "$workflow_step" \
+      --arg updated_at "$timestamp" \
+      '. + {
+        version: $version,
+        workflow_step: $workflow_step,
+        workflow_detail: (.workflow_detail // {complexity: null, plan_file: null, review_stage: null, revamp_round: 0, blocker: null}),
+        step_history: (.step_history // []),
+        updated_at: $updated_at
+      }')"
+    write_state "$updated" "$wt_path"
+    ok "migrated state v1 -> v2 (phase=${phase} -> workflow_step=${workflow_step})"
+    version="2"
   fi
 
-  local phase
-  phase="$(jq -r '.phase // "setup"' "$state_file")"
+  # v2 -> v3: add base_ref (inferred from default branch), open_threads,
+  # migrate scalar `blocker` -> `blockers` array, backfill empty notes.
+  if [[ "$version" == "2" ]]; then
+    local default_br
+    default_br="$(default_branch)"
+    local inferred_base="origin/${default_br}"
 
-  # Map v1 phase to v2 workflow_step
-  local workflow_step
-  case "$phase" in
-    setup) workflow_step="assess" ;;
-    claude_running | claude_exited) workflow_step="implement" ;;
-    pushing) workflow_step="push" ;;
-    pr_created) workflow_step="waiting" ;;
-    *) workflow_step="assess" ;;
-  esac
-
-  local timestamp
-  timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-  local current updated
-  current="$(cat "$state_file")"
-  updated="$(printf '%s' "$current" | jq \
-    --argjson version 2 \
-    --arg workflow_step "$workflow_step" \
-    --arg updated_at "$timestamp" \
-    '. + {
-      version: $version,
-      workflow_step: $workflow_step,
-      workflow_detail: (.workflow_detail // {complexity: null, plan_file: null, review_stage: null, revamp_round: 0, blocker: null}),
-      step_history: (.step_history // []),
-      updated_at: $updated_at
-    }')"
-  write_state "$updated" "$wt_path"
-  ok "migrated state v1 -> v2 (phase=${phase} -> workflow_step=${workflow_step})"
+    local timestamp current updated
+    timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    current="$(cat "$state_file")"
+    updated="$(printf '%s' "$current" | jq \
+      --argjson version 3 \
+      --arg base_ref "$inferred_base" \
+      --arg updated_at "$timestamp" \
+      '. + {
+        version: $version,
+        base_ref: (.base_ref // $base_ref),
+        workflow_detail: (
+          (.workflow_detail // {})
+          | (
+              if has("blocker") and (.blocker != null)
+              then . + {blockers: [.blocker]}
+              else . + {blockers: (.blockers // [])}
+              end
+            )
+          | . + {open_threads: (.open_threads // [])}
+          | del(.blocker)
+        ),
+        step_history: ((.step_history // []) | map(. + {note: (.note // "")})),
+        updated_at: $updated_at
+      }')"
+    write_state "$updated" "$wt_path"
+    ok "migrated state v2 -> v3 (added base_ref=${inferred_base}, blockers array, open_threads, per-step notes)"
+  fi
 }
 
-# Reconcile workflow_step with git/PR signals
+# Back-compat shim for any callers still using the v1-named helper.
+migrate_v1_state() { migrate_state "$@"; }
+
+# Reconcile workflow_step with git/PR/CI signals. Returns nothing; mutates state.
+# Signals handled:
+#   - PR merged -> done
+#   - PR closed without merge -> closed
+#   - PR open + changes_requested (from waiting) -> revamp
+#   - PR open + CI failing (from waiting/push/review_*) -> ci_fix
+#   - commits exist but step pre-implementation -> implement
+#   - PR exists but step still push -> review_dev
 reconcile_state() {
   local wt_path="$1" branch="$2" pr_url="$3" default_br="$4"
   local state_file="${wt_path}/.worktree-state.json"
-  local workflow_step
+  local workflow_step base_ref
   workflow_step="$(jq -r '.workflow_step' "$state_file")"
+  base_ref="$(jq -r '.base_ref // empty' "$state_file")"
+  [[ -z "$base_ref" ]] && base_ref="origin/${default_br}"
 
   local new_step=""
+  local reconcile_note=""
 
-  # Check PR state if URL exists
   if [[ -n "$pr_url" ]]; then
     local pr_state
     pr_state="$(gh pr view "$pr_url" --json state --jq '.state' 2>/dev/null)" || pr_state=""
@@ -237,42 +292,52 @@ reconcile_state() {
       MERGED)
         if [[ "$workflow_step" != "done" ]]; then
           new_step="done"
+          reconcile_note="PR merged."
         fi
         ;;
       CLOSED)
         if [[ "$workflow_step" != "closed" ]]; then
           new_step="closed"
+          reconcile_note="PR closed without merge."
         fi
         ;;
       OPEN)
-        local review
+        local review ci_conclusion
         review="$(gh pr view "$pr_url" --json reviewDecision --jq '.reviewDecision // ""' 2>/dev/null)" || review=""
-        if [[ "$review" == "CHANGES_REQUESTED" ]] && [[ "$workflow_step" == "waiting" ]]; then
+        ci_conclusion="$(detect_ci_conclusion "$pr_url")"
+
+        if [[ "$ci_conclusion" == "failing" ]] && [[ "$workflow_step" == "waiting" || "$workflow_step" == "push" || "$workflow_step" == "review_dev" || "$workflow_step" == "review_security" ]]; then
+          new_step="ci_fix"
+          reconcile_note="CI failing on PR — routed to ci_fix."
+        elif [[ "$review" == "CHANGES_REQUESTED" ]] && [[ "$workflow_step" == "waiting" ]]; then
           new_step="revamp"
+          reconcile_note="Reviewer requested changes — routed to revamp."
         fi
         ;;
     esac
   else
-    # No PR — check branch merge status
     if is_branch_merged "$branch"; then
       if [[ "$workflow_step" != "done" ]]; then
         new_step="done"
+        reconcile_note="Branch merged to ${default_br}."
       fi
     fi
   fi
 
   # Commits exist but step says pre-implementation
-  if [[ "$workflow_step" == "plan" ]] || [[ "$workflow_step" == "assess" ]] || [[ "$workflow_step" == "design" ]]; then
+  if [[ -z "$new_step" ]] && { [[ "$workflow_step" == "plan" ]] || [[ "$workflow_step" == "assess" ]] || [[ "$workflow_step" == "design" ]]; }; then
     local commit_count
     commit_count="$(git -C "$wt_path" rev-list --count "${default_br}..${branch}" 2>/dev/null)" || commit_count="0"
     if [[ "$commit_count" -gt 0 ]]; then
       new_step="implement"
+      reconcile_note="Commits detected — advanced to implement."
     fi
   fi
 
   # PR exists but step says push
-  if [[ "$workflow_step" == "push" ]] && [[ -n "$pr_url" ]]; then
+  if [[ -z "$new_step" ]] && [[ "$workflow_step" == "push" ]] && [[ -n "$pr_url" ]]; then
     new_step="review_dev"
+    reconcile_note="PR created — advanced to review_dev."
   fi
 
   if [[ -n "$new_step" ]]; then
@@ -283,17 +348,88 @@ reconcile_state() {
     updated="$(printf '%s' "$current" | jq \
       --arg step "$new_step" \
       --arg t "$timestamp" \
+      --arg note "$reconcile_note" \
       '.workflow_step = $step | .updated_at = $t |
-       .step_history = .step_history + [{step: $step, completed_at: $t, reconciled: true}]')"
+       .step_history = .step_history + [{step: $step, completed_at: $t, reconciled: true, note: $note}]')"
     write_state "$updated" "$wt_path"
     ok "reconciled workflow_step: ${workflow_step} -> ${new_step}"
   fi
 }
 
+# Summarize PR CI state as "passing" | "failing" | "pending" | "none".
+detect_ci_conclusion() {
+  local pr_url="$1"
+  local checks_json
+  checks_json="$(gh pr checks "$pr_url" --json state,conclusion 2>/dev/null)" || checks_json="[]"
+  local total failing pending passing
+  total="$(printf '%s' "$checks_json" | jq 'length')"
+  if [[ "$total" -eq 0 ]]; then
+    printf 'none'
+    return
+  fi
+  failing="$(printf '%s' "$checks_json" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')"
+  pending="$(printf '%s' "$checks_json" | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS")] | length')"
+  passing="$(printf '%s' "$checks_json" | jq '[.[] | select(.conclusion == "SUCCESS" or .conclusion == "NEUTRAL")] | length')"
+  if [[ "$failing" -gt 0 ]]; then
+    printf 'failing'
+  elif [[ "$pending" -gt 0 ]]; then
+    printf 'pending'
+  elif [[ "$passing" -eq "$total" ]]; then
+    printf 'passing'
+  else
+    printf 'none'
+  fi
+}
+
 # ── Subcommands ──────────────────────────────────────────────────────────────
 
+# Parse blocker references from issue body. Matches "Blocked by #N",
+# "Depends on #N", "Requires #N", "Needs #N" (case-insensitive). For each
+# hit, fetches issue state + title via gh. Emits JSON array:
+#   [{"number": N, "state": "OPEN"|"CLOSED", "title": "..."}]
+# Missing/unreachable issues are skipped silently (offline-safe).
+parse_blockers() {
+  local body="$1"
+  local numbers
+  numbers="$(printf '%s' "$body" \
+    | grep -oiE '(blocked by|depends on|requires|needs)[[:space:]]*#[0-9]+' \
+    | grep -oE '[0-9]+' \
+    | sort -u)"
+
+  local result="[]"
+  local n entry
+  while IFS= read -r n; do
+    [[ -z "$n" ]] && continue
+    entry="$(gh issue view "$n" --json number,state,title 2>/dev/null)" || continue
+    result="$(printf '%s' "$result" | jq --argjson e "$entry" '. + [$e]')"
+  done <<<"$numbers"
+  printf '%s' "$result"
+}
+
 cmd_setup() {
-  local issue_number="${1:?usage: github-issue setup <issue-number>}"
+  local issue_number=""
+  local base_ref=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --base)
+        base_ref="${2:?--base requires a value}"
+        shift 2
+        ;;
+      -*)
+        die "unknown option: $1"
+        ;;
+      *)
+        if [[ -z "$issue_number" ]]; then
+          issue_number="$1"
+          shift
+        else
+          die "unexpected argument: $1"
+        fi
+        ;;
+    esac
+  done
+  [[ -n "$issue_number" ]] || die "usage: github-issue setup <issue-number> [--base <ref>]"
+
   local wt_path
   wt_path="$(worktree_base)/issue-${issue_number}"
 
@@ -304,12 +440,34 @@ cmd_setup() {
   fetch_remote
   assert_clean_tree
 
+  # Resolve base: default to origin/<default-branch>. Verify it exists.
+  local default_br
+  default_br="$(default_branch)"
+  if [[ -z "$base_ref" ]]; then
+    base_ref="origin/${default_br}"
+  fi
+  git rev-parse --verify --quiet "$base_ref" >/dev/null \
+    || die "base ref '${base_ref}' does not resolve -- run 'git fetch origin' or pass a valid --base"
+  ok "base: ${base_ref}"
+
   local issue_json issue_title issue_labels issue_body
   issue_json="$(fetch_issue_metadata "$issue_number")"
   issue_title="$(printf '%s' "$issue_json" | jq -r '.title')"
   issue_labels="$(printf '%s' "$issue_json" | jq -c '.labels')"
   issue_body="$(printf '%s' "$issue_json" | jq -r '.body')"
   ok "fetched: ${issue_title}"
+
+  # Parse blockers. Warn if any are still OPEN but don't block setup — user can
+  # proceed knowingly. Blocker state is persisted for use by audit merge-ordering.
+  local blockers_json open_blockers_count
+  blockers_json="$(parse_blockers "$issue_body")"
+  open_blockers_count="$(printf '%s' "$blockers_json" | jq '[.[] | select(.state == "OPEN")] | length')"
+  if [[ "$open_blockers_count" -gt 0 ]]; then
+    warn "issue #${issue_number} references ${open_blockers_count} open blocker(s):"
+    while IFS= read -r line; do
+      [[ -n "$line" ]] && warn "  ${line}"
+    done < <(printf '%s' "$blockers_json" | jq -r '.[] | select(.state == "OPEN") | "#\(.number) [\(.state)] \(.title)"')
+  fi
 
   local branch_type
   branch_type="$(derive_branch_type_auto "$issue_labels")"
@@ -320,23 +478,27 @@ cmd_setup() {
   ok "branch: ${branch_name}"
 
   mkdir -p "$(dirname "$wt_path")"
-  git worktree add --no-checkout "$wt_path" -b "$branch_name"
+  # Pin branch explicitly to base_ref so the new branch never inherits an
+  # accidental stack from whatever HEAD happened to be when this ran.
+  git worktree add --no-checkout "$wt_path" -b "$branch_name" "$base_ref"
   register_cleanup "$wt_path"
   checkout_and_unlock "$wt_path"
-  create_issue_state "$branch_name" "$wt_path" "$issue_number" "$issue_title" "$issue_body"
+  create_issue_state "$branch_name" "$wt_path" "$issue_number" "$issue_title" "$issue_body" "$base_ref" "$blockers_json"
   _WT_CLEANUP_PATH=""
   ok "worktree created at ${wt_path}"
 
   json_ok "$(jq -n \
     --arg issue_number "$issue_number" \
     --arg branch "$branch_name" \
+    --arg base_ref "$base_ref" \
     --arg worktree "$wt_path" \
     --arg branch_type "$branch_type" \
     --arg title "$issue_title" \
     --arg issue_body "$issue_body" \
-    '{issue_number: ($issue_number|tonumber), branch: $branch, worktree: $worktree,
+    --argjson blockers "$blockers_json" \
+    '{issue_number: ($issue_number|tonumber), branch: $branch, base_ref: $base_ref, worktree: $worktree,
       branch_type: $branch_type, title: $title, issue_body: $issue_body,
-      workflow_step: "assess"}')"
+      blockers: $blockers, workflow_step: "assess"}')"
 }
 
 cmd_status() {
@@ -359,8 +521,8 @@ cmd_status() {
     json_error "worktree exists but no state file at ${state_file}"
   fi
 
-  # Migrate v1 -> v2 if needed
-  migrate_v1_state "$wt_path"
+  # Migrate to current schema version if needed.
+  migrate_state "$wt_path"
 
   local branch pr_url issue_title issue_body workflow_step workflow_detail step_history
   branch="$(jq -r '.branch' "$state_file")"
@@ -427,27 +589,45 @@ cmd_push() {
     json_error "no worktree for issue #${issue_number}"
   fi
 
-  local branch pr_url issue_title default_br
+  migrate_state "$wt_path"
+
+  local branch pr_url issue_title default_br base_ref issue_labels
   branch="$(read_state_field branch "$wt_path")"
   pr_url="$(read_state_field pr_url "$wt_path" 2>/dev/null || echo "")"
   issue_title="$(read_state_field issue_title "$wt_path")"
   default_br="$(default_branch)"
+  base_ref="$(jq -r '.base_ref // empty' "${wt_path}/.worktree-state.json")"
+  [[ -z "$base_ref" ]] && base_ref="origin/${default_br}"
 
-  # Check for commits
+  # Silent pre-push rebase. Refresh base, check whether we're already ahead of
+  # it, and rebase only when needed. A successful rebase makes later pushes
+  # non-fast-forward, so we switch to --force-with-lease for PR updates.
+  fetch_remote
+  local rebased=0
+  if ! git -C "$wt_path" merge-base --is-ancestor "$base_ref" "$branch" 2>/dev/null; then
+    info "rebasing ${branch} onto ${base_ref}..."
+    if ! git -C "$wt_path" rebase "$base_ref" >&2; then
+      git -C "$wt_path" rebase --abort 2>/dev/null || true
+      json_error "rebase onto ${base_ref} produced conflicts -- agent must resolve. Run 'git -C ${wt_path} rebase ${base_ref}' and address conflicts before retrying push."
+    fi
+    rebased=1
+    ok "rebased onto ${base_ref}"
+  fi
+
+  # commits-vs-base check (not commits-vs-default; base may differ in future)
   local commit_count
-  commit_count="$(git -C "$wt_path" rev-list --count "${default_br}..${branch}")"
+  commit_count="$(git -C "$wt_path" rev-list --count "${base_ref}..${branch}")"
   if [[ "$commit_count" -eq 0 ]]; then
-    json_error "no commits on branch ${branch} -- nothing to push"
+    json_error "no commits on branch ${branch} relative to ${base_ref} -- nothing to push"
   fi
 
   local action=""
   if [[ -z "$pr_url" ]]; then
-    # Push + create PR
     (cd "$wt_path" && safe_push "$branch")
     ok "branch pushed"
 
     local commit_log pr_body
-    commit_log="$(git -C "$wt_path" log --format='- %s%n%w(0,2,2)%b' "${default_br}..${branch}")"
+    commit_log="$(git -C "$wt_path" log --format='- %s%n%w(0,2,2)%b' "${base_ref}..${branch}")"
     pr_body="$(printf '## Summary\nCloses #%s: %s\n\n%s' "$issue_number" "$issue_title" "$commit_log")"
 
     pr_url="$(cd "$wt_path" && gh pr create \
@@ -456,7 +636,19 @@ cmd_push() {
       --head "$branch")"
     ok "PR created: ${pr_url}"
 
-    # Update state with PR URL
+    # Propagate issue labels to PR. Safe no-op when the issue has none.
+    issue_labels="$(gh issue view "$issue_number" --json labels --jq '[.labels[].name]' 2>/dev/null)" || issue_labels="[]"
+    local label_count
+    label_count="$(printf '%s' "$issue_labels" | jq 'length')"
+    if [[ "$label_count" -gt 0 ]]; then
+      local label_args=()
+      while IFS= read -r name; do
+        [[ -n "$name" ]] && label_args+=(--add-label "$name")
+      done < <(printf '%s' "$issue_labels" | jq -r '.[]')
+      gh pr edit "$pr_url" "${label_args[@]}" >/dev/null 2>&1 || warn "could not apply some labels to PR"
+      ok "propagated ${label_count} label(s) from issue to PR"
+    fi
+
     local current updated timestamp
     current="$(cat "${wt_path}/.worktree-state.json")"
     timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
@@ -469,8 +661,14 @@ cmd_push() {
     gh issue comment "$issue_number" --body "PR ready for review: $pr_url" 2>/dev/null || true
     action="created"
   else
-    # Push updates to existing PR
-    (cd "$wt_path" && git push origin "$branch")
+    # Rebasing rewrites history, so subsequent pushes to an existing PR branch
+    # require --force-with-lease. Never --force — avoids clobbering concurrent
+    # updates pushed from elsewhere.
+    if [[ "$rebased" -eq 1 ]]; then
+      (cd "$wt_path" && assert_not_main && git push --force-with-lease origin "$branch")
+    else
+      (cd "$wt_path" && assert_not_main && git push origin "$branch")
+    fi
     ok "updates pushed to PR: ${pr_url}"
     action="updated"
   fi
@@ -505,6 +703,14 @@ cmd_push() {
       branch: $branch, commits: $commits, ci_status: $ci_status}')"
 }
 
+# Compute the set of files changed on branch vs. its base. Used by audit to
+# surface cross-worktree overlap. Emits newline-delimited paths; empty on
+# offline/error.
+branch_touched_files() {
+  local wt_dir="$1" branch="$2" base_ref="$3"
+  git -C "$wt_dir" diff "${base_ref}...${branch}" --name-only 2>/dev/null || true
+}
+
 cmd_audit() {
   fetch_remote
 
@@ -512,7 +718,7 @@ cmd_audit() {
   wt_base="$(worktree_base)"
 
   if [[ ! -d "$wt_base" ]]; then
-    json_ok "[]"
+    json_ok '{"worktrees": [], "overlaps": [], "merge_order": []}'
     return
   fi
 
@@ -528,17 +734,24 @@ cmd_audit() {
     wt_type="$(jq -r '.type' "$state_file")"
     [[ "$wt_type" == "issue" ]] || continue
 
-    # Migrate v1 if needed
-    migrate_v1_state "$wt_dir"
+    migrate_state "$wt_dir"
 
-    local issue_num issue_title branch pr_url workflow_step
+    local issue_num issue_title branch pr_url workflow_step base_ref blockers
     issue_num="$(jq -r '.issue_number' "$state_file")"
     issue_title="$(jq -r '.issue_title' "$state_file")"
     branch="$(jq -r '.branch' "$state_file")"
     pr_url="$(jq -r '.pr_url // ""' "$state_file")"
     workflow_step="$(jq -r '.workflow_step' "$state_file")"
+    base_ref="$(jq -r '.base_ref // empty' "$state_file")"
+    [[ -z "$base_ref" ]] && base_ref="origin/${default_br}"
+    blockers="$(jq -c '.workflow_detail.blockers // []' "$state_file")"
 
     detect_issue_state "$wt_dir" "$branch" "$pr_url" "$default_br"
+
+    # Collect touched-file list for overlap pass below.
+    local touched_files_json
+    touched_files_json="$(branch_touched_files "$wt_dir" "$branch" "$base_ref" \
+      | jq -Rsc 'split("\n") | map(select(length > 0))')"
 
     results="$(printf '%s' "$results" | jq \
       --arg num "$issue_num" \
@@ -546,16 +759,61 @@ cmd_audit() {
       --arg state "$_detected_state" \
       --arg detail "$_detected_detail" \
       --arg branch "$branch" \
+      --arg base_ref "$base_ref" \
       --arg pr_url "$pr_url" \
       --arg worktree "$wt_dir" \
       --arg workflow_step "$workflow_step" \
+      --argjson blockers "$blockers" \
+      --argjson touched "$touched_files_json" \
       '. + [{issue_number: ($num|tonumber), title: $title, state: $state,
-              detail: $detail, branch: $branch,
+              detail: $detail, branch: $branch, base_ref: $base_ref,
               pr_url: (if $pr_url == "" then null else $pr_url end),
-              worktree: $worktree, workflow_step: $workflow_step}]')"
+              worktree: $worktree, workflow_step: $workflow_step,
+              blockers: $blockers, touched_files: $touched}]')"
   done < <(find "$wt_base" -maxdepth 1 -mindepth 1 -type d -name 'issue-*' -print0 2>/dev/null)
 
-  json_ok "$results"
+  # Overlap pass: every pair of active worktrees that share >=1 touched file.
+  # Surfaces merge-conflict risk before it materializes.
+  local overlaps
+  overlaps="$(printf '%s' "$results" | jq '
+    [
+      . as $all
+      | range(0; length) as $i
+      | range($i+1; length) as $j
+      | {
+          a: $all[$i].issue_number,
+          b: $all[$j].issue_number,
+          shared: (($all[$i].touched_files // []) - (($all[$i].touched_files // []) - ($all[$j].touched_files // [])))
+        }
+      | select((.shared | length) > 0)
+    ]
+  ')"
+
+  # Merge-ordering: take worktrees whose PR is mergeable (waiting or
+  # review_security with an open PR), annotate each with the set of peer
+  # issues it unblocks, then sort so issues that unblock the most peers
+  # merge first. Non-mergeable worktrees are excluded.
+  local merge_order
+  merge_order="$(printf '%s' "$results" | jq '
+    [ .[] | select(.pr_url != null and (.workflow_step == "waiting" or .workflow_step == "review_security")) ]
+    | . as $mergeable
+    | map(. as $item
+          | . + {
+              blocks: [
+                $mergeable[]
+                | select(.blockers | map(.number) | index($item.issue_number))
+                | .issue_number
+              ]
+            })
+    | sort_by(-(.blocks | length))
+    | map({issue_number, title, pr_url, workflow_step, blocks})
+  ')"
+
+  json_ok "$(jq -n \
+    --argjson worktrees "$results" \
+    --argjson overlaps "$overlaps" \
+    --argjson merge_order "$merge_order" \
+    '{worktrees: $worktrees, overlaps: $overlaps, merge_order: $merge_order}')"
 }
 
 cmd_cleanup() {
@@ -612,23 +870,32 @@ cmd_cleanup() {
 }
 
 cmd_transition() {
-  local issue_number="${1:?usage: github-issue transition <issue-number> <step> [--detail-json '<json>']}"
-  local new_step="${2:?usage: github-issue transition <issue-number> <step>}"
+  local issue_number="${1:?usage: github-issue transition <issue-number> <step> --note '...' [--detail-json '<json>']}"
+  local new_step="${2:?usage: github-issue transition <issue-number> <step> --note '...'}"
   shift 2
 
-  # Parse optional --detail-json
   local detail_json="{}"
+  local note=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --detail-json)
         detail_json="${2:?--detail-json requires a value}"
         shift 2
         ;;
+      --note)
+        note="${2:?--note requires a value}"
+        shift 2
+        ;;
       *) die "unknown option: $1" ;;
     esac
   done
 
-  # Validate step name
+  # --note is mandatory. Autonomous resume depends on every transition leaving
+  # a trail the next agent can read.
+  if [[ -z "$note" ]]; then
+    json_error "--note '<short summary of what happened>' is required on transition"
+  fi
+
   if ! is_valid_step "$new_step"; then
     json_error "invalid step '${new_step}' -- valid steps: ${VALID_STEPS[*]}"
   fi
@@ -645,18 +912,15 @@ cmd_transition() {
     json_error "worktree exists but no state file"
   fi
 
-  # Migrate v1 if needed
-  migrate_v1_state "$wt_path"
+  migrate_state "$wt_path"
 
   local current_step
   current_step="$(jq -r '.workflow_step' "$state_file")"
 
-  # Validate transition
   if ! is_valid_transition "$current_step" "$new_step"; then
     json_error "invalid transition: ${current_step} -> ${new_step} -- allowed from ${current_step}: ${VALID_TRANSITIONS[$current_step]:-none}"
   fi
 
-  # Validate detail_json is valid JSON
   if ! printf '%s' "$detail_json" | jq . >/dev/null 2>&1; then
     json_error "invalid --detail-json: not valid JSON"
   fi
@@ -668,20 +932,22 @@ cmd_transition() {
   updated="$(printf '%s' "$current" | jq \
     --arg step "$new_step" \
     --arg t "$timestamp" \
+    --arg note "$note" \
     --argjson detail "$detail_json" \
     '.workflow_step = $step |
      .updated_at = $t |
      .workflow_detail = (.workflow_detail // {}) * $detail |
-     .step_history = (.step_history // []) + [{step: $step, completed_at: $t}]')"
+     .step_history = (.step_history // []) + [{step: $step, completed_at: $t, note: $note}]')"
   write_state "$updated" "$wt_path"
 
   json_ok "$(jq -n \
     --arg issue_number "$issue_number" \
     --arg previous_step "$current_step" \
     --arg current_step "$new_step" \
+    --arg note "$note" \
     --arg updated_at "$timestamp" \
     '{issue_number: ($issue_number|tonumber), previous_step: $previous_step,
-      current_step: $current_step, updated_at: $updated_at}')"
+      current_step: $current_step, note: $note, updated_at: $updated_at}')"
 }
 
 cmd_validate_cwd() {
@@ -814,10 +1080,118 @@ cmd_review_feedback() {
       inline_comments: $inline_comments}')"
 }
 
+# Enable GitHub-side auto-merge (squash). The merge lands the moment branch
+# protection, required reviews, and CI are all satisfied. The skill's state
+# machine still polls status; reconciliation detects the merge and routes to
+# done.
+cmd_auto_merge() {
+  local issue_number="${1:?usage: github-issue auto-merge <issue-number>}"
+  local wt_path
+  wt_path="$(worktree_base)/issue-${issue_number}"
+
+  if [[ ! -d "$wt_path" ]]; then
+    json_error "no worktree for issue #${issue_number}"
+  fi
+
+  local pr_url
+  pr_url="$(read_state_field pr_url "$wt_path" 2>/dev/null || echo "")"
+  if [[ -z "$pr_url" ]] || [[ "$pr_url" == "null" ]]; then
+    json_error "no PR exists for issue #${issue_number} -- push first"
+  fi
+
+  local enabled="false"
+  local message=""
+  if gh pr merge "$pr_url" --auto --squash >/dev/null 2>&1; then
+    enabled="true"
+    message="auto-merge (squash) enabled"
+    ok "$message on ${pr_url}"
+  else
+    # Most common non-error cause: branch protection doesn't allow auto-merge,
+    # or PR is already mergeable and gh would need --merge instead.
+    local pr_state
+    pr_state="$(gh pr view "$pr_url" --json state,mergeStateStatus 2>/dev/null)" || pr_state="{}"
+    message="could not enable auto-merge ($(printf '%s' "$pr_state" | jq -r '.mergeStateStatus // "unknown"'))"
+    warn "$message"
+  fi
+
+  json_ok "$(jq -n \
+    --arg issue_number "$issue_number" \
+    --arg pr_url "$pr_url" \
+    --arg enabled "$enabled" \
+    --arg message "$message" \
+    '{issue_number: ($issue_number|tonumber), pr_url: $pr_url,
+      auto_merge_enabled: ($enabled == "true"), message: $message}')"
+}
+
+# Gather close-context for agent synthesis of a post-mortem comment.
+# Returns PR state, review summary (latest reviews + inline comments), CI
+# history at close, commit log, and last few step_history notes. The skill
+# then writes a short comment on the issue.
+cmd_post_mortem() {
+  local issue_number="${1:?usage: github-issue post-mortem <issue-number>}"
+  local wt_path
+  wt_path="$(worktree_base)/issue-${issue_number}"
+
+  if [[ ! -d "$wt_path" ]]; then
+    json_error "no worktree for issue #${issue_number}"
+  fi
+
+  migrate_state "$wt_path"
+
+  local state_file="${wt_path}/.worktree-state.json"
+  local branch pr_url base_ref workflow_step
+  branch="$(jq -r '.branch' "$state_file")"
+  pr_url="$(jq -r '.pr_url // ""' "$state_file")"
+  base_ref="$(jq -r '.base_ref // empty' "$state_file")"
+  workflow_step="$(jq -r '.workflow_step' "$state_file")"
+
+  local default_br
+  default_br="$(default_branch)"
+  [[ -z "$base_ref" ]] && base_ref="origin/${default_br}"
+
+  local pr_json reviews inline_comments checks commits step_notes
+  if [[ -n "$pr_url" ]]; then
+    pr_json="$(gh pr view "$pr_url" --json state,title,url,author,mergeStateStatus,closedAt,updatedAt 2>/dev/null)" || pr_json="{}"
+    local pr_number repo_path
+    pr_number="$(printf '%s' "$pr_url" | grep -oE '[0-9]+$' || echo "")"
+    repo_path="$(printf '%s' "$pr_url" | sed 's|https://github.com/||; s|/pull/[0-9]*$||')"
+    reviews="$(gh api "repos/${repo_path}/pulls/${pr_number}/reviews" \
+      --jq '[.[] | {state, body, author: .user.login, submitted_at}]' 2>/dev/null)" || reviews="[]"
+    inline_comments="$(gh api "repos/${repo_path}/pulls/${pr_number}/comments" \
+      --jq '[.[] | {path, line: (.line // .original_line), body, author: .user.login}]' 2>/dev/null)" || inline_comments="[]"
+    checks="$(gh pr checks "$pr_url" --json name,state,conclusion 2>/dev/null)" || checks="[]"
+  else
+    pr_json="{}"
+    reviews="[]"
+    inline_comments="[]"
+    checks="[]"
+  fi
+
+  commits="$(git -C "$wt_path" log --format='%H%x09%s' "${base_ref}..${branch}" 2>/dev/null \
+    | jq -Rsc 'split("\n") | map(select(length > 0) | split("\t") | {sha: .[0], subject: .[1]})')" \
+    || commits="[]"
+  step_notes="$(jq -c '[.step_history[-10:][] | {step, completed_at, note}]' "$state_file")"
+
+  json_ok "$(jq -n \
+    --arg issue_number "$issue_number" \
+    --arg pr_url "$pr_url" \
+    --arg workflow_step "$workflow_step" \
+    --argjson pr "$pr_json" \
+    --argjson reviews "$reviews" \
+    --argjson inline_comments "$inline_comments" \
+    --argjson checks "$checks" \
+    --argjson commits "$commits" \
+    --argjson step_notes "$step_notes" \
+    '{issue_number: ($issue_number|tonumber), pr_url: (if $pr_url == "" then null else $pr_url end),
+      workflow_step: $workflow_step, pr: $pr, reviews: $reviews,
+      inline_comments: $inline_comments, checks: $checks, commits: $commits,
+      recent_step_notes: $step_notes}')"
+}
+
 # ── Entry point ──────────────────────────────────────────────────────────────
 
 case "${1:-}" in
-  setup | status | push | audit | cleanup | transition | validate-cwd | check-ci | review-feedback)
+  setup | status | push | audit | cleanup | transition | validate-cwd | check-ci | review-feedback | auto-merge | post-mortem)
     _JSON_MODE=1
     SUBCMD="${1//-/_}"
     shift

--- a/modules/apps/cli/worktree-flow/skills/github-issue/SKILL.md
+++ b/modules/apps/cli/worktree-flow/skills/github-issue/SKILL.md
@@ -8,13 +8,19 @@ description: Use when working on a GitHub issue (by number or URL), checking iss
 
 # GitHub Issue Workflow
 
-State-machine orchestrator for the full GitHub issue lifecycle. Uses the `github-issue` CLI for all mechanical operations (worktree creation, state management, push+PR, cleanup). AI handles only judgment work — classification, design, implementation, review evaluation.
+State-machine orchestrator for the full GitHub issue lifecycle. Uses the `github-issue` CLI for mechanical operations (worktree creation pinned to main, state management, pre-push rebase, push+PR+label-propagation, auto-merge, cleanup). AI handles only judgment work — classification, design, implementation, review evaluation, conflict resolution.
 
 All work happens in an isolated git worktree. Never implement in the main working tree.
 
+## Branching Rules
+
+- **Base is always `origin/main`** (or the repo's default branch). The CLI pins the branch to this base at `setup` time; the worktree does not inherit from current HEAD. A SessionStart `git-sync` hook keeps local main fresh.
+- **No stacking.** Do not branch off another in-progress branch. If issue B depends on issue A, wait for A to merge, then start B.
+- `setup` accepts `--base <ref>` for explicit override. Do not use this unless the user asked for stacking.
+
 ## Worktree Anchoring
 
-The skill uses the `EnterWorktree` tool to persist cwd at the session level, so every subsequent Bash call runs inside the worktree without needing a `cd <worktree> &&` prefix. This is set up once during **Setup** (see below) and holds across sub-skill invocations.
+The skill uses the `EnterWorktree` tool to persist cwd at the session level, so every subsequent Bash call runs inside the worktree without needing a `cd <worktree> &&` prefix. This is set up once during **Setup** and holds across sub-skill invocations.
 
 **Fallback check** — if a sub-skill (brainstorming, writing-plans, executing-plans, verification, receiving-code-review) appears to have disturbed cwd, re-verify:
 
@@ -24,33 +30,48 @@ github-issue validate-cwd <number>
 
 If `valid` is false, call `EnterWorktree` with `path: <worktree-path>` to re-anchor, or run the `fix` command as a last resort.
 
+## Transition notes
+
+Every `github-issue transition` **requires** `--note '<short summary>'`. The note is persisted in `step_history` and becomes the breadcrumb the next agent (or you, resuming tomorrow) reads to pick up context. Write a one-sentence note covering *what happened this step and any loose threads*.
+
+Open threads the agent knows about but hasn't resolved (e.g., intermittent test failure, questionable assumption, TODO in a file) go into `workflow_detail.open_threads` via:
+
+```bash
+github-issue transition <N> <step> --note "..." --detail-json '{"open_threads": ["verify intermittent failure in src/foo.test.ts:142"]}'
+```
+
 ## Entry Point
 
-### 1. Audit active worktrees
+### 1. If no issue number provided — audit active work
 
 ```bash
 github-issue audit
 ```
 
-Report any active worktrees. Flag `done` worktrees for cleanup.
+Returns `{worktrees, overlaps, merge_order}`:
+- `worktrees`: list of active issue worktrees with step, PR, base_ref, blockers, touched_files.
+- `overlaps`: pairs of worktrees sharing touched files — surfaces merge-conflict risk ahead of time.
+- `merge_order`: mergeable PRs ordered by blocker graph (issues that unblock others merge first).
 
-### 2. If no issue number provided — list open issues
+Then list open issues so the user can pick one:
 
 ```bash
 gh issue list --state open --limit 20 --json number,title,labels
 ```
 
-Present the list. Let the user pick one.
-
-### 3. Detect state
+### 2. If an issue number is provided — skip audit, go straight to status
 
 ```bash
 github-issue status <number>
 ```
 
-Route on `workflow_step`. If `workflow_step` is null (v1 migration), fall back to `state`.
+`audit` is fleet-survey; it is unnecessary overhead when you already know which issue you're touching.
 
-**If a worktree already exists** (any `workflow_step` other than the `(no worktree)` case), anchor the session to it immediately using the `EnterWorktree` tool with `path: <worktree>` from the status response. All subsequent Bash calls will then run inside the worktree.
+### 3. Detect state and route
+
+Route on `workflow_step`.
+
+**If a worktree already exists**, anchor the session to it immediately using the `EnterWorktree` tool with `path: <worktree>` from the status response. All subsequent Bash calls will then run inside the worktree.
 
 ## State Routing
 
@@ -62,13 +83,14 @@ Route on `workflow_step`. If `workflow_step` is null (v1 migration), fall back t
 | `plan` | Invoke `superpowers:writing-plans` |
 | `implement` | Code the solution in the worktree |
 | `verify` | Invoke `superpowers:verification-before-completion` |
-| `push` | `github-issue push <N>` |
+| `push` | `github-issue push <N>` (rebases silently, creates PR, propagates labels) |
 | `review_dev` | Invoke `/review-dev` via Skill tool, handle findings; on clean auto-chain to `review_security` |
-| `review_security` | UI-only skip check, else invoke `/review-security` via Skill tool, handle findings |
+| `review_security` | Invoke `/review-security` via Skill tool, handle findings. On clean: `github-issue auto-merge <N>`, transition to `waiting` |
 | `waiting` | Re-check status for PR state changes |
-| `revamp` | `github-issue review-feedback <N>`, evaluate, fix |
+| `revamp` | Review feedback received — `github-issue review-feedback <N>`, evaluate, fix |
+| `ci_fix` | Post-push CI failure — diagnose from `check-ci`, fix, re-verify, push |
 | `done` | `github-issue cleanup <N>` |
-| `closed` | Report to user, offer options |
+| `closed` | `github-issue post-mortem <N>`, draft comment on issue, offer options |
 
 ## Step Details
 
@@ -78,7 +100,9 @@ Route on `workflow_step`. If `workflow_step` is null (v1 migration), fall back t
 github-issue setup <number>
 ```
 
-Parse JSON response for `worktree` and `branch`. Switch the session into the worktree using the `EnterWorktree` tool with `path: <worktree>` — this persists cwd at the session level, so subsequent Bash calls run inside the worktree without a `cd` prefix.
+Parse JSON response for `worktree`, `branch`, `base_ref`, and `blockers`. If any blocker is `OPEN`, surface it to the user — with the no-stacks rule, open blockers mean this issue probably shouldn't be started yet.
+
+Switch the session into the worktree using the `EnterWorktree` tool with `path: <worktree>`.
 
 Proceed to assess (setup already sets `workflow_step: "assess"`).
 
@@ -92,18 +116,20 @@ Read the issue body (available in `status` response as `issue_body`). Classify c
 | standard | Multi-file, clear requirements | `plan` |
 | complex | Unclear requirements, design needed | `design` |
 
-**Auto-classification:** If the issue body contains implementation guidance — file paths (e.g., `src/foo/bar.ts`), code blocks with snippets, or explicit acceptance criteria / step-by-step instructions — auto-classify at the appropriate level and skip user confirmation:
+**Auto-classification without user confirmation** — only when ALL THREE signals are present in the issue body:
 
-```
-"Auto-classified as <level> (detailed implementation guidance present). Proceeding to <target>."
-```
+1. **Prescriptive file paths** — "modify `src/auth/jwt.ts`", "add handler in `src/api/routes.ts`". Stack-trace locations (`at src/foo.ts:42`) do NOT count; they describe bug sites, not work sites.
+2. **Prescriptive code** — snippets showing what to write (diff syntax, "change X to Y" phrasing, target structure). Exception traces, error output, or symptom dumps do NOT count.
+3. **Explicit acceptance criteria or step-by-step instructions** — a checklist (`- [ ]`), a numbered procedure, or an "Acceptance Criteria" section.
 
-If the issue body is vague or lacks implementation signals, present the assessment and let the user confirm or override as before.
+If any of the three is absent, present the assessment and ask the user to confirm or override.
 
 Then transition:
 
 ```bash
-github-issue transition <N> <target> --detail-json '{"complexity":"<level>"}'
+github-issue transition <N> <target> \
+  --note "Classified as <level> — <reason>" \
+  --detail-json '{"complexity":"<level>"}'
 ```
 
 ### Design
@@ -113,7 +139,7 @@ github-issue transition <N> <target> --detail-json '{"complexity":"<level>"}'
 Hard gate — do not proceed until design is approved. Then:
 
 ```bash
-github-issue transition <N> plan
+github-issue transition <N> plan --note "Design approved: <one-sentence summary>"
 ```
 
 ### Plan
@@ -123,7 +149,9 @@ github-issue transition <N> plan
 Input: issue body + design (if design ran). Output: implementation plan. Then:
 
 ```bash
-github-issue transition <N> implement --detail-json '{"plan_file":"PLAN.md"}'
+github-issue transition <N> implement \
+  --note "Plan written with <N> tasks covering <scope>" \
+  --detail-json '{"plan_file":"PLAN.md"}'
 ```
 
 ### Implement
@@ -133,15 +161,12 @@ Execute implementation inside the worktree.
 - If a plan exists: **invoke `superpowers:subagent-driven-development`** (independent tasks) or **`superpowers:executing-plans`** (sequential tasks)
 - If trivial (no plan): implement directly
 
-Follow commit conventions from `references/conventions.md`:
-- Format: `type(scope): description`
-- Sign with `-S`, no Co-Authored-By
-- Atomic commits — one logical change per commit
+**Commit style on issue branches.** The branch is squash-merged, so the final commit on main is built from the PR title + body. Internal branch commits do not need to be atomic or follow a strict format — commit whenever it's natural. Do NOT add Co-Authored-By, Signed-off-by, or any AI attribution trailer. See `references/conventions.md`.
 
 When implementation is believed complete:
 
 ```bash
-github-issue transition <N> verify
+github-issue transition <N> verify --note "<what got done + any open threads>"
 ```
 
 ### Verify
@@ -150,25 +175,10 @@ github-issue transition <N> verify
 
 Run the project's test suite, linters, and build.
 
-- If verification fails: `github-issue transition <N> implement` (loop back)
-- If verification passes and `workflow_detail.complexity == "trivial"`: proceed to push, then skip reviews (see **Trivial fast-path** below)
-- If verification passes (non-trivial): `github-issue transition <N> push`
+- If verification fails: `github-issue transition <N> implement --note "verify failed: <which suite / what error> — returning to implement"`
+- If verification passes: `github-issue transition <N> push --note "All checks green: <suites run>"`
 
-**Trivial fast-path:** When complexity is trivial, after verification passes, push and transition directly to waiting — skipping both review steps:
-
-```bash
-github-issue transition <N> push
-```
-
-Then after push completes:
-
-```
-"Trivial change — skipping reviews, proceeding directly to waiting."
-```
-
-```bash
-github-issue transition <N> waiting
-```
+Every PR walks the full review gate. There is no trivial fast-path.
 
 ### Push
 
@@ -176,60 +186,53 @@ github-issue transition <N> waiting
 github-issue push <number>
 ```
 
+Mechanics handled by the CLI:
+- Silent pre-push rebase onto `base_ref` (origin/main by default). If the rebase conflicts, the CLI fails with a clear escalation message — see **Merge Conflict Resolution** below.
+- Push; `--force-with-lease` if rebase rewrote history (never `--force`).
+- Create PR if one doesn't exist; update otherwise.
+- Propagate issue labels onto the PR.
+
 Report `pr_url` and `ci_status` from response. Then:
 
-- If trivial fast-path: `github-issue transition <N> waiting` (reviews already skipped above)
-- Otherwise: `github-issue transition <N> review_dev`
+```bash
+github-issue transition <N> review_dev --note "PR created: <url>"
+```
 
 ### Review (Dev)
 
-Invoke `/review-dev` directly via the `Skill` tool (do not wait for user to trigger). Announce: `"PR created: <pr_url>. Running /review-dev."`
+Invoke `/review-dev` directly via the `Skill` tool. Announce: `"PR created: <pr_url>. Running /review-dev."`
 
-After dev review completes, parse the summary line if present:
+After dev review completes, parse the summary line:
 - `REVIEW_DEV_SUMMARY: verdict=block`: critical issue — fix the blocker, verify, push before continuing
-- `REVIEW_DEV_SUMMARY: verdict=fix`: batch all findings in a single pass (see **Batching** below)
-- `verdict=clean`: transition to next step **and immediately auto-chain into `/review-security`** (see below)
-- No summary line (backward compat): ask user if there are findings to address
+- `REVIEW_DEV_SUMMARY: verdict=fix`: batch all findings in a single pass. Fix them all, then one verify-push cycle. Log: "Batched N minor fixes."
+- `verdict=clean`: transition and **immediately auto-chain into `/review-security`** — the diff is unchanged, so security review runs against the same state in the same turn
+- No summary line: ask user if there are findings to address
 
-**Batching minor fixes:** When verdict is `fix`, collect ALL findings from the review. Fix them all in one pass, then run a single verify-push cycle instead of cycling per finding. Log: "Batched N minor fixes into a single commit."
-
-**Auto-chain on clean:** When dev returns `verdict=clean`, the diff is unchanged, so security review can run against the same diff immediately — no user wait needed. Transition to `review_security` and invoke `/review-security` in the same turn.
-
-After all fixes (or user declines review):
+After all fixes (or clean):
 
 ```bash
-github-issue transition <N> review_security
+github-issue transition <N> review_security --note "Dev review: <verdict> — <brief>"
 ```
 
 ### Review (Security)
 
-**UI-only skip:** Before running `/review-security`, check the diff profile:
+Invoke `/review-security` directly via the `Skill` tool. Announce: `"Running /review-security."`
+
+Security review runs for every PR — there is no UI-only skip path. Small PRs still go through it; it's fast and catches the things that verification alone can't (new dependencies, sketchy patterns, credential leaks).
+
+After security review completes, parse the summary:
+- `REVIEW_SECURITY_SUMMARY: verdict=block`: fix the blocker, verify, push
+- `REVIEW_SECURITY_SUMMARY: verdict=fix`: batch all findings, then one verify-push cycle
+- `verdict=clean`: enable auto-merge and transition to waiting
+
+After fixes are clean:
 
 ```bash
-git diff <default-branch>..HEAD --name-only
+github-issue auto-merge <N>
+github-issue transition <N> waiting --note "Security review: clean. Auto-merge enabled."
 ```
 
-If the diff touches **only** UI files (Composables, layout XML, string resources, theme files, icons) with **no** new dependencies, network calls, file I/O, user input handling, or permission changes — auto-skip the security review:
-
-```
-"Security review skipped — UI-only changes with no security surface."
-```
-
-The user can force a security review by explicitly requesting it.
-
-**Otherwise**, invoke `/review-security` directly via the `Skill` tool (no user prompt needed). Announce: `"Running /review-security."`
-
-After security review completes, parse the summary line if present:
-- `REVIEW_SECURITY_SUMMARY: verdict=block`: critical issue — fix the blocker, verify, push before continuing
-- `REVIEW_SECURITY_SUMMARY: verdict=fix`: batch all findings in a single pass — fix everything, then one verify-push cycle. Log: "Batched N minor fixes into a single commit."
-- `verdict=clean`: transition
-- No summary line (backward compat): ask user if there are findings to address
-
-After all fixes (or user declines):
-
-```bash
-github-issue transition <N> waiting
-```
+GitHub will merge the moment branch protection and required checks are satisfied. Reconciliation detects the merge and routes to `done`.
 
 ### Waiting
 
@@ -240,9 +243,10 @@ github-issue status <N>
 ```
 
 Reconciliation auto-detects:
-- PR merged -> advances to `done`
-- Changes requested -> advances to `revamp`
-- PR closed -> advances to `closed`
+- PR merged → advances to `done`
+- Changes requested → advances to `revamp`
+- CI failure on open PR → advances to `ci_fix`
+- PR closed without merge → advances to `closed`
 
 If still waiting, report current state and CI status:
 
@@ -250,7 +254,7 @@ If still waiting, report current state and CI status:
 github-issue check-ci <N>
 ```
 
-### Revamp
+### Revamp (review feedback)
 
 Fetch review feedback:
 
@@ -259,7 +263,7 @@ github-issue review-feedback <N>
 ```
 
 1. **Invoke `superpowers:receiving-code-review`** — evaluate feedback technically, don't blindly agree
-2. Implement fixes with focused commits
+2. Implement fixes
 3. **Invoke `superpowers:verification-before-completion`** — verify changes
 4. Push: `github-issue push <N>`
 5. Comment on PR summarizing what was addressed
@@ -267,10 +271,57 @@ github-issue review-feedback <N>
 Then:
 
 ```bash
-github-issue transition <N> verify --detail-json '{"revamp_round": <round+1>}'
+github-issue transition <N> verify \
+  --note "Addressed <N> review comments — <brief>" \
+  --detail-json '{"revamp_round": <round+1>}'
 ```
 
-This cycle repeats if reviewer requests more changes.
+This cycle repeats if the reviewer requests more changes.
+
+### CI Fix (post-push CI failure)
+
+Distinct from revamp — this is diagnosing a failing CI check after push, not addressing reviewer comments. Do NOT invoke `receiving-code-review`.
+
+1. `github-issue check-ci <N>` — structured failure output with `detailsUrl`s
+2. Fetch failing job logs for details (`gh run view <run-id> --log-failed`)
+3. Fix the failure directly
+4. Re-verify locally
+5. Push: `github-issue push <N>`
+
+Then:
+
+```bash
+github-issue transition <N> verify --note "Fixed CI failure: <which check> — <root cause>"
+```
+
+### Merge Conflict Resolution
+
+When the pre-push rebase conflicts, the CLI aborts the rebase and returns an error. The agent (you) attempts resolution with strict guardrails.
+
+**Hard-escalate signals — DO NOT attempt resolution, hand off to the user immediately if any are true:**
+
+1. **Conflict touches file types that can't be hand-resolved safely:**
+   - Lockfiles: `*.lock`, `package-lock.json`, `yarn.lock`, `flake.lock`, `Cargo.lock`, `poetry.lock`
+   - Migrations: `**/migrations/**`, `**/db/migrate/**`
+   - Generated code: files with `generated` / `DO NOT EDIT` headers
+2. **A test file AND its corresponding source file both have conflicts** (semantic divergence risk — tests on both sides may have drifted).
+
+**Resolution procedure (single attempt, no retry loops):**
+
+1. Re-run the rebase manually: `git -C <worktree> rebase <base_ref>`
+2. Inspect conflict markers. Resolve each hunk. Use clear judgment — if both sides semantically changed the same logic, escalate.
+3. Stage the resolved files: `git add <files>`
+4. Continue the rebase: `git rebase --continue`
+5. **Mandatory post-resolve verification** — run the project's full test + build + lint suite.
+6. If verification passes → push.
+7. If verification fails → `git rebase --abort`, escalate to user with:
+   - List of conflicting files
+   - Which side each hunk came from (ours/theirs)
+   - What the resolution attempted
+   - Why verification failed
+   - Command to resume: `cd <worktree> && git rebase <base_ref>`
+
+**No retry on failure.** One attempt, then escalate. Do not try a "different approach" to the same conflict — if the first resolution didn't pass verification, the divergence is semantic and needs human judgment.
 
 ### Done (Cleanup)
 
@@ -282,11 +333,34 @@ Removes worktree, deletes branches, closes issue.
 
 ### Closed
 
-PR closed without merge. Report to user. Offer: reopen PR, create new PR, or abandon.
+PR closed without merge. Gather context and draft a post-mortem comment.
+
+```bash
+github-issue post-mortem <N>
+```
+
+The response includes PR state, last reviews, inline comments, CI history, commit log, and recent step_history notes. Synthesize a short comment inferring why it was closed, then post to the issue:
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+## PR closed without merge
+
+<PR link + close date>
+
+**Inferred reason:** <one-paragraph synthesis>
+
+**State at close:** <commits, CI, review status>
+
+**Options:** reopen, new PR, abandon.
+EOF
+)"
+```
+
+Then offer the user the three options: reopen the PR, create a new one, or abandon.
 
 ## Interruption Recovery
 
-The skill reads `workflow_step` from `status` and picks up where it left off. The `status` command reconciles state with git/PR signals automatically:
+The skill reads `workflow_step` and the most recent `step_history` notes to pick up where it left off. The `status` command reconciles state with git/PR signals automatically:
 
 | Situation | Auto-reconciliation |
 |-----------|-------------------|
@@ -294,26 +368,27 @@ The skill reads `workflow_step` from `status` and picks up where it left off. Th
 | Step says `push` but PR exists | Advances to `review_dev` |
 | Step says `waiting` but PR merged | Advances to `done` |
 | Step says `waiting` but changes requested | Advances to `revamp` |
+| Step says `waiting` but CI failing | Advances to `ci_fix` |
+| Step says `waiting` but PR closed | Advances to `closed` |
 
-No manual recovery needed — just re-invoke the skill.
+No manual recovery needed — re-invoke the skill. The last few `step_history.note` fields plus `workflow_detail.open_threads` tell you what was in flight.
 
 ## Flow Deviations
 
 | Situation | Detection | Action |
 |-----------|-----------|--------|
-| PR closed without merge | `status` returns `closed` | Report; offer reopen, new PR, or abandon |
-| Multi-PR issue | Large scope in assess | Break into sub-tasks; each gets own branch/PR |
-| Blocked | User says blocked | Note blocker, suggest exiting. On resume: ask if resolved |
-| Merge conflicts | Push rejected | Rebase onto default branch; use `--force-with-lease` |
-| CI failure after PR | `check-ci` shows failures | Re-enter implement with CI context; fix, push |
+| PR closed without merge | `status` returns `closed` | `post-mortem`, draft comment, offer reopen/new/abandon |
+| Multi-PR issue | Large scope in assess | Break into sub-tasks; each gets own issue → branch → PR |
+| Blocked | Open blocker found at setup, or user reports | Surface; with no-stacks rule, prefer to wait for blocker to merge |
+| Merge conflicts | Pre-push rebase failed | Run the Merge Conflict Resolution procedure above |
+| CI failure after PR | Reconciled to `ci_fix` | Distinct path from `revamp`; diagnose + fix, no code review skill |
 | Issue already closed | `gh issue view` state=CLOSED | Check for merged PR. If found, report done |
 
 ## Conventions Quick Reference
 
-See `references/conventions.md` for full details.
+See `references/conventions.md` for details.
 
-- **Commits:** `type(scope): description` — signed with `-S`
-- **No AI attribution:** never add Co-Authored-By, Signed-off-by, or any mention of Claude/Anthropic/AI in commits, PR bodies, or issue comments
-- **Branches:** `type/issue-number-slug` (e.g., `feat/42-add-jwt-auth`)
-- **PR body:** Must include `Closes #<issue-number>`
-- **Atomic commits:** One logical change per commit
+- **Commits on issue branches:** freeform — branch is squash-merged. No Co-Authored-By, no AI attribution.
+- **Squashed merge commit on main:** `type(scope): description` built by the skill from PR title + body.
+- **Branches:** `type/issue-number-slug` (e.g., `feat/42-add-jwt-auth`) — CLI builds this from issue labels.
+- **PR body:** Must include `Closes #<issue-number>`.

--- a/modules/apps/cli/worktree-flow/skills/github-issue/references/conventions.md
+++ b/modules/apps/cli/worktree-flow/skills/github-issue/references/conventions.md
@@ -1,6 +1,16 @@
 # Conventions
 
-## Commit Format
+Issue branches in this workflow are **squash-merged** by default, so the commit that ends up on `main` is one synthetic commit whose message is derived from the PR title + body. That changes how strict to be about history on the branch itself.
+
+## Commits on issue branches
+
+- **Freeform is fine.** WIP checkpoints, small fixes, batches of review-fix changes all go on the branch however is natural. These commits are collapsed at merge time.
+- **No AI attribution.** Do NOT add `Co-Authored-By:`, `Signed-off-by:`, or any mention of Claude / Anthropic / AI / "generated" anywhere in commit messages, PR bodies, or issue comments. The user's git identity is the sole author.
+- Signing with `-S` is fine if the user's setup requires it, but do not add it unconditionally.
+
+## The squash-merge commit on main
+
+The squash commit title and body follow Conventional Commits:
 
 Format: `<type>(<scope>): <description>`
 
@@ -20,32 +30,29 @@ Format: `<type>(<scope>): <description>`
 | security | Security fix |
 | deps | Dependency update |
 
-Rules:
+Rules for the squashed commit:
 - Scope is REQUIRED: lowercase, kebab-case module name
 - Description: imperative mood, lowercase start, no period
-- Sign commits: always use `-S` flag
-- **NEVER** add Co-Authored-By, Signed-off-by, or any AI attribution trailer
-- No mentions of Claude, Anthropic, AI, or "generated" anywhere in commit messages, PR bodies, or issue comments
-- The user's git identity is the sole author — do not inject any co-author or tool attribution
+- No AI attribution (as above)
 
 Examples:
 - `feat(auth): add JWT refresh rotation`
 - `fix(api): handle null response from upstream`
 - `refactor(db): extract connection pooling`
 
-## Branch Naming
+## Branch naming
 
 Format: `{type}/{issue-number}-{slug}`
 
-- Type matches commit type (feat, fix, docs, refactor, etc.)
-- Slug is kebab-case from issue title, truncated to fit ~50 chars total
+- Type matches the Conventional Commit type (feat, fix, docs, refactor, …)
+- Slug is kebab-case from the issue title, truncated to fit ~50 chars total
 - Examples: `feat/42-add-jwt-auth`, `fix/17-null-response-upstream`
 
-The bash worktree-flow derives this automatically from issue labels and title. In standalone mode, follow the same pattern manually.
+The CLI derives this from issue labels and title automatically.
 
-## PR Body
+## PR body
 
-Use `Closes #{issue-number}` to auto-close the issue on merge.
+Use `Closes #{issue-number}` so the issue auto-closes on merge.
 
 Structure:
 ```
@@ -55,8 +62,8 @@ Closes #<number>: <issue title>
 - <commit log entries>
 ```
 
-The bash worktree-flow builds this automatically from the commit log. In standalone mode, use `gh pr create` with this format.
+The CLI builds this from the commit log at push time.
 
-## Atomic Commits
+## Direct-to-main work (outside this skill)
 
-Make each commit a logical unit of work. If changes span unrelated concerns, split into separate commits. The commit skill handles staging and security scanning.
+When working directly on `main` (no PR), **atomic commits** matter — each commit lives on its own forever. Split changes that span unrelated concerns into separate commits. That rule does NOT apply on issue branches because of squash-merge.

--- a/modules/apps/cli/worktree-flow/skills/github-issue/references/revamp-workflow.md
+++ b/modules/apps/cli/worktree-flow/skills/github-issue/references/revamp-workflow.md
@@ -1,106 +1,135 @@
-# Revamp Workflow (PR Review Loop)
+# Revamp & CI-Fix Workflows
 
-When a PR receives "changes requested", Claude re-enters the implementation cycle to address the feedback. This can happen multiple times — each round follows the same pattern.
+Two distinct post-push recovery paths that the state machine treats separately.
 
-## Entry Condition
+- **`revamp`** — a reviewer left `CHANGES_REQUESTED`. Human (or AI) judgment about code quality is required.
+- **`ci_fix`** — CI went red after push. Diagnose the failure and fix it. No code-review evaluation needed.
 
-State detection finds a PR with `reviewDecision: CHANGES_REQUESTED`. In worktree mode, the bash script may also inject review comments into the system prompt.
+Both end by looping back through `verify` so the full gate runs again.
 
-## Procedure
+---
 
-### 1. Fetch Review Feedback
+## `revamp` — address review feedback
 
-```bash
-# Get all reviews with CHANGES_REQUESTED state
-gh pr view <pr_url> --json reviews --jq '.reviews[] | select(.state == "CHANGES_REQUESTED")'
+### Entry
 
-# Get individual review comments (inline code comments)
-gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --jq '.[] | {path, line, body, created_at}'
-```
+`status` detects an open PR with `reviewDecision == CHANGES_REQUESTED` and advances `workflow_step` to `revamp`.
 
-Read both the review-level comments (high-level feedback) and inline code comments (specific line feedback).
+### Procedure
 
-### 2. Evaluate Feedback Technically
+1. **Fetch review feedback**
 
-**Invoke `superpowers:receiving-code-review`** before making changes.
+   ```bash
+   github-issue review-feedback <N>
+   ```
 
-This skill enforces technical rigor: don't blindly agree with all feedback. For each piece of feedback:
-- Does the suggestion improve the code?
-- Is there a technical reason the current approach is better?
-- Is the feedback based on a misunderstanding of the codebase?
+   Returns `reviews` (high-level comments) and `inline_comments` (specific line feedback), plus `review_decision`.
 
-If feedback is questionable, push back with evidence in the PR comment. If it's valid, address it.
+2. **Evaluate technically — invoke `superpowers:receiving-code-review`**
 
-### 3. Implement Changes
+   Do not blindly agree with every comment. For each piece of feedback ask:
+   - Does the suggestion actually improve the code?
+   - Is there a technical reason the current approach is better?
+   - Is the feedback based on a misunderstanding of the codebase?
 
-Re-enter the IMPLEMENT state with review context:
-- Work through each actionable review item
-- Make focused commits — one per review concern where practical
-- Use commit messages that reference the review (e.g., `fix(auth): :bug: handle edge case from review`)
-- Follow all conventions from conventions.md
+   If a suggestion is questionable, push back with evidence in a PR comment. If valid, address it.
 
-### 4. Verify
+3. **Implement fixes**
 
-**Invoke `superpowers:verification-before-completion`** after making changes.
+   Batch all minor findings into a single commit — the branch is squash-merged anyway, so individual review-fix commits just add noise. Log "Batched N minor fixes" in the transition note.
 
-Run tests, linters, build. Evidence before claims.
+   Block-level issues (verdict=block): fix, verify, push before moving on.
 
-### 5. Push Updates
+4. **Verify — invoke `superpowers:verification-before-completion`**
 
-Push directly to the existing PR branch:
+5. **Push updates**
 
-```bash
-git push origin <branch>
-```
+   ```bash
+   github-issue push <N>
+   ```
 
-Claude can push during REVAMP because the PR already exists — the bash script only creates the initial PR.
+   The CLI rebases onto base first (silent), then pushes with `--force-with-lease` if the rebase rewrote history.
 
-### 6. Comment on PR
+6. **Comment on the PR**
 
-After pushing, leave a comment summarizing what was addressed:
+   ```bash
+   gh pr comment <pr_url> --body "Addressed review feedback:
+   - <item 1>
+   - <item 2>"
+   ```
 
-```bash
-gh pr comment <pr_url> --body "Addressed review feedback:
-- <item 1>
-- <item 2>
-- <item 3>"
-```
+7. **Transition back through verify**
 
-### 7. Request Re-review (optional)
+   ```bash
+   github-issue transition <N> verify \
+     --note "Addressed <N> review comments — <brief>" \
+     --detail-json '{"revamp_round": <round+1>}'
+   ```
 
-If the reviewer should be notified:
+   The cycle repeats if the reviewer requests more changes. No round limit.
 
-```bash
-gh pr edit <pr_url> --add-reviewer <reviewer>
-```
+---
 
-Or simply note in the comment that changes are ready for re-review.
+## `ci_fix` — post-push CI failure
 
-## Multiple Review Rounds
+### Entry
 
-The same cycle repeats if the reviewer requests more changes. Each round:
-1. Fetch latest review feedback (filter by date to see only new comments)
-2. Evaluate technically
-3. Implement + verify + push
-4. Comment
+`status` detects an open PR where `gh pr checks` reports `FAILURE` or `ERROR` checks, while the workflow step is `waiting`, `push`, `review_dev`, or `review_security`. Reconciliation advances `workflow_step` to `ci_fix`.
 
-There's no limit on rounds — the cycle continues until the PR is approved or the user decides to close it.
+### Procedure — do NOT invoke `receiving-code-review`
 
-## CI Failures During Revamp
+1. **Get structured failure data**
 
-If CI fails after pushing revamp changes:
-1. Fetch check details: `gh pr checks <pr_url>`
-2. Identify failing checks
-3. Fix the failures (this is still part of the REVAMP cycle)
-4. Push again
-5. Monitor checks before commenting that changes are ready
+   ```bash
+   github-issue check-ci <N>
+   ```
 
-## Merge Conflicts During Revamp
+   Returns `failing_checks` (name, conclusion, detailsUrl), `passing_checks`, `pending_checks`.
 
-If the PR develops merge conflicts while addressing review feedback:
-1. Rebase onto the default branch: `git fetch origin && git rebase origin/<default>`
-2. Resolve conflicts if able
-3. If conflicts need human input, report conflicting files and stop
-4. After resolution: `git push --force-with-lease origin <branch>`
+2. **Fetch failing job logs** for each failing check
 
-Use `--force-with-lease` (not `--force`) to avoid overwriting concurrent changes.
+   ```bash
+   gh run view <run-id> --log-failed
+   ```
+
+   The `detailsUrl` from check-ci output contains the run id.
+
+3. **Fix the failure**
+
+   - Flaky test: stabilize or skip with issue reference
+   - Real regression: fix the code
+   - Environment / config drift: update the config
+   - Do not paper over real failures
+
+4. **Verify locally — invoke `superpowers:verification-before-completion`**
+
+   Run the same suite that failed in CI to confirm local repro + fix.
+
+5. **Push**
+
+   ```bash
+   github-issue push <N>
+   ```
+
+6. **Transition back through verify**
+
+   ```bash
+   github-issue transition <N> verify \
+     --note "Fixed CI failure in <check-name>: <root cause>"
+   ```
+
+   The state machine continues forward from verify through push/review again — the review skills run again on the new diff.
+
+---
+
+## Merge conflicts encountered during either path
+
+If `github-issue push` fails because the pre-push rebase conflicted, apply the **Merge Conflict Resolution** procedure from `SKILL.md`:
+
+- Single attempt, no retry loops
+- Hard-escalate on lockfile/migration/generated-file conflicts
+- Hard-escalate when both a test file and its source file conflict
+- Mandatory post-resolve verification
+- On verification failure: `git rebase --abort` and hand off to the user with a clear status dump
+
+Never use `git push --force` during revamp or ci_fix — always `--force-with-lease` so concurrent pushes can't be silently overwritten.

--- a/modules/apps/cli/worktree-flow/skills/github-issue/references/state-detection.md
+++ b/modules/apps/cli/worktree-flow/skills/github-issue/references/state-detection.md
@@ -1,19 +1,20 @@
-# State Detection (v2)
+# State Detection (v3)
 
-The `github-issue status <number>` command detects the current lifecycle state. It returns the v2 `workflow_step` (authoritative position in the state machine) and a legacy `state` field for backward compatibility.
+The `github-issue status <number>` command detects the current lifecycle state. It returns `workflow_step` (authoritative position in the state machine) and a legacy `state` field for backward compatibility.
 
-## State File Schema (v2)
+## State File Schema (v3)
 
 Path: `<worktree>/.worktree-state.json` (`.gitignore`d)
 
 ```json
 {
-  "version": 2,
+  "version": 3,
   "type": "issue",
   "issue_number": "42",
   "issue_title": "Add JWT auth",
   "issue_body": "...",
   "branch": "feat/42-add-jwt-auth",
+  "base_ref": "origin/main",
   "wt_path": "/absolute/path/to/.worktrees/issue-42",
   "pr_url": "",
   "session_id": "",
@@ -24,18 +25,30 @@ Path: `<worktree>/.worktree-state.json` (`.gitignore`d)
     "plan_file": "PLAN.md",
     "review_stage": null,
     "revamp_round": 0,
-    "blocker": null
+    "blockers": [
+      {"number": 40, "state": "OPEN", "title": "Refactor token storage"}
+    ],
+    "open_threads": [
+      "verify intermittent test failure in src/auth.test.ts:142"
+    ]
   },
   "step_history": [
-    {"step": "setup", "completed_at": "2026-04-15T10:00:00Z"},
-    {"step": "assess", "completed_at": "2026-04-15T10:05:00Z"},
-    {"step": "plan", "completed_at": "2026-04-15T10:15:00Z"}
+    {"step": "setup",  "completed_at": "2026-04-23T10:00:00Z", "note": "Worktree created from origin/main."},
+    {"step": "assess", "completed_at": "2026-04-23T10:05:00Z", "note": "Auto-classified as standard (all three signals present)."},
+    {"step": "plan",   "completed_at": "2026-04-23T10:15:00Z", "note": "Plan written with 3 tasks covering middleware + tests + docs."}
   ],
 
-  "started_at": "2026-04-15T09:50:00Z",
-  "updated_at": "2026-04-15T10:20:00Z"
+  "started_at": "2026-04-23T09:50:00Z",
+  "updated_at": "2026-04-23T10:20:00Z"
 }
 ```
+
+### v3 changes vs v2
+
+- `base_ref` (string) — the ref the branch was pinned to at `setup`. Defaults to `origin/<default-branch>`. Used by pre-push rebase and touched-file overlap detection.
+- `workflow_detail.blockers` — array of `{number, state, title}` parsed from issue body (`Blocked by #N`, `Depends on #N`, `Requires #N`, `Needs #N`). The v2 scalar `blocker` field is migrated into a single-element array.
+- `workflow_detail.open_threads` — freeform array of short strings. Loose ends the agent noticed but hasn't resolved. Read on resume; add during transitions via `--detail-json '{"open_threads": ["..."]}'`.
+- `step_history[].note` — required non-empty string on each transition. Backfilled as `""` for v2 entries; new entries are rejected without `--note`.
 
 ## Workflow Steps
 
@@ -49,12 +62,13 @@ Path: `<worktree>/.worktree-state.json` (`.gitignore`d)
 | `push` | Ready to push branch and create/update PR |
 | `review_dev` | PR created, dev review stage |
 | `review_security` | Dev review done, security review stage |
-| `waiting` | Both reviews done, waiting for external review |
-| `revamp` | PR has changes requested |
+| `waiting` | Both reviews done, auto-merge enabled, waiting for CI + branch protection |
+| `revamp` | Reviewer requested changes |
+| `ci_fix` | Post-push CI failure — diagnose and fix (distinct from `revamp`) |
 | `done` | PR merged |
 | `closed` | PR closed without merge |
 
-## Status Response (v2)
+## Status Response
 
 ```json
 {
@@ -64,7 +78,7 @@ Path: `<worktree>/.worktree-state.json` (`.gitignore`d)
   "worktree": "/path/to/.worktrees/issue-42",
   "branch": "feat/42-add-jwt-auth",
   "workflow_step": "implement",
-  "workflow_detail": {"complexity": "standard", "plan_file": "PLAN.md", ...},
+  "workflow_detail": {"complexity": "standard", "plan_file": "PLAN.md", "blockers": [...], "open_threads": [...]},
   "step_history": [...],
   "title": "Add JWT auth",
   "issue_body": "Full issue body text...",
@@ -81,36 +95,71 @@ The `pr` field is `null` when no PR exists. The `state` field is the legacy dete
 
 ## Auto-Reconciliation
 
-The `status` command reconciles `workflow_step` with git/PR signals:
+The `status` command reconciles `workflow_step` with git/PR/CI signals:
 
-| `workflow_step` | Git signal | Resolution |
+| `workflow_step` | Signal | Resolution |
 |----------------|------------|------------|
-| `plan` or `assess` | Commits exist on branch | Advance to `implement` |
+| `plan`, `assess`, `design` | Commits exist on branch | Advance to `implement` |
 | `push` | PR exists | Advance to `review_dev` |
 | `waiting` | PR merged | Advance to `done` |
 | `waiting` | Changes requested | Advance to `revamp` |
-| `waiting` | PR closed | Advance to `closed` |
+| `waiting`, `push`, `review_dev`, `review_security` | CI failing on open PR | Advance to `ci_fix` |
+| `waiting` | PR closed without merge | Advance to `closed` |
 
-## v1 Migration
+Every reconciliation writes a new `step_history` entry with `reconciled: true` and a `note` describing the trigger, so resume-time agents can see why the state changed.
 
-State files without a `version` field are auto-migrated by `status`:
+## Audit Response (Fleet Survey)
 
-| v1 `phase` | v2 `workflow_step` |
-|-------------|-------------------|
-| `setup` | `assess` |
-| `claude_running` | `implement` |
-| `claude_exited` | `implement` |
-| `pushing` | `push` |
-| `pr_created` | `waiting` |
+`github-issue audit` returns a graph, not just a list:
+
+```json
+{
+  "worktrees": [
+    {
+      "issue_number": 42,
+      "title": "...",
+      "state": "IMPLEMENT",
+      "workflow_step": "implement",
+      "branch": "feat/42-...",
+      "base_ref": "origin/main",
+      "pr_url": null,
+      "worktree": "/path/...",
+      "blockers": [...],
+      "touched_files": ["src/foo.ts", "src/bar.ts"]
+    }
+  ],
+  "overlaps": [
+    {"a": 42, "b": 43, "shared": ["src/foo.ts"]}
+  ],
+  "merge_order": [
+    {"issue_number": 40, "title": "...", "pr_url": "...", "workflow_step": "waiting", "blocks": [42, 43]},
+    {"issue_number": 42, "title": "...", "pr_url": "...", "workflow_step": "waiting", "blocks": []}
+  ]
+}
+```
+
+- `overlaps` surfaces worktree pairs that touch shared files — merge-conflict risk to plan around.
+- `merge_order` ranks mergeable PRs so issues that unblock others merge first.
+
+## Migration
+
+`status` and `audit` auto-migrate state files forward:
+
+| From | To | Transformation |
+|------|----|----------------|
+| v1 (no `version`) | v2 | Add `version: 2`, map `phase` → `workflow_step` |
+| v2 | v3 | Add `base_ref` (defaulted to `origin/<default>`), convert scalar `blocker` → `blockers` array, add empty `open_threads`, backfill empty `note` on each `step_history` entry |
 
 ## Edge Cases Requiring AI Judgment
 
-**PR closed without merge (`closed`):** Ask the user: reopen the PR, create a new one, or abandon the issue.
+**PR closed without merge (`closed`):** Run `github-issue post-mortem <N>` for close-context, draft a comment on the issue, then ask the user: reopen the PR, create a new one, or abandon.
 
-**Ambiguous complexity (during `assess`):** Read the issue body and classify as trivial/standard/complex.
+**Ambiguous complexity (during `assess`):** Read the issue body and classify as trivial / standard / complex. Auto-skip confirmation only when all three signals (prescriptive paths + prescriptive code + acceptance criteria) are present.
 
-**Blocked work:** Not detectable by the script. If the user reports a blocker, note it and suggest exiting.
+**Blocked work:** Open blockers are surfaced at `setup` from the `blockers` array. With the no-stacks rule, prefer to wait for the blocker to merge rather than branching off it.
 
-**CI failures after PR:** Use `github-issue check-ci <N>` for structured failure data.
+**CI failures after PR:** `ci_fix` state. Use `github-issue check-ci <N>` for structured failure data. Distinct from `revamp`; do not invoke `receiving-code-review`.
 
-**Offline / gh unavailable:** The script falls back to git-only signals when `gh` fails. PR status may be unknown.
+**Merge conflicts at pre-push rebase:** The CLI aborts the rebase and returns an error. Follow the Merge Conflict Resolution procedure in `SKILL.md` — one attempt, mandatory post-resolve verification, escalate on failure.
+
+**Offline / gh unavailable:** The script falls back to git-only signals when `gh` fails. PR state may be unknown.


### PR DESCRIPTION
## Summary

Major rework of the github-issue skill and CLI informed by a workflow assessment. Anchors branches to main, rebases silently before every push, hands off cleanly to GitHub auto-merge, and makes autonomous resume a first-class concern via mandatory step notes.

### State schema -> v3
- `base_ref`: ref the branch is pinned to (default `origin/<default>`).
- `workflow_detail.blockers`: array of `{number, state, title}` parsed from issue body on setup.
- `workflow_detail.open_threads`: freeform array of loose ends agents noted but have not resolved.
- `step_history[].note`: required non-empty on every transition.
- Auto-migration v1 -> v2 -> v3 on read.

### State machine
- Split `revamp` (review feedback) from `ci_fix` (post-push CI failure).
- Reconciliation now detects CI failure on open PR and advances to `ci_fix`.

### CLI behavior
- `setup`: pins branch to `origin/<default>` via explicit base ref; `--base` for opt-in override; parses blockers and warns on open ones.
- `push`: silent pre-push rebase, `--force-with-lease` when rebase rewrote history, propagates issue labels to PR.
- `auto-merge`: new subcommand wrapping `gh pr merge --auto --squash`.
- `post-mortem`: new subcommand gathering PR/review/CI/commits/step-notes for agent synthesis on closed PRs.
- `transition`: `--note` now required.
- `audit`: returns `{worktrees, overlaps, merge_order}` with cross-worktree overlap detection and blocker-graph merge ordering.

### Skill
- No stacking; base is always main.
- Trivial fast-path removed; every PR runs dev + security review.
- Auto-merge on clean security review.
- Audit only on fleet-survey; status alone when an issue number is given.
- Tightened auto-classification (prescriptive paths + code + acceptance checklist).
- Conflict resolution procedure: single attempt, mandatory post-resolve verification, hard-escalate on lockfile/migration/generated conflicts or test+source both conflicting.

## Test plan

- [x] `bash -n` and `shellcheck --severity=error` clean
- [x] `writeShellApplication` build passes (shellcheck at build time)
- [x] `nixos-rebuild dry-build` resolves cleanly
- [x] Isolated `nix build` of the CLI derivation succeeded
- [x] `--help` and `audit` smoke-tested on the built binary
- [x] Live `nixos-rebuild switch` deployed CLI + home-manager skill files