### PR TITLE
Automate the live-USB → first-boot secrets bootstrap; drop scp dependency

### DIFF
--- a/extras/docs/bootstrap.txt
+++ b/extras/docs/bootstrap.txt
@@ -90,54 +90,54 @@ sudo nixos-enter --root /mnt -c "passwd $INSTALL_USER"
 
 ## OPTIONAL Path B addendum: stage SA flow so first boot uses 1Password
 ##
-## Run BETWEEN Step 10 and Step 11 if you want the post-install rebuilds on
-## this host to use the 1Password service-account flow from boot #1, with
-## NO git-crypt transit. The install itself in Step 8 still uses the
-## git-crypt fallback (the live USB doesn't have /home/dustin, so the
-## external file path can't resolve there), but staging the SA token and a
-## pre-rendered secrets file under /mnt/home/dustin/ means the very first
-## `nixos-rebuild switch` after first boot picks up the SA flow.
+## Run this addendum if you want the post-install rebuilds on this host to
+## use the 1Password service-account flow from boot #1, with NO git-crypt
+## transit on the running system. The install itself in Step 8 still uses
+## the git-crypt fallback (no clean way around that on the live USB), but
+## staging the SA token + pre-rendered secrets file under /mnt/home/dustin/
+## means the very first `nixos-rebuild switch` after first boot picks up
+## the SA flow.
 ##
 ## Skip this whole block for the default Path A flow (use git-crypt now,
 ## migrate to 1Password later via "Optional: migrate to 1Password" below).
 ##
-## Prerequisites: an SA token (ops_...) already created in 1Password,
-## scoped read-only on the `nixerator` vault. See extras/docs/secrets.md.
+## Prerequisites:
+##   - SA token (ops_...) already created in 1Password admin web UI,
+##     scoped read-only on the `nixerator` vault
+##   - SA token stored in your Personal vault for `op read` retrieval
+##   - Your 1Password account credentials handy (email, secret key, password)
+##     for the live-USB `op signin`
+##   - See extras/docs/secrets.md for full setup
+##
+## The bootstrap-install-secrets.sh helper does everything via two
+## subcommands. Both are interactive -- they print what they're about to
+## do, ask for confirmation, and tell you what to run next.
 
-## Path B.1: Get the SA token onto the live USB.
-# Option 1: scp from source machine (preferred if you've already set it up there).
-scp "$SOURCE_SSH:~/.config/op/service-account-token" /tmp/op-sa-token
-# Option 2: paste manually:
-#   printf '%s' 'ops_PASTE_HERE' > /tmp/op-sa-token
-chmod 600 /tmp/op-sa-token
+## Path B.stage: BEFORE Step 5 (Verify Disk), stage SA token + render secrets
+## into /home/dustin/ on the live USB so nixos-install can read them.
+sudo ./extras/helpers/bootstrap-install-secrets.sh stage
 
-## Path B.2: Render secrets.json into /mnt/home/dustin/.config/nixos-secrets/
-## using the SA token (no biometric).
-sudo mkdir -p "$TARGET_HOME/.config/nixos-secrets"
-sudo chmod 700 "$TARGET_HOME/.config/nixos-secrets"
-sudo OP_SERVICE_ACCOUNT_TOKEN="$(cat /tmp/op-sa-token)" \
-    nix-shell -p _1password-cli --run \
-    "op inject --force -i secrets.json.tpl \
-        -o $TARGET_HOME/.config/nixos-secrets/secrets.json"
-sudo chmod 600 "$TARGET_HOME/.config/nixos-secrets/secrets.json"
+# This will:
+#   - Verify op CLI signed in (prompts you for `op signin` if not)
+#   - Fetch SA token from Personal vault via `op read` (one biometric prompt)
+#   - Stage token at  /home/dustin/.config/op/service-account-token (0600)
+#   - Render secrets  /home/dustin/.config/nixos-secrets/secrets.json (0600)
 
-## Path B.3: Also stage the SA token itself onto the target so render-secrets /
-## just render-secrets / just push-secrets work without prompts after reboot.
-sudo mkdir -p "$TARGET_HOME/.config/op"
-sudo chmod 700 "$TARGET_HOME/.config/op"
-sudo install -m 0600 /tmp/op-sa-token "$TARGET_HOME/.config/op/service-account-token"
+## ... continue with Steps 5-8 (verify disk, disko, hardware-config, nixos-install).
 
