### PR TITLE
Signal-cli install

### DIFF
--- a/modules/apps/cli/signal-cli/default.nix
+++ b/modules/apps/cli/signal-cli/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  cfg = config.apps.cli.signal-cli;
+in
+{
+  options = {
+    apps.cli.signal-cli = {
+      enable = lib.mkEnableOption "signal-cli CLI/dbus client for Signal Messenger";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.signal-cli ];
+  };
+}

--- a/modules/apps/cli/signal-cli/default.nix
+++ b/modules/apps/cli/signal-cli/default.nix
@@ -11,7 +11,7 @@ in
 {
   options = {
     apps.cli.signal-cli = {
-      enable = lib.mkEnableOption "signal-cli CLI/dbus client for Signal Messenger";
+      enable = lib.mkEnableOption "signal-cli, the command-line/D-Bus client for Signal";
     };
   };
 

--- a/modules/suites/offcomms/default.nix
+++ b/modules/suites/offcomms/default.nix
@@ -49,6 +49,7 @@ in
         meetsum.enable = true;
         pandoc.enable = true;
         percollate.enable = true;
+        signal-cli.enable = true;
         slack-token-refresh.enable = true;
         slack-tracker.enable = true;
         sheets.enable = true;
@@ -89,7 +90,6 @@ in
       slack
       todoist-electron
       fractal
-      signal-cli
     ];
 
     # Force Todoist Electron to use native Wayland (avoids XWayland key


### PR DESCRIPTION
## Summary
Closes #57: Signal-cli install

- feat(signal-cli): extract from offcomms suite into dedicated module
  Move signal-cli out of environment.systemPackages in the offcomms
  suite into its own apps.cli.signal-cli module so that it follows
  the standard module pattern used by every other CLI tool in the
  suite. Behaviour is unchanged: offcomms hosts still get signal-cli.