### PR TITLE
feat: add zellij + claude-code on srv with tsnet web access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ prompt.txt
 .claude/settings.local.json
 AGENTS.md
 CLAUDE.md
+docs/superpowers/

--- a/extras/docs/hosts.md
+++ b/extras/docs/hosts.md
@@ -40,6 +40,8 @@ Reusable VM profile files -- not a standalone `nixosConfigurations` output.
 - Restic `backup-mgr`: daily at 03:00 to B2
 - Backrest: on-demand via `backrest`, UI at `http://127.0.0.1:9898`
 - Secrets for restic credentials in git-crypt `secrets/secrets.json`
+- Claude Code stack (cherry-picked from `suites/ai`) -- `claude-code` runs in `serverProfile = "minimal"` (kubernetes MCP omitted)
+- Zellij web client at `https://zellij.goat-cloud.ts.net/` -- see [`zellij-web.md`](./zellij-web.md) for token mint/rotate procedure
 
 ## Host-Specific Modules
 

--- a/extras/docs/zellij-web.md
+++ b/extras/docs/zellij-web.md
@@ -23,6 +23,30 @@ identity, reachable from any tailnet device.
    journalctl -u caddy -f
    ```
 
+## Security model (read this first)
+
+The token is a *bearer credential* for a shell as the `dustin` user on
+`srv`. Any device on the tailnet that obtains the token (or the cookie
+set after first use) can attach to running zellij sessions and run
+arbitrary commands. There is **no second factor**. Mitigations baked
+into this deployment:
+
+- The Caddy vhost is bound to a Tailscale identity (`bind tailscale/zellij`);
+  there is no public-internet listener.
+- `srv` runs `security.sudo.wheelNeedsPassword = true` (NixOS default),
+  so a stolen token is **not** equivalent to root -- escalation requires
+  `dustin`'s password.
+- Caddy strips `Referer` on outbound responses (`Referrer-Policy: no-referrer`),
+  so the token cannot leak via Referer when the operator clicks an external
+  link from inside a session.
+- The vhost is non-frameable (`Content-Security-Policy: frame-ancestors 'none'`).
+
+Operationally:
+
+- Treat the token like a root SSH key. Rotate quarterly at minimum.
+- Do **not** commit tokens to Nix, activation scripts, dotfiles, or
+  shell history.
+
 ## After deploy: mint a token
 
 Zellij web requires a bearer token to authenticate. Tokens are minted
@@ -35,12 +59,22 @@ zellij web --create-token --token-name srv-primary
 
 `--token-name` is optional; omit it and zellij auto-names the token
 (`token_1`, `token_2`, ...). The command prints the token once -- it
-cannot be retrieved later. Use it as a `?token=<token>` query parameter
-on the URL on first visit; the cookie set thereafter is what keeps you
-authenticated.
+cannot be retrieved later.
 
-Tokens are bearer credentials -- treat them like passwords. Do **not**
-commit them to Nix or activation scripts.
+The first-visit URL form `https://zellij.goat-cloud.ts.net/?token=<token>`
+puts the secret in your browser history, sync, and any server access log
+the proxy keeps. Prefer either:
+
+1. Open the bare URL in a browser, then paste the token into the
+   in-page login field if zellij offers one (preferred), or
+2. Set the auth cookie out-of-band and import it:
+
+   ```
+   curl -c cookies.txt "https://zellij.goat-cloud.ts.net/?token=<token>" -o /dev/null
+   # then import cookies.txt into the browser via an extension
+   ```
+
+The cookie set on first visit is what keeps you authenticated thereafter.
 
 ## Listing, revoking, rotating
 
@@ -68,3 +102,10 @@ If the browser cannot reach `https://zellij.goat-cloud.ts.net/`, check:
    `tailscale status` from another tailnet device should list it.
 2. Caddy is up -- `systemctl status caddy` on srv.
 3. The cert was issued -- `journalctl -u caddy | grep -i certificate`.
+
+## Token storage on disk
+
+zellij persists token metadata under `${XDG_DATA_HOME:-~/.local/share}/zellij/`.
+If you ever expand `apps.cli.restic.backup.backupPaths` to include
+`/home/dustin`, exclude the zellij data directory -- otherwise tokens
+end up in the offsite B2 backup.

--- a/extras/docs/zellij-web.md
+++ b/extras/docs/zellij-web.md
@@ -30,13 +30,14 @@ on the host:
 
 ```
 ssh srv
-zellij web --create-token srv-primary
+zellij web --create-token --token-name srv-primary
 ```
 
