### PR TITLE
fix(justfile): restore remote-rebuild host allowlist + host quoting

### DIFF
--- a/justfile
+++ b/justfile
@@ -414,9 +414,17 @@ quiet-upgrade:
 remote-rebuild host repo_path="~/git/nixerator":
     #!/usr/bin/env bash
     set -uo pipefail
+    case "{{host}}" in
+        qbert|donkeykong|srv) ;;
+        *)
+            echo "Refusing to ssh to unrecognized host: {{host}}"
+            echo "Allowed: qbert, donkeykong, srv"
+            exit 1
+            ;;
+    esac
     echo "Rebuilding {{host}} via SSH..."
     rc=0
-    ssh -A -o BatchMode=yes -o ConnectTimeout=5 {{host}} \
+    ssh -A -o BatchMode=yes -o ConnectTimeout=5 "{{host}}" \
         "cd {{repo_path}} && git pull --ff-only && just qr" || rc=$?
     if [[ "$rc" -eq 0 ]]; then
         echo "Remote rebuild on {{host}} succeeded."
@@ -431,9 +439,17 @@ remote-rebuild host repo_path="~/git/nixerator":
 remote-upgrade host repo_path="~/git/nixerator":
     #!/usr/bin/env bash
     set -uo pipefail
+    case "{{host}}" in
+        qbert|donkeykong|srv) ;;
+        *)
+            echo "Refusing to ssh to unrecognized host: {{host}}"
+            echo "Allowed: qbert, donkeykong, srv"
+            exit 1
+            ;;
+    esac
     echo "Upgrading {{host}} via SSH..."
     rc=0
-    ssh -A -o BatchMode=yes -o ConnectTimeout=5 {{host}} \
+    ssh -A -o BatchMode=yes -o ConnectTimeout=5 "{{host}}" \
         "cd {{repo_path}} && git pull --ff-only && just qu" || rc=$?
     if [[ "$rc" -eq 0 ]]; then
         echo "Remote upgrade on {{host}} succeeded."


### PR DESCRIPTION
## Summary

Follow-up to #68. The mechanical revert in #68 dropped two security hardenings that PR #65 had added to the `remote-rebuild` / `remote-upgrade` recipes — a case-statement host allowlist (`qbert|donkeykong|srv`) and quoting around `"{{host}}"` in the `ssh` invocation. The security review on #68 flagged this as a High finding (ssh option-injection vector, [CVE-2023-51385](https://nvd.nist.gov/vuln/detail/CVE-2023-51385) class).

The hardening is independent of the 1Password plumbing it shipped alongside — it just constrains which strings can reach `ssh` as a destination. This PR re-adds it on top of the merged revert.

## What changed

`justfile` — both `remote-rebuild` and `remote-upgrade` recipes get:

- A `case "{{host}}" in qbert|donkeykong|srv) ;; *) ... exit 1 ;; esac` allowlist immediately after `set -uo pipefail`. An unrecognized host prints `Refusing to ssh to unrecognized host: <host>` and exits 1.
- Quoted `"{{host}}"` in the `ssh -A` invocation so an arg containing whitespace can't word-split into multiple ssh args.

Without these, `just remote-rebuild '-oProxyCommand=...'` would treat the arg as an ssh option rather than a destination and execute the ProxyCommand locally. Combined with `-A` (agent forwarding), the ssh-agent socket leaks to that process.

## Verification

Red-green tested live in the worktree:

- `just remote-rebuild '-oProxyCommand=echo PWNED'` → exit 1, "Refusing to ssh to unrecognized host" (allowlist holds)
- `just remote-rebuild bogushost` → exit 1, "Refusing to ssh to unrecognized host"
- `just remote-upgrade evilhost` → exit 1, same
- `bash -c 'case "qbert" in qbert|donkeykong|srv) echo PASS ;; ...'` → PASS for all three real hosts
- `nix flake check --impure --no-build` → clean across qbert / donkeykong / srv
- `just fmt` → 0 files reformatted

## Test plan

- [ ] `just remote-rebuild qbert` from donkeykong succeeds (allowlisted host still works end-to-end)
- [ ] `just remote-rebuild someinvalidhost` exits 1 without invoking `ssh`