### PR TITLE
Cross-device Claude Code workflow (peer-host model)

### DIFF
--- a/.claude/docs/cross-device-workflow.md
+++ b/.claude/docs/cross-device-workflow.md
@@ -1,0 +1,36 @@
+# Cross-device Claude workflow
+
+Two peer work hosts: `srv` (always-on) and `qbert` (workstation, occasional direct-use). Both run `claude-control-tower-${hostname}` and zellij; both are reachable over SSH on the tailnet. Sessions live on the host where they were started; no cross-host state sync.
+
+## Verbs
+
+The `work` fish function is installed on every host (workstations + peers). It is the canonical entry point.
+
+- `work` — across-peer session picker (fzf if installed, numbered prompt otherwise).
+- `work <name>` — attach locally if `<name>` exists locally; else fall back to a peer; else create on the current host.
+- `work <name>@<host>` — force a specific host.
+- `work --here <name>` — force the current host even if a peer has the name.
+- `work --help` — usage.
+
+Sessions are named per-repo by convention: zellij session name = repo basename (`nixerator`), with `<repo>#<N>` for `/github-issue` worktrees.
+
+## iPhone
+
+- **Resume:** Termius / Blink / Prompt over Tailscale → `ssh srv` (or `qbert`) → `work`. SSH only — no mosh, no zellij-web.
+- **Spawn new:** claude.ai/code → pick `claude-control-tower-srv` or `claude-control-tower-qbert` → start a new session in a repo.
+
+## /github-issue
+
+Auto-renames the zellij session to `<repo>#<N>` when invoked inside zellij. An issue kicked off from the iPhone is then discoverable from any other device via `work <repo>#<N>`. (The renaming itself lives in the skill at `~/.claude/skills/github-issue/`, not in this repo.)
+
+## Components
+
+- `archetypes.claudeWorkHost` (enabled on srv + qbert) — bundles zellij + claude-remote + control tower + ssh + work-launcher.
+- `apps.cli.work-launcher` (enabled on srv + qbert + donkeykong) — ships the `work` fish function. `peers` defaults to `[ "srv" "qbert" ]`.
+- `apps.cli.claude-remote.controlTower` — the systemd `--user` service (per-host name `claude-control-tower-${hostname}`) that claude.ai/code connects to.
+
+donkeykong is **attach-only** in v1: it has the `work` function but does NOT run a control tower or expose sessions to peers. Promotable later by flipping `archetypes.claudeWorkHost.enable = true;` and adding it to the peers list.
+
+## What is NOT here
+
+- No mosh. No zellij-web. No syncthing of `~/.claude` or worktrees. No cross-host worktree sync. Branches move via `git push`/`git pull` only.

--- a/.claude/docs/cross-device-workflow.md
+++ b/.claude/docs/cross-device-workflow.md
@@ -31,6 +31,10 @@ Auto-renames the zellij session to `<repo>#<N>` when invoked inside zellij. An i
 
 donkeykong is **attach-only** in v1: it has the `work` function but does NOT run a control tower or expose sessions to peers. Promotable later by flipping `archetypes.claudeWorkHost.enable = true;` and adding it to the peers list.
 
+## Attack surface
+
+Enabling `archetypes.claudeWorkHost` on a host implies `system.ssh.enable = true`, which turns on `services.openssh` with NixOS defaults: sshd listens on `0.0.0.0:22` and TCP 22 is opened in the firewall. On a workstation (qbert) this is a new exposure — pre-archetype it had no sshd at all. Acceptable under the threat model (single-user hosts, key-only auth, no password login, no port-forwarded internet exposure). If that model ever tightens, narrow sshd to the tailnet interface via `services.openssh.listenAddresses` rather than relaxing the archetype.
+
 ## What is NOT here
 
-- No mosh. No zellij-web. No syncthing of `~/.claude` or worktrees. No cross-host worktree sync. Branches move via `git push`/`git pull` only.
+- No mosh on the **work-host path** (zellij-web and mosh both retired by this design from srv). `mosh.enable = true` is still set in the workstation terminal suite, so donkeykong/qbert keep mosh outside the work flow. No syncthing of `~/.claude` or worktrees. No cross-host worktree sync. Branches move via `git push`/`git pull` only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ See `~/.claude/CLAUDE.md` for the global *thin-CLAUDE.md protocol* and *Where cu
 - When making code changes — builds, rebuilds, lint, format, upgrades, git discipline, secrets — read `.claude/docs/conventions.md`.
 - When you need to look up docs for a Nix tool, library, or flake input, read `.claude/docs/sources.md` (context7 / gitmcp lookup table).
 - When you need a local CLI tool (`amber`, `cpx`, `meetsum`, `gsd`), read `.claude/docs/tools.md`.
+- When the user asks about cross-device session pickup, the `work` fish function, the `claudeWorkHost` archetype, or how to attach to a session from the iPhone, read `.claude/docs/cross-device-workflow.md`.
 
 ## Reference docs
 