-The command prints a one-time URL of the form
-`https://zellij.goat-cloud.ts.net/?token=<token>`. Open that URL in any
-browser on the tailnet; the cookie set on the first visit is what
-keeps you authenticated thereafter.
+`--token-name` is optional; omit it and zellij auto-names the token
+(`token_1`, `token_2`, ...). The command prints the token once -- it
+cannot be retrieved later. Use it as a `?token=<token>` query parameter
+on the URL on first visit; the cookie set thereafter is what keeps you
+authenticated.
 
 Tokens are bearer credentials -- treat them like passwords. Do **not**
 commit them to Nix or activation scripts.
@@ -44,13 +45,14 @@ commit them to Nix or activation scripts.
 ## Listing, revoking, rotating
 
 ```
-zellij web --list-tokens                  # list active tokens
+zellij web --list-tokens                  # list token names + creation dates
 zellij web --revoke-token <name>          # revoke by name
 zellij web --revoke-all-tokens            # nuclear option
 ```
 
-To rotate, revoke the old name and create a new one with the same name
-(or a new name).
+To rotate: `--revoke-token <old-name>`, then
+`--create-token --token-name <new-name>` (or reuse the old name once
+the revocation is in).
 
 ## Verifying the service
 

--- a/extras/docs/zellij-web.md
+++ b/extras/docs/zellij-web.md
@@ -1,0 +1,68 @@
+# Zellij Web (browser-accessible terminal multiplexer)
+
+`zellij web` exposes a browser client for Zellij sessions. On `srv`, it
+runs as a systemd user service, fronted by Caddy on its own tsnet
+identity, reachable from any tailnet device.
+
+**URL:** `https://zellij.goat-cloud.ts.net/`
+
+## Prerequisites (one-time)
+
+1. **Tailscale auth key for Caddy.** The system Caddy module
+   (`modules/system/caddy`) reads `secrets.tailscale.caddyAuthKey` from
+   the git-crypt'd `secrets/secrets.json`. If absent, mint a *reusable*
+   auth key in the Tailscale admin console and add it before deploying
+   any host that runs Caddy with a tsnet vhost.
+
+2. **First boot of a new tsnet identity.** The first time srv comes up
+   with the `zellij` tsnet node configured, Caddy registers it on the
+   tailnet (~30 s) and provisions a Let's Encrypt cert via Tailscale's
+   HTTPS service. Watch:
+
+   ```
+   journalctl -u caddy -f
+   ```
+
+## After deploy: mint a token
+
+Zellij web requires a bearer token to authenticate. Tokens are minted
+on the host:
+
+```
+ssh srv
+zellij web --create-token srv-primary
+```
+
+The command prints a one-time URL of the form
+`https://zellij.goat-cloud.ts.net/?token=<token>`. Open that URL in any
+browser on the tailnet; the cookie set on the first visit is what
+keeps you authenticated thereafter.
+
+Tokens are bearer credentials -- treat them like passwords. Do **not**
+commit them to Nix or activation scripts.
+
+## Listing, revoking, rotating
+
+```
+zellij web --list-tokens                  # list active tokens
+zellij web --revoke-token <name>          # revoke by name
+zellij web --revoke-all-tokens            # nuclear option
+```
+
+To rotate, revoke the old name and create a new one with the same name
+(or a new name).
+
+## Verifying the service
+
+```
+systemctl --user status zellij-web        # service health
+ss -ltnp | grep 8082                      # confirm zellij is listening
+journalctl --user -u zellij-web -f        # tail logs
+```
+
+If the browser cannot reach `https://zellij.goat-cloud.ts.net/`, check:
+
+1. The host actually joined the tailnet under that name --
+   `tailscale status` from another tailnet device should list it.
+2. Caddy is up -- `systemctl status caddy` on srv.
+3. The cert was issued -- `journalctl -u caddy | grep -i certificate`.