-## Path B.4: chown the staged dirs to the target user. NixOS' default user
-## uid:gid is 1000:100; verify with `nixos-enter --root /mnt -c "id $INSTALL_USER"`
-## if you're unsure.
-sudo nixos-enter --root /mnt -c "chown -R $INSTALL_USER:users \
-    /home/$INSTALL_USER/.config/nixos-secrets \
-    /home/$INSTALL_USER/.config/op"
+## Path B.promote: BETWEEN Step 10 (Set Passwords) and Step 11 (Reboot),
+## copy the staged files to /mnt and chown to the install user.
+sudo ./extras/helpers/bootstrap-install-secrets.sh promote
 
-## Path B.5: Clean up the live-USB scratch copy.
-shred -u /tmp/op-sa-token 2>/dev/null || rm -f /tmp/op-sa-token
+# This will:
+#   - Verify /mnt is mounted, has a NixOS install, install user exists on target
+#   - Copy SA token + secrets.json from /home/dustin/ → /mnt/home/dustin/
+#   - chown both dirs to ${INSTALL_USER}:users via nixos-enter
+#
+# After this completes, the script tells you exactly what to run next
+# (Step 10 passwd commands + Step 11 reboot).
 
-## End Path B addendum. Continue to Step 11.
+## End Path B addendum.
 
 ## Step 11: Reboot
 sudo umount -R /mnt && sudo reboot

--- a/extras/docs/helpers.md
+++ b/extras/docs/helpers.md
@@ -26,6 +26,43 @@ Collects hardware and driver information for GPU/audio diagnostics. Outputs a ti
 
 Gathers: PCI devices, kernel modules, DRI render nodes, ALSA/PulseAudio state, and Nix package versions. Useful when diagnosing GPU or audio issues on a new host.
 
+## bootstrap-install-secrets.sh
+
+Interactive live-USB orchestrator for the nixerator secrets pipeline during a
+fresh NixOS install. Wraps `setup-op-service-account.sh` + `render-secrets-bootstrap.sh`
+with prereq checks, prompts, and copy-into-/mnt semantics so the user can
+follow `bootstrap.txt` without inlining six error-prone commands.
+
+**Prerequisites**: Nix with flakes; 1Password account credentials handy
+(email, secret key, password) — `op signin` is interactive and runs from
+the live USB. SA token already exists in your Personal vault for
+`op read`. NIX_PATH set (which it is on a NixOS live USB; the helper uses
+`nix-shell -p _1password-cli`).
+
+**Two subcommands, both interactive (confirm prompts before destructive
+actions, print next-step guidance after):**
+
+```bash
+# Run BEFORE `sudo nixos-install` -- stages token + renders secrets
+# into /home/dustin/.config/... so the install eval can read them.
+sudo ./extras/helpers/bootstrap-install-secrets.sh stage
+
+# Run AFTER `sudo nixos-install`, BEFORE reboot -- copies the staged files
+# into /mnt/home/dustin/.config/... and chowns them via nixos-enter.
+sudo ./extras/helpers/bootstrap-install-secrets.sh promote
+```
+
+Idempotent (the underlying helpers no-op when the destination already
+matches). `stage` bails if not run as root or if op isn't signed in;
+`promote` bails if /mnt isn't mounted, the staged files don't exist, or
+the install user doesn't yet exist on the target.
+
+**Override the install user** (default `dustin`, matching `settings/globals.nix`):
+
+```bash
+INSTALL_USER=alice sudo ./extras/helpers/bootstrap-install-secrets.sh stage
+```
+
 ## setup-op-service-account.sh
 
 Installs the nixerator 1Password service-account token at
@@ -59,6 +96,17 @@ perms and exits success. Refuses to replace a different existing token unless
 **Token rotation**: regenerate the SA in 1Password, update the Personal
 vault item, then re-run with `--force` on each host.
 
+**Live-USB use** (writes from root into the target user's home, before
+`nixos-install`):
+
+```bash
+sudo ./extras/helpers/setup-op-service-account.sh \
+    --dest /home/dustin/.config/op/service-account-token
+```
+
+The `bootstrap-install-secrets.sh stage` subcommand wraps this for you
+along with the corresponding secrets render.
+
 ## render-secrets-bootstrap.sh
 
 Renders `~/.config/nixos-secrets/secrets.json` from `secrets.json.tpl` via
