### PR TITLE
security(uuid): fix uuid: Missing buffer bounds check in v3/v5/v6 whe...

### DIFF
--- a/modules/apps/cli/todoist-cli/build/package-lock.json
+++ b/modules/apps/cli/todoist-cli/build/package-lock.json
@@ -146,7 +146,7 @@
         "form-data": "4.0.5",
         "ts-custom-error": "^3.2.0",
         "undici": "^7.16.0",
-        "uuid": "11.1.0",
+        "uuid": "11.1.1",
         "zod": "4.3.6"
       },
       "engines": {
@@ -10356,9 +10356,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/settings/versions.nix
+++ b/settings/versions.nix
@@ -211,7 +211,7 @@
       npmPkg = "@doist/todoist-cli";
       version = "1.61.0";
       hash = "sha256-Cv+3QDDK1XS5knPX5XqJQSYgbeKoXYMBhnwsSkvwFtc=";
-      npmDepsHash = "sha256-w4syPOYwDnqRlW/GPFk4G8L3dFUYNBZrc5+qNAvRIwA=";
+      npmDepsHash = "sha256-YsFxtaL5+Hf64RfVABEz4im8+RGLwN2DDQM6QGEkbEk=";
     };
 
     # Upstream Claude Code skills fetched from single-maintainer GitHub repos.


### PR DESCRIPTION
## Summary
Fixes Dependabot alert #76
- Package: uuid
- uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided

- security(todoist-cli): bump uuid to 11.1.1 (CVE-2026-41907)
  Patches GHSA-w5hq-g745-h8pq / CVE-2026-41907: uuid v3/v5/v6 missing
  buffer bounds check when buf is provided, allowing silent partial
  writes into caller-provided buffers.
  
  uuid is a transitive dep via @doist/todoist-sdk. Bumped the lockfile
  entry from 11.1.0 -> 11.1.1 (the first patched release in the 11.x
  line) and refreshed the matching npmDepsHash in versions.nix.
  
  Vulnerable range: >=11.0.0, <11.1.1
  Patched: 11.1.1