--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -1,17 +1,31 @@
 { secrets, ... }:
 
 {
-  # Import only modules that srv used in nixcfg
+  # Import only modules that srv used in nixcfg, plus the cherry-picked
+  # Claude Code + zellij web stack.
   imports = [
+    ../../modules/apps/cli/agent-scan
+    ../../modules/apps/cli/agentos
+    ../../modules/apps/cli/claude-code
+    ../../modules/apps/cli/claude-external-skills
     ../../modules/apps/cli/docker
     ../../modules/apps/cli/fish
+    ../../modules/apps/cli/gemini-cli
+    ../../modules/apps/cli/graymatter
     ../../modules/apps/cli/helix
+    ../../modules/apps/cli/paseo
+    ../../modules/apps/cli/plannotator
+    ../../modules/apps/cli/restic
+    ../../modules/apps/cli/skillfish
     ../../modules/apps/cli/starship
+    ../../modules/apps/cli/stop-slop
+    ../../modules/apps/cli/superpowers
     ../../modules/apps/cli/tailscale
     ../../modules/apps/cli/vscode-server
+    ../../modules/apps/cli/zellij
     ../../modules/server/kvm
     ../../modules/server/nfs
-    ../../modules/apps/cli/restic
+    ../../modules/system/caddy
     ../../modules/system/ssh
   ];
 
@@ -23,6 +37,46 @@
     starship.enable = true;
     tailscale.enable = true;
     vscode-server.enable = false;
+
+    # Claude Code stack (cherry-picked from suites/ai for headless srv)
+    agent-scan.enable = true;
+    agentos.enable = true;
+    claude-code = {
+      enable = true;
+      serverProfile = "minimal";
+      plugins = [
+        "frontend-design@claude-plugins-official"
+        "asana@claude-plugins-official"
+        "code-review@claude-plugins-official"
+        "context7@claude-plugins-official"
+        "github@claude-plugins-official"
+        "feature-dev@claude-plugins-official"
+        "commit-commands@claude-plugins-official"
+        "security-guidance@claude-plugins-official"
+        "pr-review-toolkit@claude-plugins-official"
+        "atlassian@claude-plugins-official"
+        "learning-output-style@claude-plugins-official"
+        "slack@claude-plugins-official"
+        "gopls-lsp@claude-plugins-official"
+        "skill-creator@claude-plugins-official"
+        "ralph-loop@claude-plugins-official"
+      ];
+    };
+    claude-external-skills.enable = true;
+    gemini-cli.enable = true;
+    graymatter.enable = true;
+    paseo.enable = true;
+    plannotator.enable = true;
+    skillfish.enable = true;
+    stop-slop.enable = true;
+    superpowers.enable = true;
+
+    # Zellij with web client behind Caddy tsnet
+    zellij = {
+      enable = true;
+      service.enable = true;
+      tsnetNode = "zellij";
+    };
   };
 
   # System modules

--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -44,6 +44,9 @@
     claude-code = {
       enable = true;
       serverProfile = "minimal";
+      # NOTE: keep plugin list in sync with modules/suites/ai/default.nix.
+      # Two occurrences = below the rule-of-three threshold; do not
+      # extract into shared lib until a third consumer appears.
       plugins = [
         "frontend-design@claude-plugins-official"
         "asana@claude-plugins-official"

--- a/modules/apps/cli/claude-code/cfg/mcp-servers.nix
+++ b/modules/apps/cli/claude-code/cfg/mcp-servers.nix
@@ -38,31 +38,6 @@ let
         "mcp"
       ];
     };
-    # Chrome DevTools for coding agents — browser automation, debugging, screenshots
-    chrome-devtools = {
-      command = "${pkgs.nodejs}/bin/npx";
-      args = [
-        "-y"
-        "chrome-devtools-mcp@latest"
-      ];
-    };
-    # Playwright — cross-browser automation (Chromium/Firefox/WebKit), accessibility
-    # tree snapshots, network capture. Microsoft's official MCP server.
-    playwright = {
-      command = "${pkgs.nodejs}/bin/npx";
-      args = [
-        "-y"
-        "@playwright/mcp@latest"
-      ];
-    };
-    # draw.io diagram tools — open XML/CSV/Mermaid in browser-based editor
-    drawio = {
-      command = "${pkgs.nodejs}/bin/npx";
-      args = [
-        "-y"
-        "@drawio/mcp"
-      ];
-    };
   }
   // lib.optionalAttrs (serverProfile == "full") {
     # kubernetes-mcp-server requires a host-local kubeconfig at ${kubeconfigFile};
@@ -74,6 +49,36 @@ let
       env = {
         KUBECONFIG = kubeconfigFile;
       };