@@ -87,6 +135,17 @@ later (see `setup-git-crypt.sh`).
 Atomic write: renders to a tempfile inside `~/.config/nixos-secrets/` (perms
 `0700`) then `mv -f`'s into place. Partial `op inject` failure or SIGINT
 leaves any existing live file untouched.
+
+**Live-USB use** (writes from root into the target user's home, before
+`nixos-install`):
+
+```bash
+sudo ./extras/helpers/render-secrets-bootstrap.sh \
+    --dest /home/dustin/.config/nixos-secrets/secrets.json
+```
+
+The `bootstrap-install-secrets.sh stage` subcommand wraps this for you
+along with the corresponding SA-token install.
 
 ## setup-git-crypt.sh
 

--- a/extras/docs/secrets.md
+++ b/extras/docs/secrets.md
@@ -355,16 +355,36 @@ The next rebuild on this host picks up the rendered file automatically.
 ### Path B: SA flow active on first boot (no git-crypt transit)
 
 Use this when you want the SA flow live from the very first post-install
-rebuild, with no git-crypt transit. The `nixos-install` step itself still
-uses the git-crypt fallback (the live USB doesn't have `/home/dustin`, so the
-external file path doesn't resolve there — there's no clean way around this),
-but the SA token and a rendered secrets file are staged under `/mnt/home/dustin/`
-during install, so first-boot rebuilds use the SA flow without ever needing
-git-crypt unlocked again.
+rebuild. `nixos-install` itself still uses the git-crypt fallback (no clean
+way around that on the live USB), but the SA token and a rendered secrets
+file are staged under `/mnt/home/dustin/` during install, so first-boot
+rebuilds use the SA flow without ever needing git-crypt unlocked again.
 
+The whole flow is driven by one interactive helper with two subcommands.
 See **`extras/docs/bootstrap.txt` → "Path B addendum"** for the exact
-commands. They slot in between Step 10 (Set Passwords) and Step 11 (Reboot)
-of the standard install guide.
+sequencing relative to the rest of the install (where to slot each
+subcommand). At a glance:
+
+```bash
+# BEFORE nixos-install (live USB, repo cloned; op signin happens inside
+# the helper if you're not already signed in):
+sudo ./extras/helpers/bootstrap-install-secrets.sh stage
+
+# ... standard Steps 5-8: verify disk, disko, hardware-config, nixos-install
+
+# AFTER nixos-install, BEFORE reboot (still on live USB, /mnt mounted):
+sudo ./extras/helpers/bootstrap-install-secrets.sh promote
+```
+
+`stage` fetches the SA token from your Personal vault via `op read` (one
+biometric — the only one for the whole bootstrap), installs it at
+`/home/dustin/.config/op/service-account-token`, and renders secrets to
+`/home/dustin/.config/nixos-secrets/secrets.json`. `promote` copies both
+files into `/mnt/home/dustin/.config/...` and chowns them to the install
+user via `nixos-enter`.
+
+Both subcommands print what they're about to do, confirm before touching
+anything, and tell you what to run next. Idempotent — safe to re-run.
 
 After the first reboot:
 