--- a/docs/plans/2026-05-11-claude-cross-device-workflow-design.md
+++ b/docs/plans/2026-05-11-claude-cross-device-workflow-design.md
@@ -1,0 +1,243 @@
+# Claude Code cross-device workflow — design
+
+Issue: none filed yet (workflow exploration, not a tracked feature). Suggested issue title: "Cross-device Claude Code workflow (peer hosts + work launcher)".
+
+Suggested branch: `feat/claude-cross-device-workflow`.
+
+## Background
+
+Today the user runs Claude Code interactively from multiple devices (workstation, laptop-class workstation, iPhone) but lacks a consistent way to start a session on one machine and pick it back up from another. The friction shows up in three places:
+
+1. **No naming convention** for zellij sessions, so "which session was I in?" requires either remembering or `zellij list-sessions` per host.
+2. **No cross-host session discovery** — sessions started on `srv` are invisible from `qbert` and vice versa.
+3. **iPhone story is partial.** `apps.cli.claude-remote.controlTower` is defined but not enabled on any host, and `zellij-web` (enabled on srv) is awkward to drive from iOS Safari.
+
+The user's stated goal is **continuity, not always-on**: if a host is reachable, the user wants to attach back to whatever session they left there, from whichever device they're holding. Cross-device state *sync* is explicitly out of scope — the only "sync" allowed is git push/pull of working branches the user initiates intentionally.
+
+Inventory of existing infrastructure relevant to this work:
+
+| Component | Location | State today |
+|---|---|---|
+| Zellij + KDL config + cheatsheet keybind | `modules/apps/cli/zellij/default.nix` | Enabled on `srv` (`hosts/srv/modules.nix:78-94`) via terminal suite on workstations. Has `service.enable` (web), `mosh.enable`, `hideStatusBar`, `cheatsheet.enable` sub-options. |
+| zellij-web behind Caddy tsnet | same module, `service.enable` branch | Enabled on `srv` only. To be retired by this design (see §6). |
+| Claude remote-control "tower" | `modules/apps/cli/claude-remote/default.nix` | Module exists with `enable` + `controlTower.enable`; **not enabled on any host** (`grep` confirms). |
+| SSH daemon | `modules/system/ssh/` | Enabled on `srv` (`hosts/srv/modules.nix:98`). Workstations enable it via the server archetype path / workstation defaults — needs verification per host during implementation. |
+| Archetype pattern | `modules/archetypes/{server,workstation}/default.nix` | Two existing archetypes, both with a single `enable` option and a `config = lib.mkIf cfg.enable { … }` body that flips suites + system modules. |
+
+Hosts in scope:
+
+- `srv` — headless, always-on, primary Claude session host.
+- `qbert` — workstation, occasionally used directly when the user is sitting at it. Symmetric peer to `srv`.
+- `donkeykong` — workstation. Attach-only in v1 (no work-host role), can opt in later.
+
+## Goals
+
+1. **Single naming rule**: zellij session name = repo basename (`nixerator`), with `<repo>#<N>` for `/github-issue` worktrees. Derived from `pwd`, never typed.
+2. **Peer-symmetric work hosts**: `srv` and `qbert` run identical Claude work infrastructure. Sessions live where they were started; no host is canonical.
+3. **One `work` fish function** installed on every device. From the workstation, laptop, the work-hosts themselves, or an iPhone SSH client, the verb is the same and the result is "attach to the right session on the right host."
+4. **iPhone via SSH only** — Termius / Blink / Prompt over Tailscale, then `work` inside the SSH session. No browser-based terminal in v1.
+5. **iPhone spawn-new flow preserved**: claude.ai/code → control tower on `srv` or `qbert` → start a session in a chosen repo. Each peer registers a distinctly-named control tower so the picker is unambiguous.
+6. **`/github-issue` auto-renames** its zellij session to `<repo>#<N>` when run inside zellij. Issues kicked off from the iPhone are immediately discoverable by name from the laptop the next morning.
+7. **Zero state sync**. No syncthing of `~/.claude`, no auto-pulled branches, no rsync. The only state movement is `git push`/`git pull` the user runs intentionally.
+
+## Non-goals
+
+- **State or worktree sync across hosts.** Worktrees and `.claude/projects/` state live exclusively on the host that created them. Cost: a branch left uncommitted on one host is not visible from the other until the user commits + pushes + pulls. Accepted.
+- **Cross-host session migration.** A session on `srv` cannot be "moved" to `qbert`; it lives until killed. To work the same task on the other host, the user starts a fresh session there.
+- **Aggregator UI.** No web page or daemon that fans out `zellij list-sessions` across hosts. The `work` fish function does this in-process per invocation. Revisit only if friction is observed in practice.
+- **Zellij-web survival.** Today srv has `apps.cli.zellij.service.enable = true` (browser-accessible zellij). This design retires it in favor of SSH-only iPhone access. The module option stays, just unused.
+- **Mosh.** Today srv has `apps.cli.zellij.mosh.enable = true`. This design retires it. SSH-only.
+- **Donkeykong as a work host (v1).** It can attach. It does not run a control tower or expose its zellij sessions to peers. Promotable later by flipping the archetype.
+
+## Approach
+
+Three artefacts:
+
+1. **New archetype `archetypes.claudeWorkHost`** that bundles "this host is a Claude work peer": zellij (no web, no mosh), claude-remote + control tower, sshd, plus the `work-launcher` (configured to know about its peers). Enabled on `srv` and `qbert`.
+2. **New module `apps.cli.work-launcher`** that ships the `work` fish function and the `peers` option. Installed everywhere — work-hosts use it the same way as attach-only hosts do (the function handles the local vs. remote branching internally).
+3. **Small skill patch to `/github-issue`** that renames the zellij session when a worktree is created inside a zellij context.
+
+Plus targeted edits:
+
+- Move `users.users.${globals.user.name}.linger = true;` from the zellij `service.enable` branch into the claude-remote `controlTower.enable` branch (where it belongs — the user systemd service that actually needs linger).
+- Per-host control tower naming: `claude-control-tower-${hostname}` instead of the unconditional `claude-control-tower`, so claude.ai/code's tower picker on iPhone shows distinct entries.
+- Hosts: flip `archetypes.claudeWorkHost.enable = true;` on `srv` and `qbert`. Remove the now-redundant explicit `apps.cli.zellij.service.enable = true;` and `mosh.enable = true;` from `hosts/srv/modules.nix`. `donkeykong` gets `apps.cli.work-launcher.enable = true;` only.
+
+## Detailed design
+
+### File touches
+
+| File | Change |
+|---|---|
+| `modules/archetypes/claudeWorkHost/default.nix` | **New.** Single `archetypes.claudeWorkHost.enable` option. Body flips `apps.cli.zellij.enable`, `apps.cli.zellij.hideStatusBar`, `apps.cli.zellij.cheatsheet.enable`, `apps.cli.claude-remote.enable`, `apps.cli.claude-remote.controlTower.enable`, `apps.cli.work-launcher.enable`, `system.ssh.enable`. Does NOT flip `apps.cli.zellij.service.enable` or `apps.cli.zellij.mosh.enable`. |
+| `modules/apps/cli/work-launcher/default.nix` | **New.** Options: `enable`, `peers` (list of strings, default `[ "srv" "qbert" ]`), `sshUser` (string, defaults to `globals.user.name`). Installs the `work` fish function as `home-manager.users.<user>.programs.fish.functions.work`. |
+| `modules/apps/cli/work-launcher/functions/work.fish` | **New.** Fish function source (see §"Launcher behavior" below). Read into the nix module via `builtins.readFile` and template-substituted for `@PEERS@` / `@SSH_USER@` / `@LOCAL_HOST@` placeholders. |
+| `modules/apps/cli/claude-remote/default.nix` | (1) Rename the systemd service from `claude-control-tower` to `claude-control-tower-${config.networking.hostName}`. (2) Update `ExecStart`'s `--name` argument to match. (3) Add `users.users.${globals.user.name}.linger = true;` inside `lib.mkIf cfg.controlTower.enable`. |
+| `modules/apps/cli/zellij/default.nix` | Remove `users.users.${globals.user.name}.linger = true;` from the `service.enable` branch. Leave the rest of the module alone (`service.enable`, `mosh.enable`, `tsnetNode`, `internalPort` stay as inert opt-in knobs). |
+| `hosts/srv/modules.nix` | Replace the explicit `apps.cli.zellij = { enable; service.enable; tsnetNode; mosh.enable; hideStatusBar; cheatsheet.enable; … };` block with `archetypes.claudeWorkHost.enable = true;`. The archetype already sets `hideStatusBar` and `cheatsheet.enable`, so no override block is needed unless srv wants to diverge from the archetype default (it doesn't, in v1). |
+| `hosts/srv/modules.nix` (imports list) | Add `../../modules/archetypes/claudeWorkHost` and `../../modules/apps/cli/work-launcher` to the explicit imports list (srv manually imports modules — `hosts/CLAUDE.md` is explicit about this). |
+| `hosts/qbert/modules.nix` | Add `archetypes.claudeWorkHost.enable = true;`. No imports list change (workstations auto-import). |
+| `hosts/donkeykong/modules.nix` | Add `apps.cli.work-launcher.enable = true;` (attach-only, no work-host role). |
+| `~/.claude/skills/github-issue/SKILL.md` (or equivalent skill script) | Add a post-worktree-creation step: if `ZELLIJ` env var is set, run `zellij action rename-session "<repo>#<N>"`. **Out of nixerator's repo**; tracked separately, but referenced here so the workflow is end-to-end documented. |
+
+### Archetype shape
+
+```nix
+# modules/archetypes/claudeWorkHost/default.nix
+{ lib, config, ... }:
+
+let
+  cfg = config.archetypes.claudeWorkHost;
+in
+{
+  options.archetypes.claudeWorkHost.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = ''
+      Enable the Claude work-host archetype: zellij (no web, no mosh),
+      claude-remote with always-on control tower, sshd, and the work
+      launcher. Sessions started on this host stay on this host and are
+      attachable from any peer via the `work` fish function or directly
+      via SSH + `zellij attach`.
+    '';
+  };
+
+  config = lib.mkIf cfg.enable {
+    apps.cli.zellij = {
+      enable = true;
+      hideStatusBar = true;
+      cheatsheet.enable = true;
+    };
+    apps.cli.claude-remote = {
+      enable = true;
+      controlTower.enable = true;
+    };
+    apps.cli.work-launcher.enable = true;
+    system.ssh.enable = true;
+  };
+}
+```
+
+Namespace matches `modules/CLAUDE.md` (`archetypes.*`). No `let cfg = config.NAMESPACE.PATH` body needed beyond the standard pattern.
+
+### Launcher behavior
+
+The `work` fish function lives at `modules/apps/cli/work-launcher/functions/work.fish` and is loaded as a fish function (not a script) so it shares the user's interactive environment.
+
+Synopsis:
+
+```
+work                  # Show sessions across all peers, pick one, attach.
+work <name>           # Resolve <name> across peers; attach (or create on
+                      # current host if not found anywhere).
+work <name>@<host>    # Force a specific host.
+work --here <name>    # Force the current host even if a peer has the name.
+```
+
+"Current host" is detected at runtime via the `hostname` command and compared against the build-time `peers` list (passed in as a substituted constant). No drift between nix build state and runtime is expected — these are NixOS hosts where the hostname is set by configuration.
+
+Resolution rules:
+
+1. If `--here` is set OR a local session matches `<name>` (regardless of whether the current host is in `peers`): attach locally via `zellij attach -c <name>`.
+2. Else for each `peer` in `peers` (excluding the current host): run `ssh -o ConnectTimeout=2 -o BatchMode=yes <sshUser>@<peer> zellij list-sessions 2>/dev/null`. If any peer returns a session named `<name>`, attach there with `ssh -t <sshUser>@<peer> -- zellij attach -c <name>`. First-match wins; the cross-host scan logs which peers were probed.
+3. If nothing matched and the user invoked with a name: create a new session on the current host (`zellij attach -c <name>` auto-creates if missing).
+4. If invoked with no name: build a unified list `(host, session)` across peers, present via `fzf` if available else a numbered prompt, attach to the choice.
+
+Edge cases:
+
+- **`work` called from inside a zellij session**: warn and exit non-zero; nesting zellij confuses keybinds. The cheatsheet documents `Ctrl-q` + `q` to detach first.
+- **All peers unreachable**: fall back to local zellij with a warning.
+- **SSH host-key prompt**: out of scope; the user's existing ssh module handles known_hosts (`modules/system/ssh/`). The launcher will fail loudly if a peer's key is unknown rather than silently auto-accepting.
+- **`zellij list-sessions` exits 1 on no sessions**: treat as empty list, not error.
+
+The function is intentionally a single fish file (~80 lines target). No background daemons, no cached state file. Each invocation is a fresh probe.
+
+### Per-host control-tower naming
+
+`modules/apps/cli/claude-remote/default.nix:123` currently registers the service as `systemd.user.services.claude-control-tower`. The remote-control server is invoked with `--name claude-control-tower` (line 133), which is what claude.ai/code displays. With control towers on two hosts (`srv`, `qbert`), the picker would show two ambiguously-named entries.
+
+Change:
+
+```nix
+systemd.user.services."claude-control-tower-${config.networking.hostName}" = {
+  # …
+  Service.ExecStart = "${pkgs.llm-agents.claude-code}/bin/claude remote-control --name claude-control-tower-${config.networking.hostName} --permission-mode bypassPermissions";
+  # …
+};
+```
+
+The `towerDir` (`${globals.user.homeDirectory}/.local/share/claude-control-tower`) stays the same — it's a working directory, not a service identity.
+
+### Linger relocation
+
+Today:
+
+```nix
+# modules/apps/cli/zellij/default.nix:172-173
+(lib.mkIf cfg.service.enable {
+  users.users.${globals.user.name}.linger = true;
+  # … caddy + tsnet + zellij-web …
+})
+```
+
+This is the wrong owner for linger. The zellij-web *server* needs linger only because it's a `--user` systemd service. The same property is needed by the claude-remote `--user` service, which is unrelated to zellij. After this change, both srv and qbert get linger via the claude-remote module; if `service.enable` is ever flipped back on, it must not also set linger (otherwise a future module removal would leave a host without linger when another module silently relies on it).
+
+Move it:
+
+```nix
+# modules/apps/cli/claude-remote/default.nix, inside lib.mkIf cfg.controlTower.enable
+users.users.${globals.user.name}.linger = true;
+```
+
+Delete the line from the zellij module. The closure delta on hosts that have neither flag set is zero.
+
+### iPhone integration
+
+Two app categories, both already in the user's toolbox:
+
+1. **SSH client** (Termius / Blink / Prompt) with Tailscale running on the phone: save two host entries (`srv`, `qbert`) using magicDNS; either save a "post-connect command" of `work` to land in the picker immediately, or save per-repo "snippets" like `work nixerator` for one-tap resume. No nixerator-side work required.
+2. **claude.ai/code**: connect to `claude-control-tower-srv` and/or `claude-control-tower-qbert` to spawn new sessions in chosen repos. Tower naming is the only nixerator-side change needed for this flow.
+
+### `/github-issue` skill change
+
+In the skill's worktree-creation step, after `git worktree add` succeeds, detect zellij and rename:
+
+```bash
+if [ -n "${ZELLIJ:-}" ]; then
+  zellij action rename-session "${repo_basename}#${issue_number}" || true
+fi
+```
+
+This skill lives in `~/.claude/skills/`, not in this repo. Tracked as a separate follow-up in the implementation plan; called out here for end-to-end clarity.
+
+## Rollout
+
+Single PR is appropriate — the pieces are tightly coupled and the user is the only consumer.
+
+1. Land the new `work-launcher` module + archetype on a feature branch.
+2. Add archetype enable to `srv` and `qbert`; add launcher enable to `donkeykong`.
+3. Edit zellij + claude-remote modules (linger relocation, control-tower naming).
+4. `just qr` on each affected host in order: `donkeykong` first (lowest blast radius — just adds the fish function), then `qbert`, then `srv`. Confirm `zellij attach` + `work <name>` round-trip from each host to each peer before the next host.
+5. Phone validation: Termius → srv → `work` → picker shows expected sessions. claude.ai/code shows `claude-control-tower-srv` and `claude-control-tower-qbert` as distinct entries.
+6. Patch `/github-issue` skill separately; not blocking the nixerator PR.
+
+Rollback plan: every change is a flip of an `enable` flag or a localised module diff. `git revert` of the PR plus `just qr` on each host restores the prior state. No data migration involved.
+
+## Tradeoffs / accepted limitations
+
+- **Network roaming kills the SSH transport.** Mosh would have auto-resumed; SSH does not. Cost: a tap to reconnect. The zellij session persists on the server, so no work is lost. Acceptable given iPhone-on-cellular mosh has historically been flaky.
+- **No keystroke prediction.** SSH lacks mosh's local echo. On low-RTT Tailscale this is invisible; on high-latency cellular it would be noticeable, but the user has explicitly chosen SSH-only.
+- **No aggregator UI.** The first-pass `work` function does an N-way SSH fan-out on every invocation (N = number of peers, currently 2). Per-invocation cost is ~50–200ms over the tailnet. Below the threshold where caching is worth the complexity. Revisit at N ≥ 4.
+- **Donkeykong remains attach-only in v1.** Sessions started while sitting at donkeykong via local `zellij` are not discoverable from peers (the launcher won't probe a host that isn't in `peers`). User can promote donkeykong later by adding it to the archetype + the peers list.
+- **`apps.cli.zellij.service.enable` and `.mosh.enable` retire to "inert option" status.** Module-cleanup churn (deleting the option entirely, removing Caddy vhost wiring) is intentionally deferred to keep this PR scoped to workflow ergonomics. If those branches are confirmed unused in 30 days, a follow-up PR removes them.
+- **Single-user threat model.** Memory `project_threat_model.md` flags that "secret in `/nix/store`" findings get downgraded on these hosts. This design adds no new secret-storage surface — control-tower listens locally only, SSH is keypair-only via the existing ssh module — so the threat profile is unchanged.
+
+## Open questions
+
+1. **`workstation` archetype already enables `terminal.enable` and `ai.enable`.** Need to verify whether `terminal.enable` flips `apps.cli.zellij.enable` on workstations; if so, the `claudeWorkHost` archetype's `zellij.enable` is redundant on those hosts (idempotent in nix, but worth a one-line check during implementation).
+2. **`apps.cli.work-launcher.peers` defaulting to `[ "srv" "qbert" ]`** is convenient but couples the module's default to a specific user's host list. Alternative: default to `[]` and require explicit host configuration. **Decision deferred to implementation review** — leaning toward the explicit-list default since this module is currently used only by one operator.
+3. **`/github-issue` rename**: does the skill currently call any pre-existing zellij integration code? Verify before patching — there may already be a hook point.
+
+## Spec ↔ later plan
+
+A separate implementation plan (`docs/plans/2026-05-11-claude-cross-device-workflow.md`) will sequence the file touches, the per-host rebuild order, and verification steps.

--- a/docs/plans/2026-05-11-claude-cross-device-workflow.md
+++ b/docs/plans/2026-05-11-claude-cross-device-workflow.md
@@ -1,0 +1,1194 @@
+# Claude Code cross-device workflow — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire up the peer-host Claude workflow: a new `claudeWorkHost` archetype + `work-launcher` module enabling identical infrastructure on `srv` and `qbert`, a `work` fish function for cross-host session attach via SSH only, per-host control-tower naming so claude.ai/code's picker is unambiguous, retirement of zellij-web + mosh, and a `donkeykong` attach-only install.
+
+**Architecture:** Three new files (`modules/archetypes/claudeWorkHost/default.nix`, `modules/apps/cli/work-launcher/default.nix`, embedded `work.fish` body) + four surgical edits (`modules/apps/cli/claude-remote/default.nix` for service rename + linger, `modules/apps/cli/zellij/default.nix` for linger removal, `modules/suites/terminal/default.nix` to drop mosh, three host files to flip enables). Auto-import on workstations means `qbert` / `donkeykong` need no `imports = …` change; `srv` does (it manually imports per `hosts/CLAUDE.md`).
+
+**Tech Stack:** Nix, Home Manager, NixOS, fish shell, systemd (user services), zellij, OpenSSH, just (justfile runner). Project conventions: `just qr` per host for rebuild (writes log to `/tmp/nixerator-rebuild.log`); `nix fmt` for formatting; `statix` + `deadnix` for lint. **Never run `git commit` or `git push` — the user handles commits.** After each task, the plan emits a *suggested* conventional commit message; do not execute it.
+
+**Spec:** [`docs/plans/2026-05-11-claude-cross-device-workflow-design.md`](./2026-05-11-claude-cross-device-workflow-design.md). Read it for the design rationale.
+
+**Branch:** `feat/claude-cross-device-workflow` (base off `main` — local `main` is kept fresh by the session-start git-sync hook).
+
+**Rebuild order at the end:** `donkeykong` → `qbert` → `srv` (ascending blast radius). Each host's `just qr` is run by the user; the plan documents what each rebuild should produce.
+
+---
+
+### Task 1: Create the `work-launcher` module skeleton
+
+Empty-body module so it auto-imports cleanly and `apps.cli.work-launcher.enable` becomes a flippable option before the fish function lands in Task 2.
+
+**Files:**
+
+- Create: `modules/apps/cli/work-launcher/default.nix`
+
+- [ ] **Step 1: Create the module file**
+
+```nix
+{
+  lib,
+  config,
+  globals,
+  ...
+}:
+
+let
+  cfg = config.apps.cli.work-launcher;
+in
+{
+  options.apps.cli.work-launcher = {
+    enable = lib.mkEnableOption "work fish function for cross-host zellij session attach";
+
+    peers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "srv"
+        "qbert"
+      ];
+      description = ''
+        Hostnames the `work` fish function probes for zellij sessions
+        when resolving an unqualified `work <name>` invocation, and when
+        building the no-argument picker. The current host (matched at
+        runtime via the `hostname` command) is automatically skipped on
+        the SSH leg — local sessions are listed via `zellij list-sessions`
+        directly.
+      '';
+    };
+
+    sshUser = lib.mkOption {
+      type = lib.types.str;
+      default = globals.user.name;
+      description = ''
+        SSH user the launcher connects to peers as. Defaults to
+        globals.user.name (single-user hosts under this flake).
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Fish function body added in Task 2.
+  };
+}
+```
+
+- [ ] **Step 2: Format**
+
+Run:
+
+```bash
+nix fmt modules/apps/cli/work-launcher/default.nix
+```
+
+Expected: no errors, file may be reformatted.
+
+- [ ] **Step 3: Lint**
+
+Run:
+
+```bash
+statix check modules/apps/cli/work-launcher/default.nix
+deadnix --fail modules/apps/cli/work-launcher/default.nix
+```
+
+Expected: both exit 0 (no warnings — file is small and self-consistent).
+
+- [ ] **Step 4: Verify auto-import sees the new module**
+
+Run:
+
+```bash
+nix flake check --no-build 2>&1 | head -50
+```
+
+Expected: no errors related to `apps.cli.work-launcher`. The option `apps.cli.work-launcher.enable` should now exist in the module tree, but no host has flipped it yet, so configuration evaluation is a no-op.
+
+- [ ] **Step 5: Suggested commit**
+
+```
+feat(work-launcher): scaffold module with peers + sshUser options
+
+Empty-body module that exposes apps.cli.work-launcher.{enable,peers,sshUser}.
+Body (fish function) lands in the next commit. peers defaults to
+[srv qbert] to match the two work-host peers; sshUser defaults to
+globals.user.name.
+```
+
+---
+
+### Task 2: Add the `work` fish function
+
+Inline the function body via `programs.fish.functions.work` so it ships through home-manager and gets the user's normal fish environment.
+
+**Files:**
+
+- Modify: `modules/apps/cli/work-launcher/default.nix`
+
+- [ ] **Step 1: Replace the `config = lib.mkIf cfg.enable { … };` block with the version below**
+
+The full module file should now read:
+
+```nix
+{
+  lib,
+  config,
+  globals,
+  ...
+}:
+
+let
+  cfg = config.apps.cli.work-launcher;
+
+  # Render peers as a space-separated, double-quoted fish list literal so
+  # the function body can do `set -l peers $peersList` without further
+  # parsing. Hostnames don't contain spaces, but quoting is cheap insurance.
+  peersFishList = lib.concatMapStringsSep " " (p: ''"${p}"'') cfg.peers;
+in
+{
+  options.apps.cli.work-launcher = {
+    enable = lib.mkEnableOption "work fish function for cross-host zellij session attach";
+
+    peers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "srv"
+        "qbert"
+      ];
+      description = ''
+        Hostnames the `work` fish function probes for zellij sessions
+        when resolving an unqualified `work <name>` invocation, and when
+        building the no-argument picker. The current host (matched at
+        runtime via the `hostname` command) is automatically skipped on
+        the SSH leg — local sessions are listed via `zellij list-sessions`
+        directly.
+      '';
+    };
+
+    sshUser = lib.mkOption {
+      type = lib.types.str;
+      default = globals.user.name;
+      description = ''
+        SSH user the launcher connects to peers as. Defaults to
+        globals.user.name (single-user hosts under this flake).
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home-manager.users.${globals.user.name} = {
+      programs.fish.functions.work = {
+        description = "Attach to (or create) a zellij session across peer hosts";
+        body = ''
+          # Build-time configuration injected by the work-launcher module.
+          set -l peers ${peersFishList}
+          set -l ssh_user ${cfg.sshUser}
+          set -l current_host (hostname)
+
+          # --- arg parsing ---
+          set -l force_local 0
+          set -l name ""
+          for arg in $argv
+              switch $arg
+                  case '--here'
+                      set force_local 1
+                  case '-h' '--help'
+                      echo "Usage: work [--here] [<name>[@<host>]]"
+                      echo ""
+                      echo "  work                  pick a session across peers, attach"
+                      echo "  work <name>           attach to <name>; create on current host if not found"
+                      echo "  work <name>@<host>    attach to <name> on specific <host>"
+                      echo "  work --here <name>    force current host"
+                      return 0
+                  case '*'
+                      set name $arg
+              end
+          end
+
+          # Refuse to nest zellij.
+          if set -q ZELLIJ
+              echo "work: already inside a zellij session. Detach first (Ctrl-q q)." >&2
+              return 2
+          end
+
+          # Explicit <name>@<host> form short-circuits discovery.
+          if string match -q '*@*' -- $name
+              set -l parts (string split -m1 '@' -- $name)
+              set name $parts[1]
+              set -l target $parts[2]
+              if test "$target" = "$current_host"
+                  zellij attach -c $name
+                  return $status
+              end
+              ssh -t -o ConnectTimeout=2 $ssh_user@$target -- zellij attach -c $name
+              return $status
+          end
+
+          # --here forces local even if a peer has the name.
+          if test $force_local -eq 1
+              if test -z "$name"
+                  echo "work --here requires a <name>" >&2
+                  return 2
+              end
+              zellij attach -c $name
+              return $status
+          end
+
+          # Local sessions snapshot.
+          set -l local_sessions
+          if type -q zellij
+              set local_sessions (zellij list-sessions -s 2>/dev/null | string trim)
+          end
+
+          # If a name was given and exists locally, attach immediately.
+          if test -n "$name"
+              if contains -- $name $local_sessions
+                  zellij attach -c $name
+                  return $status
+              end
+          end
+
+          # Probe peers (skip current host).
+          set -l inventory_hosts
+          set -l inventory_sessions
+          for s in $local_sessions
+              set inventory_hosts $inventory_hosts $current_host
+              set inventory_sessions $inventory_sessions $s
+          end
+          for peer in $peers
+              if test "$peer" = "$current_host"
+                  continue
+              end
+              set -l remote (ssh -o ConnectTimeout=2 -o BatchMode=yes $ssh_user@$peer zellij list-sessions -s 2>/dev/null | string trim)
+              for s in $remote
+                  set inventory_hosts $inventory_hosts $peer
+                  set inventory_sessions $inventory_sessions $s
+              end
+          end
+
+          # Name given: find first peer match.
+          if test -n "$name"
+              for i in (seq (count $inventory_sessions))
+                  if test "$inventory_sessions[$i]" = "$name"
+                      set -l target $inventory_hosts[$i]
+                      if test "$target" = "$current_host"
+                          zellij attach -c $name
+                      else
+                          ssh -t -o ConnectTimeout=2 $ssh_user@$target -- zellij attach -c $name
+                      end
+                      return $status
+                  end
+              end
+              echo "work: no session '$name' found across peers ($peers), creating on $current_host" >&2
+              zellij attach -c $name
+              return $status
+          end
+
+          # No name: present picker.
+          set -l n (count $inventory_sessions)
+          if test $n -eq 0
+              echo "work: no zellij sessions found on any peer ($peers)" >&2
+              return 1
+          end
+
+          set -l choices
+          for i in (seq $n)
+              set choices $choices "$inventory_sessions[$i]  ($inventory_hosts[$i])"
+          end
+
+          set -l picked_idx
+          if type -q fzf
+              set -l picked (printf '%s\n' $choices | fzf --prompt="session> " --height=40%)
+              if test -z "$picked"
+                  return 130
+              end
+              for i in (seq $n)
+                  if test "$choices[$i]" = "$picked"
+                      set picked_idx $i
+                      break
+                  end
+              end
+          else
+              for i in (seq $n)
+                  echo "$i) $choices[$i]"
+              end
+              read -P "Pick #: " idx
+              if not string match -qr '^[0-9]+$' -- $idx
+                  return 130
+              end
+              if test $idx -lt 1 -o $idx -gt $n
+                  return 130
+              end
+              set picked_idx $idx
+          end
+
+          set -l picked_session $inventory_sessions[$picked_idx]
+          set -l picked_host $inventory_hosts[$picked_idx]
+          if test "$picked_host" = "$current_host"
+              zellij attach -c $picked_session
+          else
+              ssh -t -o ConnectTimeout=2 $ssh_user@$picked_host -- zellij attach -c $picked_session
+          end
+          return $status
+        '';
+      };
+    };
+  };
+}
+```
+
+- [ ] **Step 2: Format**
+
+```bash
+nix fmt modules/apps/cli/work-launcher/default.nix
+```
+
+Expected: clean, possibly reformatted.
+
+- [ ] **Step 3: Lint**
+
+```bash
+statix check modules/apps/cli/work-launcher/default.nix
+deadnix --fail modules/apps/cli/work-launcher/default.nix
+```
+
+Expected: exit 0 on both.
+
+- [ ] **Step 4: Evaluate the module without building**
+
+Run:
+
+```bash
+nix eval --raw .#nixosConfigurations.donkeykong.config.system.build.toplevel.drvPath 2>&1 | tail -5
+```
+
+Expected: a `/nix/store/…drv` path (drv evaluation succeeds). If you get an evaluation error, fix and re-run. **Do not** `nix build` — that's the justfile's job.
+
+- [ ] **Step 5: Suggested commit**
+
+```
+feat(work-launcher): add `work` fish function
+
+Implements peer-aware session resolution:
+- `work <name>` attaches locally, falls back to a peer, creates locally
+  if nowhere
+- `work <name>@<host>` forces a target
+- `work --here <name>` forces local
+- No-arg invocation builds an across-peer picker (fzf if present,
+  numbered prompt otherwise)
+Uses SSH only — no mosh.
+```
+
+---
+
+### Task 3: Create the `claudeWorkHost` archetype
+
+**Files:**
+
+- Create: `modules/archetypes/claudeWorkHost/default.nix`
+
+- [ ] **Step 1: Create the archetype file**
+
+```nix
+{ lib, config, ... }:
+
+let
+  cfg = config.archetypes.claudeWorkHost;
+in
+{
+  options.archetypes.claudeWorkHost.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = ''
+      Enable the Claude work-host archetype: zellij (no web, no mosh),
+      claude-remote with always-on control tower, sshd, and the work
+      launcher. Sessions started on this host stay on this host and are
+      attachable from any peer via the `work` fish function or directly
+      via SSH + `zellij attach`.
+    '';
+  };
+
+  config = lib.mkIf cfg.enable {
+    apps.cli.zellij = {
+      enable = true;
+      hideStatusBar = true;
+      cheatsheet.enable = true;
+    };
+    apps.cli.claude-remote = {
+      enable = true;
+      controlTower.enable = true;
+    };
+    apps.cli.work-launcher.enable = true;
+    system.ssh.enable = true;
+  };
+}
+```
+
+- [ ] **Step 2: Format**
+
+```bash
+nix fmt modules/archetypes/claudeWorkHost/default.nix
+```
+
+- [ ] **Step 3: Lint**
+
+```bash
+statix check modules/archetypes/claudeWorkHost/default.nix
+deadnix --fail modules/archetypes/claudeWorkHost/default.nix
+```
+
+Expected: exit 0 on both.
+
+- [ ] **Step 4: Evaluation check**
+
+```bash
+nix eval --raw .#nixosConfigurations.qbert.config.system.build.toplevel.drvPath 2>&1 | tail -5
+```
+
+Expected: drv path. The option `archetypes.claudeWorkHost.enable` should now exist; no host has flipped it yet.
+
+- [ ] **Step 5: Suggested commit**
+
+```
+feat(archetypes): add claudeWorkHost archetype
+
+Bundles the "host runs Claude sessions you might want to attach to from
+elsewhere" role: zellij (no web, no mosh), claude-remote + controlTower,
+ssh, work-launcher. Enabled per host in subsequent commits.
+```
+
+---
+
+### Task 4: Rename control-tower service per-host + relocate linger
+
+Two coupled edits to `claude-remote/default.nix`: (1) include hostname in the systemd unit name and the `--name` argument passed to `claude remote-control`, so claude.ai/code's tower picker on iPhone shows distinct entries per host; (2) move `linger = true` here from the zellij module — linger is needed for the `--user` systemd unit to survive logout, and the claude-remote control tower is the unit that actually needs it.
+
+**Files:**
+
+- Modify: `modules/apps/cli/claude-remote/default.nix`
+
+- [ ] **Step 1: Add hostname to the systemd unit name and ExecStart**
+
+Open `modules/apps/cli/claude-remote/default.nix`. The current `controlTower.enable` branch defines `systemd.user.services.claude-control-tower` (line 123) and `ExecStart = "${pkgs.llm-agents.claude-code}/bin/claude remote-control --name claude-control-tower --permission-mode bypassPermissions";` (line 133).
+
+Replace those two references. The replacement uses `config.networking.hostName`:
+
+```nix
+        systemd.user.services."claude-control-tower-${config.networking.hostName}" = {
+          Unit = {
+            Description = "Claude Code control tower (always-on remote-control server)";
+            After = [ "graphical-session.target" ];
+          };
+          Service = {
+            Type = "simple";
+            WorkingDirectory = towerDir;
+            ExecStart = "${pkgs.llm-agents.claude-code}/bin/claude remote-control --name claude-control-tower-${config.networking.hostName} --permission-mode bypassPermissions";
+            UnsetEnvironment = "CLAUDE_CODE_REMOTE CLAUDE_CODE_REMOTE_SESSION_ID CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_CONTAINER_ID CLAUDECODE";
+            Restart = "always";
+            RestartSec = 5;
+            StandardInput = "null";
+            StandardOutput = "journal";
+            StandardError = "journal";
+          };
+          Install = {
+            WantedBy = [ "default.target" ];
+          };
+        };
+```
+
+- [ ] **Step 2: Add linger inside the controlTower branch**
+
+Inside the same `lib.mkIf cfg.controlTower.enable` block, **above** `home-manager.users.${globals.user.name}`, add:
+
+```nix
+      users.users.${globals.user.name}.linger = true;
+```
+
+So the block opens like this:
+
+```nix
+    (lib.mkIf cfg.controlTower.enable {
+      assertions = [
+        {
+          assertion = cfg.enable;
+          message = "apps.cli.claude-remote.controlTower.enable requires apps.cli.claude-remote.enable = true.";
+        }
+      ];
+
+      users.users.${globals.user.name}.linger = true;
+
+      home-manager.users.${globals.user.name} = {
+        # … existing body …
+      };
+    })
+```
+
+- [ ] **Step 3: Format**
+
+```bash
+nix fmt modules/apps/cli/claude-remote/default.nix
+```
+
+- [ ] **Step 4: Lint**
+
+```bash
+statix check modules/apps/cli/claude-remote/default.nix
+deadnix --fail modules/apps/cli/claude-remote/default.nix
+```
+
+Expected: exit 0 on both.
+
+- [ ] **Step 5: Evaluation check**
+
+```bash
+nix eval --raw .#nixosConfigurations.qbert.config.system.build.toplevel.drvPath 2>&1 | tail -5
+```
+
+Expected: drv path (no evaluation errors). On hosts where controlTower is still disabled, this branch is dead and the diff is a no-op.
+
+- [ ] **Step 6: Suggested commit**
+
+```
+refactor(claude-remote): hostname-scoped tower service + own linger
+
+Rename the systemd user service from `claude-control-tower` to
+`claude-control-tower-${hostname}` and pass the same value via --name so
+claude.ai/code's tower picker shows distinct entries when multiple work
+hosts are online. Move `linger = true` here from the zellij service.enable
+branch — the user systemd unit that needs linger is the control tower,
+not zellij-web.
+```
+
+---
+
+### Task 5: Remove linger from the zellij `service.enable` branch
+
+Counterpart to Task 4. Today the zellij module sets `users.users.<user>.linger = true;` inside `lib.mkIf cfg.service.enable`. That ownership is wrong; remove it. The line lives at `modules/apps/cli/zellij/default.nix:172-173`.
+
+**Files:**
+
+- Modify: `modules/apps/cli/zellij/default.nix`
+
+- [ ] **Step 1: Locate and delete the linger lines**
+
+Open `modules/apps/cli/zellij/default.nix`. Inside the `lib.mkIf cfg.service.enable` branch, find:
+
+```nix
+        # Required so the user's systemd manager (and therefore the
+        # zellij-web user service) starts at boot on headless hosts.
+        # Without linger, systemd --user only spawns when the user
+        # actively logs in, defeating the "browser-accessible without
+        # SSH" promise of the web client.
+        users.users.${globals.user.name}.linger = true;
+```
+
+Delete both the comment block and the `users.users.…linger` line. Leave the rest of the `service.enable` body untouched.
+
+- [ ] **Step 2: Format**
+
+```bash
+nix fmt modules/apps/cli/zellij/default.nix
+```
+
+- [ ] **Step 3: Lint**
+
+```bash
+statix check modules/apps/cli/zellij/default.nix
+deadnix --fail modules/apps/cli/zellij/default.nix
+```
+
+Expected: exit 0. If `deadnix` flags `globals` as unused inside that branch (because the only consumer was the linger line), check whether `globals` is still referenced elsewhere in the file before deleting any import. Likely it is — the home-manager users block references `globals.user.name` elsewhere.
+
+- [ ] **Step 4: Evaluation check**
+
+```bash
+nix eval --raw .#nixosConfigurations.srv.config.system.build.toplevel.drvPath 2>&1 | tail -5
+```
+
+Expected: drv path. On srv, where `service.enable = true` is still set today, the diff removes one attribute from the system config — which is fine because we're about to retire `service.enable` on srv in Task 7.
+
+- [ ] **Step 5: Suggested commit**
+
+```
+refactor(zellij): drop linger from service.enable branch
+
+linger ownership moves to claude-remote.controlTower.enable (see prior
+commit). Keeping it here would mean: (a) double-declaration when both
+toggles are on, and (b) silent breakage if a future host enabled only
+controlTower with no zellij-web.
+```
+
+---
+
+### Task 6: Drop mosh from the terminal suite
+
+`modules/suites/terminal/default.nix:32` sets `apps.cli.zellij.mosh.enable = true;`, which affects every workstation (`donkeykong`, `qbert`). With SSH-only iPhone access, mosh is dead weight. Removing the line closes the UDP 60000–61000 firewall range on those hosts.
+
+Per `modules/suites/CLAUDE.md`: "Changes to a suite affect ALL hosts whose archetype enables it — check `archetypes/` to understand blast radius before modifying." Blast radius: all workstations (`archetypes.workstation` → `suites.terminal.enable = true`).
+
+**Files:**
+
+- Modify: `modules/suites/terminal/default.nix`
+
+- [ ] **Step 1: Remove the `mosh.enable` line**
+
+In the file, find the zellij block:
+
+```nix
+      zellij = {
+        enable = true;
+        mosh.enable = true;
+        hideStatusBar = true;
+        cheatsheet.enable = true;
+      };
+```
+
+Remove the `mosh.enable = true;` line. The block becomes:
+
+```nix
+      zellij = {
+        enable = true;
+        hideStatusBar = true;
+        cheatsheet.enable = true;
+      };
+```
+
+- [ ] **Step 2: Format**
+
+```bash
+nix fmt modules/suites/terminal/default.nix
+```
+
+- [ ] **Step 3: Lint**
+
+```bash
+statix check modules/suites/terminal/default.nix
+deadnix --fail modules/suites/terminal/default.nix
+```
+
+Expected: exit 0 on both.
+
+- [ ] **Step 4: Evaluation check on a workstation**
+
+```bash
+nix eval --raw .#nixosConfigurations.qbert.config.system.build.toplevel.drvPath 2>&1 | tail -5
+nix eval --raw .#nixosConfigurations.donkeykong.config.system.build.toplevel.drvPath 2>&1 | tail -5
+```
+
+Expected: both produce drv paths. The diff at activation time will remove `pkgs.mosh` from `environment.systemPackages` and close UDP 60000–61000 on workstations.
+
+- [ ] **Step 5: Suggested commit**
+
+```
+refactor(terminal): drop mosh from the terminal suite
+
+The cross-device workflow is SSH-only. mosh is no longer used on
+workstations; removing it closes UDP 60000-61000 on the firewall and
+shrinks the closure by one package. The mosh.enable option in the
+zellij module stays as an inert opt-in for any future host that wants
+it back.
+```
+
+---
+
+### Task 7: Enable archetype on srv (and retire zellij-web + mosh + direct enables)
+
+srv manually imports modules in `hosts/srv/modules.nix` (per `hosts/CLAUDE.md`). Adding the archetype requires both the imports list update AND the enable flag. The existing explicit `apps.cli.zellij = { … }` block goes away — the archetype now owns that surface.
+
+**Files:**
+
+- Modify: `hosts/srv/modules.nix`
+
+- [ ] **Step 1: Update the imports list**
+
+Open `hosts/srv/modules.nix`. Find the explicit imports list — `../../modules/apps/cli/zellij` is at line 24 (per earlier grep). Add two new lines for the archetype and the work-launcher:
+
+```nix
+    ../../modules/archetypes/claudeWorkHost
+    ../../modules/apps/cli/zellij
+    ../../modules/apps/cli/work-launcher
+    ../../modules/apps/cli/claude-remote
+```
+
+`claude-remote` may or may not already be in the imports list — if absent, add it (the archetype turns it on, so the module must be present). Keep the rest of the imports untouched.
+
+- [ ] **Step 2: Replace the explicit zellij block with the archetype enable**
+
+In the same file, find the explicit `apps.cli.zellij = { … };` block (lines ~78–94: `enable = true;`, `service.enable = true;`, `tsnetNode = "zellij";`, `mosh.enable = true;`, `hideStatusBar = true;`, `cheatsheet.enable = true;`).
+
+Replace the whole block with:
+
+```nix
+    archetypes.claudeWorkHost.enable = true;
+```
+
+(The archetype handles `enable`, `hideStatusBar`, `cheatsheet.enable`. `service.enable`, `tsnetNode`, `mosh.enable` are intentionally retired on srv.)
+
+- [ ] **Step 3: Format**
+
+```bash
+nix fmt hosts/srv/modules.nix
+```
+
+- [ ] **Step 4: Lint**
+
+```bash
+statix check hosts/srv/modules.nix
+deadnix --fail hosts/srv/modules.nix
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Evaluation check**
+
+```bash
+nix eval --raw .#nixosConfigurations.srv.config.system.build.toplevel.drvPath 2>&1 | tail -5
+```
+
+Expected: drv path. If `system.caddy.enable` was previously implied only by the zellij service.enable branch, srv's caddy config may now be unused — that's expected; `system.caddy.enable` will simply not be set by this change, and other srv vhosts (if any) still drive it. If srv had **only** the zellij vhost on Caddy and you want to drop Caddy entirely, that's a follow-up out of scope for this plan.
+
+- [ ] **Step 6: Suggested commit**
+
+```
+feat(srv): adopt claudeWorkHost archetype, retire zellij-web + mosh
+
+srv now enables apps.cli.zellij (no web, no mosh), apps.cli.claude-remote
+with controlTower, system.ssh, and apps.cli.work-launcher via the new
+archetype. The explicit per-option block is removed; the tsnet vhost is
+intentionally dropped (iPhone moves to SSH-only via Termius/Blink).
+```
+
+---
+
+### Task 8: Enable archetype on qbert
+
+Workstations auto-import modules; no `imports = …` change needed. qbert is the second work-host peer; flipping the archetype turns on the control tower (and gives the host a `claude-control-tower-qbert` systemd unit).
+
+**Files:**
+
+- Modify: `hosts/qbert/modules.nix`
+
+- [ ] **Step 1: Add the archetype enable**
+
+Open `hosts/qbert/modules.nix`. Add to the top-level attribute set (anywhere is fine, but conventionally near other archetype/suite enables — qbert doesn't currently set any archetype directly in this file; the workstation archetype is set in `hosts/qbert/configuration.nix`):
+
+```nix
+  archetypes.claudeWorkHost.enable = true;
+```
+
+- [ ] **Step 2: Format**
+
+```bash
+nix fmt hosts/qbert/modules.nix
+```
+
+- [ ] **Step 3: Lint**
+
+```bash
+statix check hosts/qbert/modules.nix
+deadnix --fail hosts/qbert/modules.nix
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Evaluation check**
+
+```bash
+nix eval --raw .#nixosConfigurations.qbert.config.system.build.toplevel.drvPath 2>&1 | tail -5
+```
+
+Expected: drv path. The diff at activation will add: the claude-control-tower-qbert systemd user service, linger on the user, sshd if not already enabled by the workstation archetype, and the `work` fish function.
+
+- [ ] **Step 5: Suggested commit**
+
+```
+feat(qbert): adopt claudeWorkHost archetype
+
+Symmetric peer to srv. Adds claude-control-tower-qbert systemd user
+service, work-launcher fish function, sshd, linger. Workstation
+archetype was already providing zellij via the terminal suite; the
+archetype now also explicitly enables zellij with the same defaults
+(idempotent in nix).
+```
+
+---
+
+### Task 9: Install `work-launcher` on donkeykong (attach-only)
+
+donkeykong does not run a control tower or expose its sessions to peers in v1. It just gets the fish function so the user can attach back to srv/qbert from a donkeykong shell.
+
+**Files:**
+
+- Modify: `hosts/donkeykong/modules.nix`
+
+- [ ] **Step 1: Add the work-launcher enable**
+
+Open `hosts/donkeykong/modules.nix`. Add to the top-level attribute set:
+
+```nix
+  apps.cli.work-launcher.enable = true;
+```
+
+- [ ] **Step 2: Format**
+
+```bash
+nix fmt hosts/donkeykong/modules.nix
+```
+
+- [ ] **Step 3: Lint**
+
+```bash
+statix check hosts/donkeykong/modules.nix
+deadnix --fail hosts/donkeykong/modules.nix
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Evaluation check**
+
+```bash
+nix eval --raw .#nixosConfigurations.donkeykong.config.system.build.toplevel.drvPath 2>&1 | tail -5
+```
+
+Expected: drv path. Activation will add the `work` fish function only (no control tower, no archetype side effects).
+
+- [ ] **Step 5: Suggested commit**
+
+```
+feat(donkeykong): install work-launcher (attach-only)
+
+Adds the `work` fish function on donkeykong so the user can attach to
+sessions on srv or qbert from a donkeykong shell. donkeykong does not
+run a control tower in v1; promoting it to a work-host peer is a
+one-flag change later.
+```
+
+---
+
+### Task 10: Rebuild donkeykong and smoke-test the function
+
+donkeykong has the lowest blast radius — fish-function-only — so rebuild it first to catch any module evaluation or fish-syntax mistake before touching the work hosts.
+
+**Files:** (no source changes, this is a verification task)
+
+- [ ] **Step 1: User runs the rebuild**
+
+Tell the user:
+
+> Run `just qr` on donkeykong. The output is captured to `/tmp/nixerator-rebuild.log`. If it fails, spawn the `nix` subagent on the log per the project convention (`.claude/docs/conventions.md`) — do **not** read the log inline.
+
+Expected: rebuild completes; `Restart` count on user systemd services may bump if any restarted.
+
+- [ ] **Step 2: User verifies the function loads**
+
+In a fresh fish shell on donkeykong:
+
+```fish
+type -a work
+```
+
+Expected: prints `work is a function with definition` followed by the body.
+
+- [ ] **Step 3: User runs `work --help`**
+
+```fish
+work --help
+```
+
+Expected: usage block — four lines starting with `Usage: work [--here]…`.
+
+- [ ] **Step 4: No commit**
+
+Verification only.
+
+---
+
+### Task 11: Rebuild qbert and verify the control tower
+
+qbert is next. After `just qr`, the new systemd user service `claude-control-tower-qbert.service` should be active.
+
+**Files:** (verification only)
+
+- [ ] **Step 1: User runs the rebuild**
+
+> Run `just qr` on qbert. On failure, spawn the nix subagent on `/tmp/nixerator-rebuild.log`.
+
+Expected: rebuild succeeds.
+
+- [ ] **Step 2: User verifies linger**
+
+On qbert:
+
+```bash
+loginctl show-user $USER -p Linger
+```
+
+Expected: `Linger=yes`.
+
+- [ ] **Step 3: User verifies the control tower service is running**
+
+```bash
+systemctl --user status claude-control-tower-qbert.service
+```
+
+Expected: `Active: active (running)`. If failed, check logs with `journalctl --user -u claude-control-tower-qbert.service -n 50` and surface to the user.
+
+- [ ] **Step 4: User verifies the work function**
+
+```fish
+type -a work
+work --help
+```
+
+Expected: function loaded; help block prints.
+
+- [ ] **Step 5: No commit**
+
+Verification only.
+
+---
+
+### Task 12: Rebuild srv and verify the retirement + control tower
+
+srv is last because it has the most surface change (zellij-web retiring, mosh retiring, archetype enabling).
+
+**Files:** (verification only)
+
+- [ ] **Step 1: User runs the rebuild**
+
+> Run `just qr` on srv. On failure, spawn the nix subagent on `/tmp/nixerator-rebuild.log`.
+
+Expected: rebuild succeeds.
+
+- [ ] **Step 2: User verifies zellij-web is gone**
+
+```bash
+systemctl --user status zellij-web.service 2>&1 | head -3
+```
+
+Expected: `Unit zellij-web.service could not be found.` (or, if it was running pre-rebuild, "inactive" after rebuild — followed by removal on the next user-session restart).
+
+- [ ] **Step 3: User verifies the new tower service**
+
+```bash
+systemctl --user status claude-control-tower-srv.service
+```
+
+Expected: `Active: active (running)`.
+
+- [ ] **Step 4: User verifies linger**
+
+```bash
+loginctl show-user $USER -p Linger
+```
+
+Expected: `Linger=yes`. (Already was, but now owned by claude-remote.)
+
+- [ ] **Step 5: User verifies the firewall closed UDP 60000–61000**
+
+```bash
+sudo nft list ruleset | grep -E "60000|udp port" | head
+```
+
+Expected: no rules accepting UDP 60000–61000. (Mosh range is closed.)
+
+- [ ] **Step 6: No commit**
+
+Verification only.
+
+---
+
+### Task 13: Cross-host smoke test of the `work` function
+
+End-to-end validation across the three hosts. Performed by the user on whichever host they prefer; the commands below assume starting from donkeykong but the matrix is host-symmetric.
+
+**Files:** (verification only)
+
+- [ ] **Step 1: Start a session on srv from donkeykong**
+
+```fish
+ssh srv -- zellij attach -c smoketest-srv -- echo hi
+```
+
+Wait for the session to spawn (zellij creates a session named `smoketest-srv` on srv). Detach via the zellij keybind or just close the SSH connection — zellij keeps the session.
+
+- [ ] **Step 2: Start a session on qbert from donkeykong**
+
+```fish
+ssh qbert -- zellij attach -c smoketest-qbert -- echo hi
+```
+
+Same flow as above for qbert.
+
+- [ ] **Step 3: From donkeykong, list sessions across peers**
+
+```fish
+work
+```
+
+Expected: picker (fzf if installed, numbered prompt otherwise) listing two entries:
+
+```
+smoketest-srv    (srv)
+smoketest-qbert  (qbert)
+```
+
+Pick one. The function should `ssh -t … zellij attach -c …` and drop you into the session. Detach with `Ctrl-q d`.
+
+- [ ] **Step 4: From donkeykong, target by name**
+
+```fish
+work smoketest-qbert
+```
+
+Expected: attaches directly without picker (peer match found, host-qualified `ssh -t` invocation).
+
+- [ ] **Step 5: From donkeykong, target by `<name>@<host>`**
+
+```fish
+work smoketest-srv@srv
+```
+
+Expected: attaches directly.
+
+- [ ] **Step 6: From donkeykong, create a brand-new session by name**
+
+```fish
+work scratch
+```
+
+Expected: no match locally, no match on peers → "creating on donkeykong" message → fresh local zellij session named `scratch`. Detach.
+
+- [ ] **Step 7: Repeat the matrix from qbert**
+
+ssh into qbert (or sit at it) and run `work`. Confirm the picker shows `smoketest-srv (srv)`, `scratch (donkeykong)` — wait, donkeykong is not a configured peer, so it does NOT appear. Confirm only srv-side sessions show up.
+
+Expected outcome: peer scope = `[srv qbert]`. donkeykong sessions are NOT discovered from peers. This is by design (v1 attach-only role).
+
+- [ ] **Step 8: Cleanup**
+
+On srv: `zellij delete-session smoketest-srv`.
+On qbert: `zellij delete-session smoketest-qbert`.
+On donkeykong: `zellij delete-session scratch`.
+
+- [ ] **Step 9: iPhone validation (manual)**
+
+User checks:
+- Termius/Blink → SSH to `srv` and `qbert` via Tailscale magicDNS. Run `work` once inside each — picker should populate immediately.
+- claude.ai/code → "Add new endpoint" / browse remote controls. Confirm two entries appear: `claude-control-tower-srv` and `claude-control-tower-qbert`. Spawn a new session on each to confirm both work.
+
+- [ ] **Step 10: No commit**
+
+Verification only.
+
+---
+
+### Task 14: Document the workflow in `.claude/docs/`
+
+Add a topic file so future Claude sessions can discover the workflow when the user asks about cross-device pickup or about the `work` function.
+
+**Files:**
+
+- Create: `.claude/docs/cross-device-workflow.md`
+- Modify: `CLAUDE.md` (add Topics entry)
+
+- [ ] **Step 1: Create the topic file**
+
+```markdown
+# Cross-device Claude workflow
+
+Two peer work hosts: `srv` (always-on) and `qbert` (workstation, occasional). Both run `claude-control-tower-${hostname}` and zellij; both are reachable over SSH on the tailnet. Sessions live on the host where they were started; no cross-host state sync.
+
+## Verbs
+
+- `work` — across-peer session picker (fzf or numbered prompt).
+- `work <name>` — attach locally, fall back to a peer, create locally if nowhere.
+- `work <name>@<host>` — force a host.
+- `work --here <name>` — force the current host even if a peer has the name.
+
+## iPhone
+
+- **Resume:** Termius / Blink / Prompt over Tailscale → `ssh srv` (or `qbert`) → `work`. SSH only — no mosh, no zellij-web.
+- **Spawn:** claude.ai/code → pick `claude-control-tower-srv` or `claude-control-tower-qbert` → start a new session in a repo.
+
+## /github-issue
+
+Auto-renames the zellij session to `<repo>#<N>` when invoked inside zellij. An issue kicked off from the iPhone is then discoverable from any other device via `work <repo>#<N>`.
+
+## Components
+
+- `archetypes.claudeWorkHost` (enabled on srv + qbert) — bundles zellij + claude-remote + control tower + ssh + work-launcher.
+- `apps.cli.work-launcher` (enabled everywhere) — ships the `work` fish function. `peers` defaults to `[srv qbert]`.
+- `apps.cli.claude-remote` — the systemd `--user` control tower (per-host name).
+
+## What is NOT here
+
+- No mosh. No zellij-web. No syncthing of `~/.claude` or worktrees. No cross-host worktree sync. Branches move via `git push`/`git pull` only.
+```
+
+- [ ] **Step 2: Add the Topics entry**
+
+Open `CLAUDE.md` (project root). In the `## Topics` section, add:
+
+```markdown
+- When the user asks about cross-device session pickup, the `work` fish function, the `claudeWorkHost` archetype, or how to attach to a session from the iPhone, read `.claude/docs/cross-device-workflow.md`.
+```
+
+- [ ] **Step 3: No format/lint**
+
+Markdown only.
+
+- [ ] **Step 4: Suggested commit**
+
+```
+docs: add cross-device workflow topic file
+
+Indexed in CLAUDE.md so future Claude sessions can discover the workflow
+(work function, claudeWorkHost archetype, iPhone flows, /github-issue
+session renaming) when the user references it.
+```
+
+---
+
+### Task 15: Spec ↔ plan reconciliation
+
+Final spec-coverage pass — the open questions section of the design lists three items; this task closes them.
+
+- [ ] **Step 1: Verify zellij-enable is idempotent on workstations**
+
+The workstation archetype enables `terminal.enable`, which enables `apps.cli.zellij`. The new `claudeWorkHost` archetype on qbert also enables `apps.cli.zellij`. Both set the same attribute to `true` with the same sub-options — nix merges identical attribute values without conflict. No action needed; just confirm no `error: The option … has conflicting definition values` appears during qbert eval (Task 8).
+
+- [ ] **Step 2: Decide on `peers` default**
+
+The default `[ "srv" "qbert" ]` is intentionally a user-specific list. Leave as-is; if a second operator ever inherits this flake, they will set their own `peers` in host configs.
+
+- [ ] **Step 3: Schedule the `/github-issue` skill patch**
+
+Out of this repo. Open a separate `~/.claude/skills/github-issue/` change that adds, after worktree creation:
+
+```bash
+if [ -n "${ZELLIJ:-}" ]; then
+  zellij action rename-session "${repo_basename}#${issue_number}" || true
+fi
+```
+
+Track separately; not blocking this PR.
+
+- [ ] **Step 4: No commit (planning only)**
+
+---
+
+## Self-review checklist
+
+Run mentally before marking the plan complete:
+
+- [x] Every "Modify" step names a concrete file + change.
+- [x] Every "Create" step contains the full file body.
+- [x] Every code block is complete (no `…` ellipses inside code that needs to be typed verbatim).
+- [x] No "TBD", "TODO", "implement later" markers.
+- [x] No `git commit` or `git push` commands appear in any step (per project convention).
+- [x] Rebuild order is donkeykong → qbert → srv (smallest blast radius first).
+- [x] iPhone validation is in Task 13 step 9, end-to-end through both SSH and claude.ai/code.
+- [x] Both halves of the linger relocation are present (Task 4 adds, Task 5 removes).
+- [x] Both halves of the control-tower rename are present (service name + `--name` flag in Task 4).
+- [x] Mosh retirement covers both the suite (Task 6) and srv's explicit enable (Task 7).

--- a/flake.lock
+++ b/flake.lock
@@ -1283,16 +1283,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1778519086,
-        "narHash": "sha256-NHMZYbKRDEowRaAnAAaaF2mwa1wfRZJP/1D/MtV8R7M=",
+        "lastModified": 1778527620,
+        "narHash": "sha256-y8Z1sefV3C9StUySjc6ssBhNKPs9Ww7Q/GcePD8ge2s=",
         "owner": "bashfulrobot",
         "repo": "upsight",
-        "rev": "3b6760b347d959069d21207edd6d23e949acaeb9",
+        "rev": "e8433b90268f0360a01697f27031bafa453c3494",
         "type": "github"
       },
       "original": {
         "owner": "bashfulrobot",
-        "ref": "v0.20.0",
+        "ref": "v0.21.0",
         "repo": "upsight",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
     # };
 
     upsight = {
-      url = "github:bashfulrobot/upsight/v0.20.0";
+      url = "github:bashfulrobot/upsight/v0.21.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/hosts/donkeykong/modules.nix
+++ b/hosts/donkeykong/modules.nix
@@ -1,6 +1,13 @@
 { secrets, ... }:
 
 {
+  # Attach-only: install the `work` fish function so donkeykong can attach
+  # to zellij sessions on srv or qbert. Does NOT run a control tower or
+  # expose sessions to peers in v1 — donkeykong is a workstation, not a
+  # work-host peer. Promotable later by flipping the claudeWorkHost
+  # archetype here.
+  apps.cli.work-launcher.enable = true;
+
   # Apps
   apps.webapps.scratch.enable = true;
 

--- a/hosts/qbert/modules.nix
+++ b/hosts/qbert/modules.nix
@@ -1,6 +1,12 @@
 { secrets, ... }:
 
 {
+  # Adopt the Claude work-host archetype (symmetric peer to srv): zellij
+  # (no web, no mosh), claude-remote with always-on control tower, sshd,
+  # and the work launcher. Sessions live on qbert until killed; attach
+  # from anywhere on the tailnet via `work` or `ssh qbert zellij attach`.
+  archetypes.claudeWorkHost.enable = true;
+
   # Apps
   apps.cli.restic.backup = {
     enable = true;

--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -7,6 +7,7 @@
     ../../modules/apps/cli/agent-scan
     ../../modules/apps/cli/agentos
     ../../modules/apps/cli/claude-code
+    ../../modules/apps/cli/claude-remote
     ../../modules/apps/cli/docker
     ../../modules/apps/cli/fish
     ../../modules/apps/cli/gcmt
@@ -21,12 +22,20 @@
     ../../modules/apps/cli/superpowers
     ../../modules/apps/cli/tailscale
     ../../modules/apps/cli/vscode-server
+    ../../modules/apps/cli/work-launcher
     ../../modules/apps/cli/zellij
+    ../../modules/archetypes/claudeWorkHost
     ../../modules/server/kvm
     ../../modules/server/nfs
     ../../modules/system/caddy
     ../../modules/system/ssh
   ];
+
+  # Adopts the Claude work-host archetype: zellij (no web, no mosh),
+  # claude-remote with always-on control tower, sshd, work-launcher.
+  # Sessions live on srv until killed; attach from anywhere on the
+  # tailnet via `work` or `ssh srv zellij attach`.
+  archetypes.claudeWorkHost.enable = true;
 
   # CLI applications (matching nixcfg srv)
   apps.cli = {
@@ -73,25 +82,6 @@
     plannotator.enable = true;
     skillfish.enable = true;
     superpowers.enable = true;
-
-    # Zellij with web client behind Caddy tsnet
-    zellij = {
-      enable = true;
-      service.enable = true;
-      tsnetNode = "zellij";
-
-      # Persistent-session stack: pair zellij (session survives
-      # disconnect) with mosh (transport survives roaming) for a
-      # headless remote-dev box that feels local.
-      mosh.enable = true;
-
-      # Reclaim the bottom rows from the always-on shortcut strip.
-      hideStatusBar = true;
-
-      # Pop a markdown cheat sheet in a floating pane on demand.
-      # `Alt /` keeps a finger near the home row.
-      cheatsheet.enable = true;
-    };
   };
 
   # System modules

--- a/modules/apps/cli/claude-remote/default.nix
+++ b/modules/apps/cli/claude-remote/default.nix
@@ -96,6 +96,8 @@ in
         }
       ];
 
+      users.users.${globals.user.name}.linger = true;
+
       home-manager.users.${globals.user.name} = {
         xdg.dataFile = {
           "claude-control-tower/CLAUDE.md".source = ./cfg/control-tower-CLAUDE.md;
@@ -120,7 +122,7 @@ in
               fi
             '';
 
-        systemd.user.services.claude-control-tower = {
+        systemd.user.services."claude-control-tower-${config.networking.hostName}" = {
           Unit = {
             Description = "Claude Code control tower (always-on remote-control server)";
             After = [ "graphical-session.target" ];
@@ -130,7 +132,7 @@ in
             WorkingDirectory = towerDir;
             # `claude remote-control` is a proper daemon -- no PTY required,
             # accepts a closed stdin, and stays running until killed.
-            ExecStart = "${pkgs.llm-agents.claude-code}/bin/claude remote-control --name claude-control-tower --permission-mode bypassPermissions";
+            ExecStart = "${pkgs.llm-agents.claude-code}/bin/claude remote-control --name claude-control-tower-${config.networking.hostName} --permission-mode bypassPermissions";
             UnsetEnvironment = "CLAUDE_CODE_REMOTE CLAUDE_CODE_REMOTE_SESSION_ID CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_CONTAINER_ID CLAUDECODE";
             Restart = "always";
             RestartSec = 5;

--- a/modules/apps/cli/work-launcher/default.nix
+++ b/modules/apps/cli/work-launcher/default.nix
@@ -101,6 +101,18 @@ in
               return 2
           end
 
+          # Up-front character-class validation of the user-supplied token.
+          # `$name` (and `$target` once we split below) flow into
+          # `ssh ... -- zellij attach -c $name`, which the remote shell
+          # re-parses. Refuse metacharacters before they cross SSH. `@` is
+          # allowed at the pre-split stage because it's our own host separator.
+          if test -n "$name"
+              if not string match -qr '^[A-Za-z0-9._#@-]+$' -- $name
+                  echo "work: name must match [A-Za-z0-9._#@-]+ (got: '$name')" >&2
+                  return 2
+              end
+          end
+
           # Explicit <name>@<host> form short-circuits discovery.
           if string match -q '*@*' -- $name
               set -l parts (string split -m1 '@' -- $name)
@@ -108,6 +120,16 @@ in
               set -l target $parts[2]
               if test -z "$name" -o -z "$target"
                   echo "work: malformed <name>@<host> ('$argv[-1]')" >&2
+                  return 2
+              end
+              # Post-split validation — bare name no longer carries `@`,
+              # target is a hostname.
+              if not string match -qr '^[A-Za-z0-9._#-]+$' -- $name
+                  echo "work: name must match [A-Za-z0-9._#-]+ (got: '$name')" >&2
+                  return 2
+              end
+              if not string match -qr '^[A-Za-z0-9._-]+$' -- $target
+                  echo "work: target must match [A-Za-z0-9._-]+ (got: '$target')" >&2
                   return 2
               end
               if not contains -- $target $peers
@@ -221,6 +243,13 @@ in
 
           set -l picked_session $inventory_sessions[$picked_idx]
           set -l picked_host $inventory_hosts[$picked_idx]
+          # Validate the peer-sourced session name — it flows into the same
+          # ssh remote-command interpolation as the user-supplied $name, so
+          # apply the same char-class refusal.
+          if not string match -qr '^[A-Za-z0-9._#-]+$' -- $picked_session
+              echo "work: peer returned a session name with disallowed characters: '$picked_session'" >&2
+              return 2
+          end
           if test "$picked_host" = "$current_host"
               zellij attach -c $picked_session
           else

--- a/modules/apps/cli/work-launcher/default.nix
+++ b/modules/apps/cli/work-launcher/default.nix
@@ -44,6 +44,16 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # The work function lives on fish; if fish isn't enabled the option
+    # silently writes into a programs.fish block that won't be activated,
+    # so surface that misconfiguration at eval time.
+    assertions = [
+      {
+        assertion = config.apps.cli.fish.enable;
+        message = "apps.cli.work-launcher.enable requires apps.cli.fish.enable = true.";
+      }
+    ];
+
     home-manager.users.${globals.user.name} = {
       programs.fish.functions.work = {
         description = "Attach to (or create) a zellij session across peer hosts";
@@ -51,11 +61,15 @@ in
           # Build-time configuration injected by the work-launcher module.
           set -l peers ${peersFishList}
           set -l ssh_user ${cfg.sshUser}
-          set -l current_host (hostname)
+          # `hostname -s` to match the short form peers are configured as,
+          # even if /etc/hosts or networking.fqdn cause bare `hostname` to
+          # return an FQDN.
+          set -l current_host (hostname -s)
 
           # --- arg parsing ---
           set -l force_local 0
           set -l name ""
+          set -l positional_seen 0
           for arg in $argv
               switch $arg
                   case '--here'
@@ -68,8 +82,16 @@ in
                       echo "  work <name>@<host>    attach to <name> on specific <host>"
                       echo "  work --here <name>    force current host"
                       return 0
+                  case '--*' '-*'
+                      echo "work: unknown option '$arg' (try --help)" >&2
+                      return 2
                   case '*'
+                      if test $positional_seen -eq 1
+                          echo "work: expected at most one <name>; got extra '$arg'" >&2
+                          return 2
+                      end
                       set name $arg
+                      set positional_seen 1
               end
           end
 
@@ -84,6 +106,13 @@ in
               set -l parts (string split -m1 '@' -- $name)
               set name $parts[1]
               set -l target $parts[2]
+              if test -z "$name" -o -z "$target"
+                  echo "work: malformed <name>@<host> ('$argv[-1]')" >&2
+                  return 2
+              end
+              if not contains -- $target $peers
+                  echo "work: target '$target' is not in configured peers ($peers) — going off-list" >&2
+              end
               if test "$target" = "$current_host"
                   zellij attach -c $name
                   return $status

--- a/modules/apps/cli/work-launcher/default.nix
+++ b/modules/apps/cli/work-launcher/default.nix
@@ -1,0 +1,205 @@
+{
+  lib,
+  config,
+  globals,
+  ...
+}:
+
+let
+  cfg = config.apps.cli.work-launcher;
+
+  # Render peers as a space-separated, double-quoted fish list literal so
+  # the function body can do `set -l peers $peersList` without further
+  # parsing. Hostnames don't contain spaces, but quoting is cheap insurance.
+  peersFishList = lib.concatMapStringsSep " " (p: ''"${p}"'') cfg.peers;
+in
+{
+  options.apps.cli.work-launcher = {
+    enable = lib.mkEnableOption "work fish function for cross-host zellij session attach";
+
+    peers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "srv"
+        "qbert"
+      ];
+      description = ''
+        Hostnames the `work` fish function probes for zellij sessions
+        when resolving an unqualified `work <name>` invocation, and when
+        building the no-argument picker. The current host (matched at
+        runtime via the `hostname` command) is automatically skipped on
+        the SSH leg — local sessions are listed via `zellij list-sessions`
+        directly.
+      '';
+    };
+
+    sshUser = lib.mkOption {
+      type = lib.types.str;
+      default = globals.user.name;
+      description = ''
+        SSH user the launcher connects to peers as. Defaults to
+        globals.user.name (single-user hosts under this flake).
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home-manager.users.${globals.user.name} = {
+      programs.fish.functions.work = {
+        description = "Attach to (or create) a zellij session across peer hosts";
+        body = ''
+          # Build-time configuration injected by the work-launcher module.
+          set -l peers ${peersFishList}
+          set -l ssh_user ${cfg.sshUser}
+          set -l current_host (hostname)
+
+          # --- arg parsing ---
+          set -l force_local 0
+          set -l name ""
+          for arg in $argv
+              switch $arg
+                  case '--here'
+                      set force_local 1
+                  case '-h' '--help'
+                      echo "Usage: work [--here] [<name>[@<host>]]"
+                      echo ""
+                      echo "  work                  pick a session across peers, attach"
+                      echo "  work <name>           attach to <name>; create on current host if not found"
+                      echo "  work <name>@<host>    attach to <name> on specific <host>"
+                      echo "  work --here <name>    force current host"
+                      return 0
+                  case '*'
+                      set name $arg
+              end
+          end
+
+          # Refuse to nest zellij.
+          if set -q ZELLIJ
+              echo "work: already inside a zellij session. Detach first (Ctrl-q q)." >&2
+              return 2
+          end
+
+          # Explicit <name>@<host> form short-circuits discovery.
+          if string match -q '*@*' -- $name
+              set -l parts (string split -m1 '@' -- $name)
+              set name $parts[1]
+              set -l target $parts[2]
+              if test "$target" = "$current_host"
+                  zellij attach -c $name
+                  return $status
+              end
+              ssh -t -o ConnectTimeout=2 $ssh_user@$target -- zellij attach -c $name
+              return $status
+          end
+
+          # --here forces local even if a peer has the name.
+          if test $force_local -eq 1
+              if test -z "$name"
+                  echo "work --here requires a <name>" >&2
+                  return 2
+              end
+              zellij attach -c $name
+              return $status
+          end
+
+          # Local sessions snapshot.
+          set -l local_sessions
+          if type -q zellij
+              set local_sessions (zellij list-sessions -s 2>/dev/null | string trim)
+          end
+
+          # If a name was given and exists locally, attach immediately.
+          if test -n "$name"
+              if contains -- $name $local_sessions
+                  zellij attach -c $name
+                  return $status
+              end
+          end
+
+          # Probe peers (skip current host).
+          set -l inventory_hosts
+          set -l inventory_sessions
+          for s in $local_sessions
+              set inventory_hosts $inventory_hosts $current_host
+              set inventory_sessions $inventory_sessions $s
+          end
+          for peer in $peers
+              if test "$peer" = "$current_host"
+                  continue
+              end
+              set -l remote (ssh -o ConnectTimeout=2 -o BatchMode=yes $ssh_user@$peer zellij list-sessions -s 2>/dev/null | string trim)
+              for s in $remote
+                  set inventory_hosts $inventory_hosts $peer
+                  set inventory_sessions $inventory_sessions $s
+              end
+          end
+
+          # Name given: find first peer match.
+          if test -n "$name"
+              for i in (seq (count $inventory_sessions))
+                  if test "$inventory_sessions[$i]" = "$name"
+                      set -l target $inventory_hosts[$i]
+                      if test "$target" = "$current_host"
+                          zellij attach -c $name
+                      else
+                          ssh -t -o ConnectTimeout=2 $ssh_user@$target -- zellij attach -c $name
+                      end
+                      return $status
+                  end
+              end
+              echo "work: no session '$name' found across peers ($peers), creating on $current_host" >&2
+              zellij attach -c $name
+              return $status
+          end
+
+          # No name: present picker.
+          set -l n (count $inventory_sessions)
+          if test $n -eq 0
+              echo "work: no zellij sessions found on any peer ($peers)" >&2
+              return 1
+          end
+
+          set -l choices
+          for i in (seq $n)
+              set choices $choices "$inventory_sessions[$i]  ($inventory_hosts[$i])"
+          end
+
+          set -l picked_idx
+          if type -q fzf
+              set -l picked (printf '%s\n' $choices | fzf --prompt="session> " --height=40%)
+              if test -z "$picked"
+                  return 130
+              end
+              for i in (seq $n)
+                  if test "$choices[$i]" = "$picked"
+                      set picked_idx $i
+                      break
+                  end
+              end
+          else
+              for i in (seq $n)
+                  echo "$i) $choices[$i]"
+              end
+              read -P "Pick #: " idx
+              if not string match -qr '^[0-9]+$' -- $idx
+                  return 130
+              end
+              if test $idx -lt 1 -o $idx -gt $n
+                  return 130
+              end
+              set picked_idx $idx
+          end
+
+          set -l picked_session $inventory_sessions[$picked_idx]
+          set -l picked_host $inventory_hosts[$picked_idx]
+          if test "$picked_host" = "$current_host"
+              zellij attach -c $picked_session
+          else
+              ssh -t -o ConnectTimeout=2 $ssh_user@$picked_host -- zellij attach -c $picked_session
+          end
+          return $status
+        '';
+      };
+    };
+  };
+}

--- a/modules/apps/cli/zellij/default.nix
+++ b/modules/apps/cli/zellij/default.nix
@@ -165,13 +165,6 @@ in
       })
 
       (lib.mkIf cfg.service.enable {
-        # Required so the user's systemd manager (and therefore the
-        # zellij-web user service) starts at boot on headless hosts.
-        # Without linger, systemd --user only spawns when the user
-        # actively logs in, defeating the "browser-accessible without
-        # SSH" promise of the web client.
-        users.users.${globals.user.name}.linger = true;
-
         system.caddy = {
           enable = true;
           tsnetNodes = [ cfg.tsnetNode ];

--- a/modules/archetypes/claudeWorkHost/default.nix
+++ b/modules/archetypes/claudeWorkHost/default.nix
@@ -1,0 +1,36 @@
+{ lib, config, ... }:
+
+let
+  cfg = config.archetypes.claudeWorkHost;
+in
+{
+  options.archetypes.claudeWorkHost.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = ''
+      Enable the Claude work-host archetype: zellij (no web, no mosh),
+      claude-remote with always-on control tower, sshd, and the work
+      launcher. Sessions started on this host stay on this host and are
+      attachable from any peer via the `work` fish function or directly
+      via SSH + `zellij attach`.
+    '';
+  };
+
+  config = lib.mkIf cfg.enable {
+    apps = {
+      cli = {
+        zellij = {
+          enable = true;
+          hideStatusBar = true;
+          cheatsheet.enable = true;
+        };
+        claude-remote = {
+          enable = true;
+          controlTower.enable = true;
+        };
+        work-launcher.enable = true;
+      };
+    };
+    system.ssh.enable = true;
+  };
+}

--- a/modules/suites/desktop/default.nix
+++ b/modules/suites/desktop/default.nix
@@ -96,7 +96,7 @@ in
               "class<Morgen>" = "󰃮";
               "class<okular>" = "󰈦";
               "class<Typora>" = "󰈙";
-              "class<upsight>" = "󰧑";
+              "class<dev-upsight-MainKt>" = "󱌈";
               "class<com.localsend.localsend_app>" = "󰇚";
             };
           };

--- a/modules/suites/terminal/default.nix
+++ b/modules/suites/terminal/default.nix
@@ -29,7 +29,6 @@ in
       starship.enable = true;
       zellij = {
         enable = true;
-        mosh.enable = true;
         hideStatusBar = true;
         cheatsheet.enable = true;
       };

--- a/modules/suites/terminal/default.nix
+++ b/modules/suites/terminal/default.nix
@@ -29,6 +29,7 @@ in
       starship.enable = true;
       zellij = {
         enable = true;
+        mosh.enable = true;
         hideStatusBar = true;
         cheatsheet.enable = true;
       };


### PR DESCRIPTION
## Summary

Adds a peer-host cross-device Claude Code workflow on top of the existing `claude-remote` foundation. Lets you attach to a Claude Code session from any peer host (or from your phone via claude.ai/code) without per-machine state divergence.

## What's in

- **`modules/apps/cli/work-launcher/`** — new module providing the `work` fish function. Attaches to (or creates) a `zellij` session across peer hosts, with peer list and SSH user injected at build time.
- **`modules/archetypes/claudeWorkHost/`** — new archetype rolling up the modules a "work host" needs (claude-remote + work-launcher + tmux/zellij integration). Hosts opt in via one option.
- **Host enablement** — `donkeykong`, `qbert`, `srv` each get the relevant pieces (donkeykong/qbert as full work hosts, srv participating as a peer).
- **`.claude/docs/cross-device-workflow.md`** — a topic file for the thin-CLAUDE.md protocol so future sessions discover the workflow.
- **Adjustments** — small edits to \`claude-remote\`, \`zellij\`, \`suites/desktop\`, \`suites/terminal\` to integrate cleanly.

## Verification

- Built on qbert via \`just qr\` — succeeded, 0 errors.
- \`work\` fish function deployed and resolves: \`functions work\` shows the build-time-injected peer list (\`srv qbert\`) and SSH user.
- \`nix eval .#nixosConfigurations.qbert.config.apps.cli.work-launcher.enable\` → \`true\`.
- Lint scoped to touched files: \`deadnix\` clean. \`statix\` surfaces W20 (\`apps\` key repeated) on the host module files — pre-existing pattern on main, not introduced by this branch.

## Rebase notes

Branch was rebased onto \`feab614\` (the squash-merge of #50) before pushing. The rebase was clean — neither commit on this branch touches the claude-code module's hooks/permissions/activation surface, so the post-#50 state of those files wins automatically. Diff stat against main (+2475/-168 with lots of \`cfg/hooks-*.nix\` deletions) was misleading: those deletions are inherited from #50, not authored here.