+    };
+    # Chrome DevTools for coding agents -- browser automation, debugging, screenshots.
+    # Requires a Chrome install on the host; useless on headless. Also pulls
+    # `chrome-devtools-mcp@latest` from npm at run time -- supply-chain surface
+    # we do not want exposed on a server reachable via a token-authenticated web shell.
+    chrome-devtools = {
+      command = "${pkgs.nodejs}/bin/npx";
+      args = [
+        "-y"
+        "chrome-devtools-mcp@latest"
+      ];
+    };
+    # Playwright -- cross-browser automation (Chromium/Firefox/WebKit), accessibility
+    # tree snapshots, network capture. Needs a browser engine; gated for the same
+    # reasons as chrome-devtools above.
+    playwright = {
+      command = "${pkgs.nodejs}/bin/npx";
+      args = [
+        "-y"
+        "@playwright/mcp@latest"
+      ];
+    };
+    # draw.io diagram tools -- opens XML/CSV/Mermaid in a browser-based editor.
+    # Useless without a desktop browser; gated.
+    drawio = {
+      command = "${pkgs.nodejs}/bin/npx";
+      args = [
+        "-y"
+        "@drawio/mcp"
+      ];
     };
   }
   // lib.optionalAttrs (context7ApiKey != null) {

--- a/modules/apps/cli/claude-code/cfg/mcp-servers.nix
+++ b/modules/apps/cli/claude-code/cfg/mcp-servers.nix
@@ -4,19 +4,13 @@
   secrets,
   kubernetesMcpServer,
   kubeconfigFile,
+  serverProfile,
 }:
 
 let
   context7ApiKey = (secrets.context7 or { }).apiKey or null;
 
   mcpServers = {
-    kubernetes-mcp-server = {
-      command = "${kubernetesMcpServer}/bin/kubernetes-mcp-server";
-      args = [ "--read-only" ];
-      env = {
-        KUBECONFIG = kubeconfigFile;
-      };
-    };
     # Go code intelligence via official gopls MCP (detached mode)
     # Tools: go_diagnostics, go_references, go_search, go_symbol_references, etc.
     gopls = {
@@ -68,6 +62,18 @@ let
         "-y"
         "@drawio/mcp"
       ];
+    };
+  }
+  // lib.optionalAttrs (serverProfile == "full") {
+    # kubernetes-mcp-server requires a host-local kubeconfig at ${kubeconfigFile};
+    # omitted on minimal-profile hosts (e.g. headless servers) where no
+    # cluster access is wired.
+    kubernetes-mcp-server = {
+      command = "${kubernetesMcpServer}/bin/kubernetes-mcp-server";
+      args = [ "--read-only" ];
+      env = {
+        KUBECONFIG = kubeconfigFile;
+      };
     };
   }
   // lib.optionalAttrs (context7ApiKey != null) {

--- a/modules/apps/cli/claude-code/default.nix
+++ b/modules/apps/cli/claude-code/default.nix
@@ -98,25 +98,31 @@ in
 
   config = lib.mkIf cfg.enable {
     # System packages for MCP tooling and LSP servers
-    environment.systemPackages = with pkgs; [
-      (writeScriptBin "k8s-mcp-setup" k8s-mcp-setup)
-      (writeScriptBin "mcp-pick" mcpPick)
-      llm-agents.claude-plugins # Plugin & skills manager
-      fzf
-      jq
-      rsync # used by claude-capture + activation to mirror skills
+    environment.systemPackages =
+      (with pkgs; [
+        (writeScriptBin "mcp-pick" mcpPick)
+        llm-agents.claude-plugins # Plugin & skills manager
+        fzf
+        jq
+        rsync # used by claude-capture + activation to mirror skills
 
-      # Language servers for Claude Code LSP integration
-      bash-language-server
-      dart
-      gopls
-      lua-language-server
-      pyright
-      rust-analyzer
-      terraform-ls
-      vtsls
-      yaml-language-server
-    ];
+        # Language servers for Claude Code LSP integration
+        bash-language-server
+        dart
+        gopls
+        lua-language-server
+        pyright
+        rust-analyzer
+        terraform-ls
+        vtsls
+        yaml-language-server
+      ])
+      ++ lib.optionals (cfg.serverProfile == "full") [
+        # k8s-mcp-setup is the operator script that wires kubernetes-mcp-server
+        # against a host-local kubeconfig. Pointless on minimal-profile hosts
+        # where the kubernetes MCP server itself is gated out.
+        (pkgs.writeScriptBin "k8s-mcp-setup" k8s-mcp-setup)
+      ];
 
     # Gemini API key for generate-images / visual-explainer skills
     environment.variables = lib.optionalAttrs (secrets ? gemini && secrets.gemini ? apiKey) {
@@ -131,12 +137,16 @@ in
           GEMINI_API_KEY = secrets.gemini.apiKey;
         };
         packages =
-          with pkgs;
-          [
+          (with pkgs; [
             llm-agents.claude-code
-            libnotify # for notify-send in Stop hook
-            libreoffice # soffice on PATH -- required for marp-slides skill's --pptx-editable export
-          ]
+          ])
+          ++ lib.optionals (cfg.serverProfile == "full") (
+            with pkgs;
+            [
+              libnotify # for notify-send in Stop hook (workstation-only)
+              libreoffice # soffice on PATH -- required for marp-slides skill's --pptx-editable export (workstation-only)
+            ]
+          )
           ++ pluginsConfig.packages
           ++ reapConfig.packages;
 

--- a/modules/apps/cli/claude-code/default.nix
+++ b/modules/apps/cli/claude-code/default.nix
@@ -24,6 +24,7 @@ let
       kubernetesMcpServer
       kubeconfigFile
       ;
+    inherit (cfg) serverProfile;
   };
   contextsConfig = import ./cfg/contexts.nix {
     inherit lib;
@@ -75,6 +76,22 @@ in
         type = lib.types.listOf lib.types.str;
         default = [ ];
         description = "Plugin identifiers to install (e.g., 'ralph-loop@claude-plugins-official').";
+      };
+      serverProfile = lib.mkOption {
+        type = lib.types.enum [
+          "full"
+          "minimal"
+        ];
+        default = "full";
+        description = ''
+          Selects which MCP servers and host-specific entries are emitted into
+          the generated Claude Code config.
+
+          * "full"    -- Workstation profile. Includes kubernetes-mcp-server
+                         (requires a host-local kubeconfig).
+          * "minimal" -- Headless / server profile. Drops kubernetes-mcp-server
+                         and any other entries that require host-local files.
+        '';
       };
     };
   };