@@ -374,7 +394,7 @@ just qr     # rebuild reads the pre-staged ~/.config/nixos-secrets/secrets.json
 ```
 
 The post-install steps for SA setup (`op signin` + `just setup-op-token`)
-are then unnecessary on this host — they were already done during install.
+are unnecessary on this host — they were already done during install.
 
 ## Troubleshooting
 

--- a/extras/helpers/bootstrap-install-secrets.sh
+++ b/extras/helpers/bootstrap-install-secrets.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p _1password-cli coreutils
+# shellcheck shell=bash
+#
+# Live-USB orchestrator for the nixerator secrets bootstrap. Walks the user
+# through staging the SA token + rendered secrets file so that:
+#   - nixos-install can read /home/dustin/.config/nixos-secrets/secrets.json
+#     during the install eval.
+#   - The installed system, after first boot, has the same files in place
+#     so daily-driver workflows (just qr, just render-secrets) work
+#     immediately with zero biometric prompts.
+#
+# Usage (run from the nixerator repo root on the live USB):
+#
+#   ./extras/helpers/bootstrap-install-secrets.sh stage
+#     PRE-install. Verifies op signin, fetches the SA token from your
+#     Personal vault via `op read`, renders secrets, and stages both under
+#     /home/dustin/. Run this BEFORE `sudo nixos-install`.
+#
+#   ./extras/helpers/bootstrap-install-secrets.sh promote
+#     POST-install (before reboot). Copies the staged files from
+#     /home/dustin/ into /mnt/home/dustin/ on the target filesystem, then
+#     chowns to the install user. Run this AFTER `sudo nixos-install` and
+#     BEFORE `umount /mnt && reboot`.
+#
+# Both subcommands are interactive: they print what they're about to do,
+# confirm before touching anything destructive, and tell you what to do
+# next. Safe to re-run -- the underlying helpers are idempotent.
+#
+# Override the install user (default: dustin, matching settings/globals.nix):
+#   INSTALL_USER=somebody ./extras/helpers/bootstrap-install-secrets.sh stage
+#
+# Override the 1Password reference for the SA token (default matches
+# setup-op-service-account.sh's TOKEN_REF_DEFAULT):
+#   OP_TOKEN_REF=op://Vault/Item/field ./extras/helpers/bootstrap-install-secrets.sh stage
+
+set -euo pipefail
+
+INSTALL_USER="${INSTALL_USER:-dustin}"
+TARGET_HOME="/home/${INSTALL_USER}"
+
+# Resolve repo root from the script location so the helper works regardless
+# of cwd. Subcommands invoke the other helpers via these paths.
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# --- output helpers -----------------------------------------------------------
+
+# Coloured terminal output, falls back to plain on non-TTY.
+if [[ -t 1 ]]; then
+  C_HEAD=$'\033[1;36m'   # bold cyan
+  C_OK=$'\033[1;32m'     # bold green
+  C_WARN=$'\033[1;33m'   # bold yellow
+  C_ERR=$'\033[1;31m'    # bold red
+  C_DIM=$'\033[2m'       # dim
+  C_RESET=$'\033[0m'
+else
+  C_HEAD="" C_OK="" C_WARN="" C_ERR="" C_DIM="" C_RESET=""
+fi
+
+heading() { echo; echo "${C_HEAD}=== $* ===${C_RESET}"; }
+ok()      { echo "${C_OK}✓${C_RESET} $*"; }
+warn()    { echo "${C_WARN}!${C_RESET} $*" >&2; }
+fail()    { echo "${C_ERR}✗${C_RESET} $*" >&2; exit 1; }
+note()    { echo "${C_DIM}  $*${C_RESET}"; }
+
+confirm() {
+  local prompt="${1:-Continue?}"
+  local reply
+  read -r -p "$(printf '%s [y/N] ' "${prompt}")" reply
+  case "${reply}" in
+    y | Y | yes | YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# --- subcommand: stage --------------------------------------------------------
+
+cmd_stage() {
+  heading "Pre-install bootstrap (live USB)"
+  cat <<EOF
+This script will:
+
+  1. Verify the 1Password CLI is signed in (one-time interactive sign-in if not).
+  2. Fetch the nixerator service-account token from your Personal vault via
+     'op read' (one biometric prompt -- the only one you'll see).
+  3. Install the token at:  ${TARGET_HOME}/.config/op/service-account-token  (0600)
+  4. Render secrets to:     ${TARGET_HOME}/.config/nixos-secrets/secrets.json (0600)
+
+Both paths use ${TARGET_HOME} (the future installed user's home directory)
+because the flake.nix reads secretsFile from a path baked from
+globals.user.homeDirectory at eval time -- regardless of who runs
+nixos-install.
+
+After this script, you'll proceed with the standard nixos-install steps
+(disko / hardware-config / nixos-install). Then re-run this script with the
+'promote' subcommand to copy the staged files onto /mnt before reboot.
+EOF
+  echo
+  confirm "Proceed with staging?" || { warn "Aborted by user."; exit 0; }
+
+  # Step 1: prereqs ------------------------------------------------------------
+  heading "Step 1: Verify prerequisites"
+
+  [[ -f "${REPO_ROOT}/secrets.json.tpl" ]] || \
+    fail "secrets.json.tpl not found at ${REPO_ROOT}. Are you in the nixerator repo?"
+  ok "Template at ${REPO_ROOT}/secrets.json.tpl"
+
+  if [[ $EUID -ne 0 ]]; then
+    fail "stage must run as root (writes into ${TARGET_HOME}). Re-run with sudo."
+  fi
+  ok "Running as root"
+
+  # Step 2: op signin ----------------------------------------------------------
+  heading "Step 2: 1Password CLI sign-in"
+
+  # `op whoami` works for both desktop biometric AND service-account sessions.
+  if op whoami >/dev/null 2>&1; then
+    ok "1Password CLI already signed in: $(op whoami 2>/dev/null | head -1)"
+  else
+    cat <<EOF
+1Password CLI not signed in. You'll be prompted for:
+  - Your 1Password account email
+  - Your secret key (from your 1Password emergency kit)
+  - Your account password
+EOF
+    echo
+    confirm "Sign in to 1Password now?" || fail "Cannot proceed without 1Password sign-in."
+    # `op signin` is interactive — it sets up the local session.
+    if ! op signin; then
+      fail "op signin failed. See https://developer.1password.com/docs/cli/sign-in-manually"
+    fi
+    ok "Signed in"
+  fi
+
+  # Step 3: install the SA token ----------------------------------------------
+  heading "Step 3: Install service-account token to ${TARGET_HOME}/.config/op/"
+
+  mkdir -p "${TARGET_HOME}/.config/op"
+  chmod 700 "${TARGET_HOME}/.config/op"
+  "${SCRIPT_DIR}/setup-op-service-account.sh" \
+    --dest "${TARGET_HOME}/.config/op/service-account-token"
+  ok "SA token installed at ${TARGET_HOME}/.config/op/service-account-token"
+
+  # Step 4: render the secrets file -------------------------------------------
+  heading "Step 4: Render secrets to ${TARGET_HOME}/.config/nixos-secrets/"
+
+  mkdir -p "${TARGET_HOME}/.config/nixos-secrets"
+  chmod 700 "${TARGET_HOME}/.config/nixos-secrets"
+  # render-secrets-bootstrap.sh auto-sources OP_SERVICE_ACCOUNT_TOKEN from
+  # the token file we just installed, so this runs with no biometric prompt.
+  HOME="${TARGET_HOME}" "${SCRIPT_DIR}/render-secrets-bootstrap.sh" \
+    --dest "${TARGET_HOME}/.config/nixos-secrets/secrets.json"
+  ok "Secrets rendered at ${TARGET_HOME}/.config/nixos-secrets/secrets.json"
+
+  # Done ----------------------------------------------------------------------
+  heading "Stage complete"
+  cat <<EOF
+${C_OK}Ready to install.${C_RESET}
+
+Next steps (from bootstrap.txt):
+  - Step 5-6: verify disk, run disko to partition
+  - Step 7:   generate hardware-configuration.nix
+  - Step 8:   sudo nixos-install --impure --flake ".#\$TARGET_HOST"
+
+When nixos-install finishes (BEFORE reboot), come back and run:
+  sudo ${SCRIPT_DIR}/bootstrap-install-secrets.sh promote
+
+EOF
+}
+
+# --- subcommand: promote ------------------------------------------------------
+
+cmd_promote() {
+  heading "Post-install promotion (live USB, /mnt mounted, pre-reboot)"
+  cat <<EOF
+This script will:
+
+  1. Verify /mnt is mounted and has a NixOS install on it.
+  2. Verify the staged files exist at ${TARGET_HOME}/.config/...
+  3. Verify the install user (${INSTALL_USER}) exists on the target.
+  4. Copy:
+       ${TARGET_HOME}/.config/op/service-account-token
+       ${TARGET_HOME}/.config/nixos-secrets/secrets.json
+     into /mnt${TARGET_HOME}/.config/...
+  5. chown both directories to ${INSTALL_USER}:users on the target.
+
+After this completes, finish bootstrap.txt:
+  Step 10: set passwords with nixos-enter
+  Step 11: umount /mnt && reboot
+EOF
+  echo
+  confirm "Proceed with promotion?" || { warn "Aborted by user."; exit 0; }
+
+  # Step 1: /mnt sanity --------------------------------------------------------
+  heading "Step 1: Verify /mnt"
+
+  [[ -d /mnt ]] || fail "/mnt does not exist."
+  mountpoint -q /mnt || fail "/mnt is not a mountpoint. Did nixos-install run?"
+  [[ -f /mnt/etc/NIXOS ]] || \
+    fail "/mnt doesn't look like a NixOS install (no /mnt/etc/NIXOS)."
+  ok "/mnt is mounted and looks like a NixOS install"
+
+  if [[ $EUID -ne 0 ]]; then
+    fail "promote must run as root (writes into /mnt). Re-run with sudo."
+  fi
+  ok "Running as root"
+
+  # Step 2: staged files exist ------------------------------------------------
+  heading "Step 2: Verify staged files exist on live USB"
+
+  local SRC_TOKEN="${TARGET_HOME}/.config/op/service-account-token"
+  local SRC_SECRETS="${TARGET_HOME}/.config/nixos-secrets/secrets.json"
+
+  [[ -f "${SRC_TOKEN}" ]] || \
+    fail "Staged SA token not found at ${SRC_TOKEN}. Did 'stage' run first?"
+  ok "SA token staged at ${SRC_TOKEN}"
+
+  [[ -f "${SRC_SECRETS}" ]] || \
+    fail "Staged secrets file not found at ${SRC_SECRETS}. Did 'stage' run first?"
+  ok "Secrets file staged at ${SRC_SECRETS}"
+
+  # Step 3: install user exists on target -------------------------------------
+  heading "Step 3: Verify install user '${INSTALL_USER}' exists on target"
+
+  local UID_GID
+  if ! UID_GID="$(nixos-enter --root /mnt -c "id -u ${INSTALL_USER} && id -g ${INSTALL_USER}" 2>/dev/null)"; then
+    fail "User '${INSTALL_USER}' doesn't exist on the target filesystem.
+  This is set in settings/globals.nix and gets created on first activation
+  during nixos-install. If you set INSTALL_USER to override the default,
+  verify the value matches what's in globals.nix."
+  fi
+  local TARGET_UID TARGET_GID
+  TARGET_UID="$(echo "${UID_GID}" | head -1)"
+  TARGET_GID="$(echo "${UID_GID}" | tail -1)"
+  ok "User '${INSTALL_USER}' exists on target with uid=${TARGET_UID} gid=${TARGET_GID}"
+
+  # Step 4: copy --------------------------------------------------------------
+  heading "Step 4: Copy staged files into /mnt${TARGET_HOME}/.config/"
+
+  local DST_OP="/mnt${TARGET_HOME}/.config/op"
+  local DST_NS="/mnt${TARGET_HOME}/.config/nixos-secrets"
+
+  mkdir -p "${DST_OP}" "${DST_NS}"
+  install -m 0600 "${SRC_TOKEN}"   "${DST_OP}/service-account-token"
+  install -m 0600 "${SRC_SECRETS}" "${DST_NS}/secrets.json"
+  chmod 700 "${DST_OP}" "${DST_NS}"
+  ok "Copied to ${DST_OP}/ and ${DST_NS}/"
+
+  # Step 5: chown -------------------------------------------------------------
+  heading "Step 5: chown to ${INSTALL_USER}:users on target"
+
+  # chown via nixos-enter so the uid:gid is resolved on the target system,
+  # not the live USB (where the user may not exist or may have a different id).
+  nixos-enter --root /mnt -c "chown -R ${INSTALL_USER}:users \
+    ${TARGET_HOME}/.config/op \
+    ${TARGET_HOME}/.config/nixos-secrets"
+  ok "Ownership set on target"
+
+  # Done ----------------------------------------------------------------------
+  heading "Promote complete"
+  cat <<EOF
+${C_OK}Secrets are ready for first boot.${C_RESET}
+
+When you reboot and log in as ${INSTALL_USER}, 'just qr' will read from
+${TARGET_HOME}/.config/nixos-secrets/secrets.json directly (no git-crypt
+transit, no biometric).
+
+Remaining bootstrap.txt steps:
+  Step 10: sudo nixos-enter --root /mnt -c 'passwd root'
+           sudo nixos-enter --root /mnt -c "passwd ${INSTALL_USER}"
+  Step 11: sudo umount -R /mnt && sudo reboot
+
+EOF
+}
+
+# --- dispatch -----------------------------------------------------------------
+
+usage() {
+  sed -n '5,32p' "$0" >&2
+  exit "${1:-2}"
+}
+
+case "${1:-}" in
+  stage) shift; cmd_stage "$@" ;;
+  promote) shift; cmd_promote "$@" ;;
+  -h | --help | help | "") usage 0 ;;
+  *)
+    echo "Unknown subcommand: $1" >&2
+    echo "Use: $(basename "$0") {stage|promote}" >&2
+    exit 2
+    ;;
+esac

--- a/extras/helpers/render-secrets-bootstrap.sh
+++ b/extras/helpers/render-secrets-bootstrap.sh
@@ -25,19 +25,49 @@
 # Usage (from the repo root):
 #   ./extras/helpers/render-secrets-bootstrap.sh
 #
+# Render at a non-default path (e.g. from root on a live USB writing into
+# the target user's home before nixos-install):
+#   sudo ./extras/helpers/render-secrets-bootstrap.sh \
+#       --dest /home/dustin/.config/nixos-secrets/secrets.json
+#
 # Does NOT push to peers — for that, wait for the on-PATH render-secrets
 # after the first rebuild lands and use `just push-secrets <host>`.
 
 set -euo pipefail
 
+# Default destination: the current user's ~/.config/nixos-secrets/. Overridable
+# via --dest for live-USB bootstrap (writing into /home/dustin/... from root).
 DEST="${HOME}/.config/nixos-secrets/secrets.json"
-DEST_DIR="$(dirname "${DEST}")"
 
 # Resolve repo root from the script location so the helper works regardless
 # of cwd.
 SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TPL="${REPO_ROOT}/secrets.json.tpl"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dest)
+      shift
+      [[ $# -gt 0 ]] || {
+        echo "--dest requires a PATH argument" >&2
+        exit 2
+      }
+      DEST="$1"
+      shift
+      ;;
+    -h | --help)
+      sed -n '5,32p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+DEST_DIR="$(dirname "${DEST}")"
 
 if [[ ! -f "${TPL}" ]]; then
   echo "render-secrets-bootstrap: template not found at ${TPL}" >&2

--- a/extras/helpers/setup-op-service-account.sh
+++ b/extras/helpers/setup-op-service-account.sh
@@ -34,11 +34,17 @@
 #
 # Overwrite an existing different token (default is to refuse):
 #   ./extras/helpers/setup-op-service-account.sh --force
+#
+# Install at a non-default path (e.g. from root on a live USB writing into
+# the target user's home before nixos-install):
+#   sudo ./extras/helpers/setup-op-service-account.sh \
+#       --dest /home/dustin/.config/op/service-account-token
 
 set -euo pipefail
 
-DEST_DIR="${HOME}/.config/op"
-DEST="${DEST_DIR}/service-account-token"
+# Default destination: the current user's ~/.config/op/. Overridable via
+# --dest for live-USB bootstrap (writing into /home/dustin/... from root).
+DEST="${HOME}/.config/op/service-account-token"
 
 # Canonical reference for the SA token in 1Password. Pinned to the item ID
 # (not name) so renames don't break this script.
@@ -47,20 +53,37 @@ TOKEN_REF="${OP_TOKEN_REF:-${TOKEN_REF_DEFAULT}}"
 
 MANUAL=0
 FORCE=0
-for arg in "$@"; do
-  case "$arg" in
-    --manual) MANUAL=1 ;;
-    --force) FORCE=1 ;;
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manual)
+      MANUAL=1
+      shift
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    --dest)
+      shift
+      [[ $# -gt 0 ]] || {
+        echo "--dest requires a PATH argument" >&2
+        exit 2
+      }
+      DEST="$1"
+      shift
+      ;;
     -h | --help)
-      sed -n '4,32p' "$0"
+      sed -n '4,38p' "$0"
       exit 0
       ;;
     *)
-      echo "Unknown arg: $arg" >&2
+      echo "Unknown arg: $1" >&2
       exit 2
       ;;
   esac
 done
+
+DEST_DIR="$(dirname "${DEST}")"
 
 if ! command -v op >/dev/null 2>&1; then
   echo "setup-op-service-account: 'op' (1Password CLI) not in PATH." >&2
@@ -143,3 +166,7 @@ mv -f "${tmp}" "${DEST}"
 echo "setup-op-service-account: installed token at ${DEST} (0600)."
 echo "  Verify (no biometric prompt expected):"
 echo "    OP_SERVICE_ACCOUNT_TOKEN=\"\$(cat ${DEST})\" op vault list"
+if [[ "${DEST}" != "${HOME}/.config/op/service-account-token" ]]; then
+  echo "  NOTE: --dest used. If this is bootstrap-install-secrets staging,"
+  echo "  remember to chown the file to the target user before reboot."
+fi


### PR DESCRIPTION
## Summary
Closes #84: Automate the live-USB → first-boot secrets bootstrap; drop scp dependency

- feat(secrets): automate live-USB → first-boot bootstrap; drop scp dependency
  Adds an interactive orchestrator helper that walks the user through the
  secrets-related parts of a fresh NixOS install, and enhances the two
  single-purpose helpers it wraps so they can target /home/dustin/ from a
  root-on-live-USB context.
  
  Goal (from the issue): the live-USB bootstrap should be self-prompting
  and follow-able by someone who hasn't done it in months, without
  inlining six error-prone commands in bootstrap.txt.
  
  New helper:
    extras/helpers/bootstrap-install-secrets.sh   (nix-shell + bash, op via nix-shell)
  
    Two subcommands, both interactive:
  
      stage    PRE-install. Verifies op CLI signed in (prompts for op signin
               if not), fetches SA token from Personal vault via op read,
               installs it at /home/dustin/.config/op/service-account-token,
               renders secrets to /home/dustin/.config/nixos-secrets/secrets.json.
               Run from the repo root on the live USB, before nixos-install.
  
      promote  POST-install (before reboot). Verifies /mnt is mounted and
               looks like a NixOS install, verifies the install user exists
               on the target, copies the staged files into
               /mnt/home/dustin/.config/..., chowns via nixos-enter so the
               uid/gid is resolved on the target system. Run after
               nixos-install but before umount + reboot.
  
    Both subcommands print what's about to happen, confirm with the user
    before touching anything destructive, and tell the user exactly what
    to run next when they're done. Idempotent (the underlying helpers
    no-op when the destination already matches).
  
  Helper enhancements (additive, default behaviour unchanged):
  
    setup-op-service-account.sh
      --dest PATH   override the default $HOME/.config/op/service-account-token
                    destination. Used by bootstrap-install-secrets stage to
                    write into /home/dustin/.config/op/ from root on live USB.
                    Switched the arg parser from a 'for arg in "$@"' loop
                    to while/case/shift so flags-with-values parse cleanly.
  
    render-secrets-bootstrap.sh
      --dest PATH   same pattern. Renders to an arbitrary path regardless of
                    $HOME. Also adds a -h / --help dispatch (previously the
                    script silently ran the render when given any unknown
                    arg).
  
  scp dependency dropped from bootstrap.txt Path B entirely. op signin +
  op read replaces it — no peer machine needed, the SA token's own home
  in the Personal vault is the only required source.
  
  Documentation:
    extras/docs/bootstrap.txt: Path B addendum rewritten. Two helper
      invocations (stage + promote) instead of six inlined commands. New
      prereq block lists 1Password account credentials so the user knows
      they'll need them for op signin on the live USB.
    extras/docs/secrets.md: Path B pointer updated; references the new
      orchestrator helper, drops the scp mention.
    extras/docs/helpers.md: new bootstrap-install-secrets.sh entry (above
      setup-op-service-account.sh). Both single-purpose helpers gain a
      'Live-USB use' subsection documenting their --dest flags and noting
      that bootstrap-install-secrets wraps them for that workflow.
  
  Verified end-to-end:
    - shellcheck clean on all three helpers
    - bash -n green on all three
    - setup-op-service-account.sh --dest /tmp/test (with OP_TOKEN env var
      set to current SA token): writes the file with correct 0600 perms,
      new 'NOTE: --dest used' hint surfaces
    - render-secrets-bootstrap.sh --dest /tmp/test (with SA token
      auto-sourced from the canonical path): byte-identical output to the
      live cached secrets.json
    - bootstrap-install-secrets.sh: usage dispatch works, unknown
      subcommand rejected, --help shows the right block, 'stage' as
      non-root bails at the EUID check after passing the template check
      (decline-confirm aborts cleanly).
  
  Live cached ~/.config/nixos-secrets/secrets.json unchanged by all tests.