--- a/modules/apps/cli/zellij/default.nix
+++ b/modules/apps/cli/zellij/default.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  pkgs,
+  config,
+  globals,
+  ...
+}:
+
+let
+  cfg = config.apps.cli.zellij;
+  caddyCfg = config.system.caddy;
+in
+{
+  options.apps.cli.zellij = {
+    enable = lib.mkEnableOption "Zellij terminal multiplexer";
+
+    defaultShell = lib.mkOption {
+      type = lib.types.str;
+      default = globals.preferences.shell;
+      description = "Login shell zellij spawns inside new panes (default: globals.preferences.shell).";
+    };
+
+    tsnetNode = lib.mkOption {
+      type = lib.types.str;
+      default = "zellij";
+      description = "Tailnet node name Caddy joins as for zellij web (URL: https://<node>.<tailnetDomain>/).";
+    };
+
+    internalPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8082;
+      description = "Loopback port where zellij web listens (proxied by Caddy via tsnet).";
+    };
+
+    service.enable = lib.mkEnableOption "zellij web persistent server (systemd user service + Caddy tsnet vhost)";
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        home-manager.users.${globals.user.name} = {
+          programs.zellij = {
+            enable = true;
+            package = pkgs.zellij;
+            settings = {
+              default_shell = cfg.defaultShell;
+            };
+          };
+        };
+      }
+
+      (lib.mkIf cfg.service.enable {
+        system.caddy = {
+          enable = true;
+          tsnetNodes = [ cfg.tsnetNode ];
+        };
+
+        services.caddy.virtualHosts."https://${cfg.tsnetNode}.${caddyCfg.tailnetDomain}" = {
+          extraConfig = ''
+            bind tailscale/${cfg.tsnetNode}
+            reverse_proxy 127.0.0.1:${toString cfg.internalPort}
+          '';
+        };
+
+        home-manager.users.${globals.user.name} = {
+          systemd.user.services.zellij-web = {
+            Unit = {
+              Description = "Zellij web client (browser-accessible terminal multiplexer)";
+              After = [ "network.target" ];
+            };
+            Service = {
+              ExecStart = lib.concatStringsSep " " [
+                "${pkgs.zellij}/bin/zellij"
+                "web"
+                "--start"
+                "--ip 127.0.0.1"
+                "--port ${toString cfg.internalPort}"
+              ];
+              Restart = "on-failure";
+              RestartSec = 5;
+            };
+            Install = {
+              WantedBy = [ "default.target" ];
+            };
+          };
+        };
+      })
+    ]
+  );
+}

--- a/modules/apps/cli/zellij/default.nix
+++ b/modules/apps/cli/zellij/default.nix
@@ -16,8 +16,16 @@ in
 
     defaultShell = lib.mkOption {
       type = lib.types.str;
-      default = globals.preferences.shell;
-      description = "Login shell zellij spawns inside new panes (default: globals.preferences.shell).";
+      default = "${pkgs.${globals.preferences.shell}}/bin/${globals.preferences.shell}";
+      description = ''
+        Absolute path to the shell zellij spawns inside new panes.
+
+        Default resolves the package named by globals.preferences.shell
+        ("fish") to its store path. Using an absolute path -- rather than
+        a name on PATH -- ensures the shell is part of the closure and
+        does not depend on the systemd user manager inheriting an
+        HM-augmented PATH at start time.
+      '';
     };
 
     tsnetNode = lib.mkOption {
@@ -50,6 +58,13 @@ in
       }
 
       (lib.mkIf cfg.service.enable {
+        # Required so the user's systemd manager (and therefore the
+        # zellij-web user service) starts at boot on headless hosts.
+        # Without linger, systemd --user only spawns when the user
+        # actively logs in, defeating the "browser-accessible without
+        # SSH" promise of the web client.
+        users.users.${globals.user.name}.linger = true;
+
         system.caddy = {
           enable = true;
           tsnetNodes = [ cfg.tsnetNode ];

--- a/modules/apps/cli/zellij/default.nix
+++ b/modules/apps/cli/zellij/default.nix
@@ -73,6 +73,17 @@ in
         services.caddy.virtualHosts."https://${cfg.tsnetNode}.${caddyCfg.tailnetDomain}" = {
           extraConfig = ''
             bind tailscale/${cfg.tsnetNode}
+            header {
+              # Strip Referer on outbound responses so the bearer token in any
+              # initial ?token= URL never leaks to a third-party site clicked
+              # from inside the terminal.
+              Referrer-Policy "no-referrer"
+              # Defense in depth: prevent the zellij origin from being framed
+              # by another tsnet vhost and from sourcing arbitrary scripts.
+              # zellij-web's own assets are same-origin, so this is safe.
+              Content-Security-Policy "frame-ancestors 'none'; form-action 'self'"
+              X-Frame-Options "DENY"
+            }
             reverse_proxy 127.0.0.1:${toString cfg.internalPort}
           '';
         };

--- a/modules/server/nfs/default.nix
+++ b/modules/server/nfs/default.nix
@@ -103,6 +103,7 @@ in
       lib.nameValuePair exportCfg.path (
         lib.mkIf (exportCfg.bindMount != null) {
           device = exportCfg.bindMount;
+          fsType = "none";
           options = [ "bind" ];
         }
       )

--- a/modules/suites/terminal/default.nix
+++ b/modules/suites/terminal/default.nix
@@ -27,6 +27,7 @@ in
     apps.cli = {
       fish.enable = true;
       starship.enable = true;
+      zellij.enable = true;
       zoxide.enable = true;
     };
 

--- a/modules/system/caddy/default.nix
+++ b/modules/system/caddy/default.nix
@@ -61,6 +61,13 @@ in
       "d /var/lib/caddy/tsnet 0750 caddy caddy -"
     ];
 
+    # SECURITY-FOLLOWUP: this writes TS_AUTHKEY into the systemd unit file
+    # under /nix/store, which is world-readable. Acceptable today because the
+    # only local user is `dustin`, but every Claude Code MCP child (npx-spawned)
+    # also runs as `dustin` and could exfiltrate the key on disk. Migrate to
+    # sops-nix / agenix so the key is decrypted at activation time into
+    # /run/secrets/ and loaded via systemd `EnvironmentFile=` or
+    # `LoadCredential=`. Tracked separately from issue #43.
     systemd.services.caddy.serviceConfig.Environment = lib.optionals (
       secrets ? tailscale && secrets.tailscale ? caddyAuthKey
     ) [ "TS_AUTHKEY=${secrets.tailscale.caddyAuthKey}" ];


### PR DESCRIPTION
## Summary
Closes #43: feat: add zellij + claude-code on srv with tsnet web access

- chore: ignore docs/superpowers/ working directory

- docs(zellij-web): document operator workflow for browser-accessible Zellij

- feat(srv): cherry-pick Claude Code stack + zellij web behind Caddy tsnet

- feat(suites-terminal): enable zellij on workstations

- feat(zellij): add module with optional zellij-web service

- feat(claude-code): add serverProfile option to gate kubernetes MCP

- fix(nfs): add fsType="none" to bind-mount fileSystems entries