### PR TITLE
Setup https://netboot.xyz/docs

### DIFF
--- a/extras/docs/netboot.md
+++ b/extras/docs/netboot.md
@@ -36,14 +36,22 @@ Three layers stack:
    for the admin UI). The unauthenticated admin UI cannot be reached
    from any interface whose IP is not in `adminAddresses`.
 
-2. **`blockBridges` PREROUTING bypass.** Docker's published-port DNAT
-   lives in `nat/PREROUTING` with no input-interface predicate, so a
-   libvirt guest routing through srv toward `192.168.168.1` would
-   *otherwise* hit the admin UI before any INPUT/FORWARD ACL runs.
-   `blockBridges = [ "virbr+" ]` installs explicit
-   `nat/PREROUTING -i virbr+ ... -j RETURN` rules that bypass Docker's
-   DNAT for traffic arriving on any libvirt bridge. The kernel then
-   has no listener on `192.168.168.1` and the packet is dropped.
+2. **`blockBridges` PREROUTING bypass + `userland-proxy = false`.**
+   Docker has two port-publishing paths: an iptables DNAT in
+   `nat/PREROUTING` (with no input-interface predicate) and a
+   userspace `docker-proxy` process that binds the published host
+   IP directly. Both need to be closed.
+   - `blockBridges = [ "virbr+" ]` installs explicit
+     `nat/PREROUTING -i virbr+ ... -j RETURN` rules that skip
+     Docker's DNAT for traffic arriving on any libvirt bridge.
+   - `virtualisation.docker.daemon.settings.userland-proxy = false`
+     in `hosts/srv/modules.nix` turns off the userspace fallback so
+     Docker uses iptables-only. Without this, docker-proxy would
+     bind `192.168.168.1:3000` as a host socket and a guest packet
+     routed through srv would still hit it via the kvm module's
+     permissive INPUT chain.
+   With both, the kernel has no listener on `192.168.168.1:3000`
+   for guest-sourced packets and they are dropped.
 
 3. **Per-interface firewall (defense-in-depth).** TFTP and the admin
    UI are also opened in `networking.firewall.interfaces.*`. This

--- a/extras/docs/netboot.md
+++ b/extras/docs/netboot.md
@@ -1,0 +1,115 @@
+# netboot.xyz on srv
+
+iPXE-based network boot menu running as a LinuxServer Docker container on
+`srv`. Lets any machine on the main LAN PXE-boot installers and rescue
+ISOs (NixOS, Talos, SystemRescue, GParted, Memtest86+, Clonezilla,
+Ubuntu LTS, and the rest of the upstream netboot.xyz catalog) without
+maintaining local ISOs.
+
+## Enable
+
+```nix
+server.netbootXyz.enable = true;
+```
+
+Defined in `modules/server/netboot-xyz/default.nix`. All ports and
+interface scopes are options on `server.netbootXyz.*` -- see the module
+for the full list.
+
+## Ports
+
+| Service             | Host port | Interfaces                | Notes                             |
+| ------------------- | --------- | ------------------------- | --------------------------------- |
+| TFTP (PXE bootstrap)| 69/udp    | `enp3s0`                  | Stage-1 iPXE loader               |
+| HTTP boot files     | 8080/tcp  | `enp3s0`                  | Avoids Caddy on 80                |
+| Web admin UI        | 3000/tcp  | `enp3s0` + `tailscale0`   | No auth -- keep off public nets   |
+
+State: `/srv/netboot.xyz/{config,assets}`, owned `1000:100` to match the
+existing NFS export convention.
+
+## UniFi DHCP configuration
+
+UniFi is external to Nix, so configure it via the UniFi controller UI.
+Settings panel locations vary by controller version; check the upstream
+[UniFi DHCP options docs](https://help.ui.com/hc/en-us/articles/204909754)
+if a control isn't where this guide says it is.
+
+### Single-architecture (simple) setup
+
+In **Settings -> Networks -> [your LAN] -> DHCP Service**, set:
+
+- **Network Boot**: enabled
+- **TFTP Server (DHCP option 66)**: `192.168.168.1`
+- **Boot File (DHCP option 67)**:
+  - UEFI x86_64 clients: `netboot.xyz.efi`
+  - Legacy BIOS clients:  `netboot.xyz.kpxe`
+
+Pick the boot file matching the majority of your fleet. Mixed fleets
+need the arch-aware setup below.
+
+### Arch-aware setup (mixed BIOS + UEFI)
+
+UniFi 8.x exposes per-client-architecture boot file selection through
+DHCP option 93 (`client-architecture`). Configurable via the **Advanced
+DHCP Options** panel or via the `config.gateway.json` override on
+self-hosted controllers:
+
+```json
+{
+  "service": {
+    "dhcp-server": {
+      "shared-network-name": {
+        "LAN": {
+          "subnet": {
+            "192.168.168.0/23": {
+              "subnet-parameters": [
+                "next-server 192.168.168.1;",
+                "if option arch = 00:07 { filename \"netboot.xyz.efi\"; } else if option arch = 00:09 { filename \"netboot.xyz.efi\"; } else { filename \"netboot.xyz.kpxe\"; }"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Place at `/srv/unifi/data/sites/default/config.gateway.json` on the
+controller, then **force-provision** the gateway.
+
+### Verify
+
+From a host on the LAN:
+
+```bash
+# TFTP smoke test
+tftp 192.168.168.1
+> get netboot.xyz.efi /tmp/netboot.xyz.efi
+> quit
+ls -l /tmp/netboot.xyz.efi    # expect ~1MB
+
+# HTTP boot file server
+curl -fsSI http://192.168.168.1:8080/menu.ipxe | head
+
+# Admin UI (LAN or Tailscale)
+xdg-open http://srv:3000
+```
+
+PXE a real client by setting boot priority to network in firmware, or
+spin up a libvirt VM with `network` first in `<os><boot>` and watch
+TFTP -> iPXE chainload -> netboot.xyz menu.
+
+## Upgrades
+
+The container tracks `lscr.io/linuxserver/netbootxyz:latest`. To pull a
+newer image:
+
+```bash
+sudo docker pull lscr.io/linuxserver/netbootxyz:latest
+sudo systemctl restart docker-netboot-xyz
+```
+
+Pin to a specific tag in `hosts/srv/modules.nix` via
+`server.netbootXyz.image = "lscr.io/linuxserver/netbootxyz:0.7.5";` if
+reproducibility matters more than fresh menu data.

--- a/extras/docs/netboot.md
+++ b/extras/docs/netboot.md
@@ -1,31 +1,55 @@
 # netboot.xyz on srv
 
-iPXE-based network boot menu running as a LinuxServer Docker container on
-`srv`. Lets any machine on the main LAN PXE-boot installers and rescue
-ISOs (NixOS, Talos, SystemRescue, GParted, Memtest86+, Clonezilla,
-Ubuntu LTS, and the rest of the upstream netboot.xyz catalog) without
-maintaining local ISOs.
+iPXE-based network boot menu running as the official netboot.xyz Docker
+container (`ghcr.io/netbootxyz/netbootxyz`) on `srv`. Lets any machine
+on the main LAN PXE-boot installers and rescue ISOs (NixOS, Talos,
+SystemRescue, GParted, Memtest86+, Clonezilla, Ubuntu LTS, and the rest
+of the upstream catalog) without maintaining local images.
 
 ## Enable
 
 ```nix
-server.netbootXyz.enable = true;
+server.netbootXyz = {
+  enable = true;
+  lanAddress = "192.168.168.1";                          # bind TFTP + HTTP boot files here
+  adminAddresses = [ "192.168.168.1" "100.64.187.14" ];  # admin UI on LAN + Tailscale
+};
 ```
 
-Defined in `modules/server/netboot-xyz/default.nix`. All ports and
-interface scopes are options on `server.netbootXyz.*` -- see the module
-for the full list.
+Defined in `modules/server/netboot-xyz/default.nix`. All ports,
+interfaces, and addresses are options on `server.netbootXyz.*` -- see
+the module for the full list.
 
-## Ports
+## Exposure model
 
-| Service             | Host port | Interfaces                | Notes                             |
-| ------------------- | --------- | ------------------------- | --------------------------------- |
-| TFTP (PXE bootstrap)| 69/udp    | `enp3s0`                  | Stage-1 iPXE loader               |
-| HTTP boot files     | 8080/tcp  | `enp3s0`                  | Avoids Caddy on 80                |
-| Web admin UI        | 3000/tcp  | `enp3s0` + `tailscale0`   | No auth -- keep off public nets   |
+| Service             | Host port | Bound to                                | Defense-in-depth firewall |
+| ------------------- | --------- | --------------------------------------- | ------------------------- |
+| TFTP (PXE)          | 69/udp    | `192.168.168.1`                         | `enp3s0` only             |
+| HTTP boot files     | 8080/tcp  | `192.168.168.1`                         | `enp3s0` only             |
+| Web admin UI        | 3000/tcp  | `192.168.168.1` + `100.64.187.14` (TS)  | `enp3s0` + `tailscale0`   |
 
-State: `/srv/netboot.xyz/{config,assets}`, owned `1000:100` to match the
-existing NFS export convention.
+**Listener-binding is the primary control.** srv's kvm module installs
+an `iptables -A INPUT -j ACCEPT` rule (needed for inter-bridge routing)
+that bypasses per-interface firewall scoping. Binding container ports
+to specific host IPs means the unauthenticated admin UI is not reachable
+from libvirt guests on `virbr1..virbr7` -- only from clients that can
+hit `192.168.168.1` (main LAN) or the Tailscale address.
+
+State lives in `/srv/netboot.xyz/{config,assets}` owned `1000:1000` (the
+upstream container's default uid/gid). The host user can read files
+under that tree without `sudo`; edits to menus over SSH need either
+`sudo` or aligning `server.netbootXyz.pgid` with your primary group.
+
+## TFTP through Docker NAT
+
+The module sets `TFTPD_OPTS=--tftp-single-port` so dnsmasq inside the
+container uses port 69 for both the initial request and the data
+transfer. Without this flag, TFTP fails silently behind Docker NAT
+because modern kernels do not auto-attach the `nf_conntrack_tftp`
+helper, and the ephemeral data ports get dropped on the way back.
+
+Disable via `server.netbootXyz.tftpSinglePort = false;` only if you
+have set up a conntrack helper or run the container on host networking.
 
 ## UniFi DHCP configuration
 
@@ -78,38 +102,57 @@ self-hosted controllers:
 Place at `/srv/unifi/data/sites/default/config.gateway.json` on the
 controller, then **force-provision** the gateway.
 
-### Verify
+## Local mirror (optional)
+
+By default, the iPXE boot files served via TFTP chain-load menus from
+`https://boot.netboot.xyz` over the LAN's internet connection. The
+container also runs a local nginx on port 8080 that can serve the
+mirrored menus + downloaded ISOs, but **upstream menus do not use it
+out of the box** -- you have to redirect them.
+
+To enable local-mirror booting:
+
+1. Open the admin UI (`http://srv:3000`).
+2. Edit `boot.cfg` (under "Boot Configuration"), set:
+   - `live_endpoint = http://192.168.168.1:8080`
+3. Save and re-deploy the menu. Subsequent PXE boots will pull from
+   the local mirror.
+
+Without that override, port 8080 in the firewall is opened but unused.
+Leave it as-is for future flexibility.
+
+## Verify
 
 From a host on the LAN:
 
 ```bash
-# TFTP smoke test
+# TFTP smoke test (single-port mode)
 tftp 192.168.168.1
 > get netboot.xyz.efi /tmp/netboot.xyz.efi
 > quit
 ls -l /tmp/netboot.xyz.efi    # expect ~1MB
 
-# HTTP boot file server
-curl -fsSI http://192.168.168.1:8080/menu.ipxe | head
+# HTTP boot file server (returns 200 once menus are deployed)
+curl -fsSI http://192.168.168.1:8080/menu.ipxe
 
 # Admin UI (LAN or Tailscale)
 xdg-open http://srv:3000
 ```
 
-PXE a real client by setting boot priority to network in firmware, or
-spin up a libvirt VM with `network` first in `<os><boot>` and watch
-TFTP -> iPXE chainload -> netboot.xyz menu.
+End-to-end test: configure a libvirt VM with `<boot dev='network'/>`
+first and watch TFTP -> iPXE chainload -> netboot.xyz menu in the
+viewer.
 
 ## Upgrades
 
-The container tracks `lscr.io/linuxserver/netbootxyz:latest`. To pull a
+The container tracks `ghcr.io/netbootxyz/netbootxyz:latest`. To pull a
 newer image:
 
 ```bash
-sudo docker pull lscr.io/linuxserver/netbootxyz:latest
+sudo docker pull ghcr.io/netbootxyz/netbootxyz:latest
 sudo systemctl restart docker-netboot-xyz
 ```
 
 Pin to a specific tag in `hosts/srv/modules.nix` via
-`server.netbootXyz.image = "lscr.io/linuxserver/netbootxyz:0.7.5";` if
+`server.netbootXyz.image = "ghcr.io/netbootxyz/netbootxyz:0.7.5";` if
 reproducibility matters more than fresh menu data.

--- a/extras/docs/netboot.md
+++ b/extras/docs/netboot.md
@@ -11,8 +11,9 @@ of the upstream catalog) without maintaining local images.
 ```nix
 server.netbootXyz = {
   enable = true;
-  lanAddress = "192.168.168.1";                          # bind TFTP + HTTP boot files here
+  lanAddress = "192.168.168.1";                          # bind TFTP listener here
   adminAddresses = [ "192.168.168.1" "100.64.187.14" ];  # admin UI on LAN + Tailscale
+  blockBridges = [ "virbr+" ];                            # keep libvirt guests out
 };
 ```
 
@@ -22,23 +23,36 @@ the module for the full list.
 
 ## Exposure model
 
-| Service             | Host port | Bound to                                | Defense-in-depth firewall |
-| ------------------- | --------- | --------------------------------------- | ------------------------- |
-| TFTP (PXE)          | 69/udp    | `192.168.168.1`                         | `enp3s0` only             |
-| HTTP boot files     | 8080/tcp  | `192.168.168.1`                         | `enp3s0` only             |
-| Web admin UI        | 3000/tcp  | `192.168.168.1` + `100.64.187.14` (TS)  | `enp3s0` + `tailscale0`   |
+| Service             | Host port | Bound to                                | Reachable from                |
+| ------------------- | --------- | --------------------------------------- | ----------------------------- |
+| TFTP (PXE)          | 69/udp    | `192.168.168.1`                         | main LAN only                 |
+| Web admin UI        | 3000/tcp  | `192.168.168.1` + `100.64.187.14`       | main LAN + Tailscale          |
+| HTTP boot files     | 8080/tcp  | not published (`localMirror` off)       | nowhere -- listener is in-container only |
 
-**Listener-binding is the primary control.** srv's kvm module installs
-an `iptables -A INPUT -j ACCEPT` rule (needed for inter-bridge routing)
-that bypasses per-interface firewall scoping. Binding container ports
-to specific host IPs means the unauthenticated admin UI is not reachable
-from libvirt guests on `virbr1..virbr7` -- only from clients that can
-hit `192.168.168.1` (main LAN) or the Tailscale address.
+Three layers stack:
 
-State lives in `/srv/netboot.xyz/{config,assets}` owned `1000:1000` (the
-upstream container's default uid/gid). The host user can read files
-under that tree without `sudo`; edits to menus over SSH need either
-`sudo` or aligning `server.netbootXyz.pgid` with your primary group.
+1. **Listener-binding (primary).** The container is published only on
+   specific host IPs (`lanAddress` for TFTP, each of `adminAddresses`
+   for the admin UI). The unauthenticated admin UI cannot be reached
+   from any interface whose IP is not in `adminAddresses`.
+
+2. **`blockBridges` PREROUTING bypass.** Docker's published-port DNAT
+   lives in `nat/PREROUTING` with no input-interface predicate, so a
+   libvirt guest routing through srv toward `192.168.168.1` would
+   *otherwise* hit the admin UI before any INPUT/FORWARD ACL runs.
+   `blockBridges = [ "virbr+" ]` installs explicit
+   `nat/PREROUTING -i virbr+ ... -j RETURN` rules that bypass Docker's
+   DNAT for traffic arriving on any libvirt bridge. The kernel then
+   has no listener on `192.168.168.1` and the packet is dropped.
+
+3. **Per-interface firewall (defense-in-depth).** TFTP and the admin
+   UI are also opened in `networking.firewall.interfaces.*`. This
+   scoping is decorative on srv because the kvm module installs an
+   `iptables -A INPUT -j ACCEPT` for routing, but it's correct on
+   hosts without that override and harmless otherwise.
+
+State lives in `/srv/netboot.xyz/{config,assets}` at mode `0750`
+(non-`puid` host users need `sudo` to read menus or cached assets).
 
 ## TFTP through Docker NAT
 
@@ -104,22 +118,23 @@ controller, then **force-provision** the gateway.
 
 ## Local mirror (optional)
 
-By default, the iPXE boot files served via TFTP chain-load menus from
+By default, iPXE boot files served via TFTP chain-load menus from
 `https://boot.netboot.xyz` over the LAN's internet connection. The
-container also runs a local nginx on port 8080 that can serve the
-mirrored menus + downloaded ISOs, but **upstream menus do not use it
-out of the box** -- you have to redirect them.
+container also runs a local nginx that can serve mirrored menus and
+downloaded ISOs from `<lanAddress>:<httpPort>`, but **upstream menus
+do not use it out of the box** and exposing the listener for no reason
+is unused attack surface. The HTTP port is therefore **not** published
+or opened in the firewall by default.
 
 To enable local-mirror booting:
 
-1. Open the admin UI (`http://srv:3000`).
-2. Edit `boot.cfg` (under "Boot Configuration"), set:
+1. Set `server.netbootXyz.localMirror.enable = true;` in
+   `hosts/srv/modules.nix`, rebuild.
+2. Open the admin UI (`http://srv:3000`).
+3. Edit `boot.cfg` (under "Boot Configuration"), set:
    - `live_endpoint = http://192.168.168.1:8080`
-3. Save and re-deploy the menu. Subsequent PXE boots will pull from
+4. Save and re-deploy the menu. Subsequent PXE boots will pull from
    the local mirror.
-
-Without that override, port 8080 in the firewall is opened but unused.
-Leave it as-is for future flexibility.
 
 ## Verify
 
@@ -132,27 +147,45 @@ tftp 192.168.168.1
 > quit
 ls -l /tmp/netboot.xyz.efi    # expect ~1MB
 
-# HTTP boot file server (returns 200 once menus are deployed)
-curl -fsSI http://192.168.168.1:8080/menu.ipxe
-
 # Admin UI (LAN or Tailscale)
 xdg-open http://srv:3000
 ```
 
 End-to-end test: configure a libvirt VM with `<boot dev='network'/>`
-first and watch TFTP -> iPXE chainload -> netboot.xyz menu in the
-viewer.
+first and watch TFTP -> iPXE chainload -> netboot.xyz menu. Note that
+libvirt guests are explicitly blocked by the `blockBridges` rules, so
+PXE booting an in-host VM through srv's netboot service will not work
+-- if you need that, add an exception or PXE-boot the VM from a host
+on the main LAN instead.
 
 ## Upgrades
 
-The container tracks `ghcr.io/netbootxyz/netbootxyz:latest`. To pull a
-newer image:
+The container is digest-pinned in
+`modules/server/netboot-xyz/default.nix`. To pull a newer build, look
+up the new digest and update the module:
 
 ```bash
-sudo docker pull ghcr.io/netbootxyz/netbootxyz:latest
-sudo systemctl restart docker-netboot-xyz
+# 1. Look up the current digest for the moving :latest tag
+TOKEN=$(curl -fsS "https://ghcr.io/token?scope=repository:netbootxyz/netbootxyz:pull" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
+curl -fsSI -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.oci.image.index.v1+json" \
+  "https://ghcr.io/v2/netbootxyz/netbootxyz/manifests/latest" \
+  | grep -i 'docker-content-digest'
+# -> docker-content-digest: sha256:<new digest>
+
+# 2. Update server.netbootXyz.image in modules/server/netboot-xyz/default.nix
+#    to the new sha256:... reference
+
+# 3. Rebuild srv. `just rebuild` (or wherever this flake is consumed).
 ```
 
-Pin to a specific tag in `hosts/srv/modules.nix` via
-`server.netbootXyz.image = "ghcr.io/netbootxyz/netbootxyz:0.7.5";` if
-reproducibility matters more than fresh menu data.
+Or override per host without touching the module default:
+
+```nix
+server.netbootXyz.image = "ghcr.io/netbootxyz/netbootxyz@sha256:<new digest>";
+```
+
+Pinning by digest (rather than `:latest`) means a compromise of the
+upstream registry cannot silently push code into the container without
+this file changing in git.

--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -25,6 +25,7 @@
     ../../modules/apps/cli/zellij
     ../../modules/archetypes/claudeWorkHost
     ../../modules/server/kvm
+    ../../modules/server/netboot-xyz
     ../../modules/server/nfs
     ../../modules/system/caddy
     ../../modules/system/ssh
@@ -108,6 +109,8 @@
         proxyArpInterfaces = [ "ens2" ];
       };
     };
+
+    netbootXyz.enable = true;
 
     nfs = {
       enable = true;

--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -1,4 +1,4 @@
-{ secrets, ... }:
+{ secrets, globals, ... }:
 
 {
   # Import only modules that srv used in nixcfg, plus the cherry-picked
@@ -110,7 +110,18 @@
       };
     };
 
-    netbootXyz.enable = true;
+    netbootXyz = {
+      enable = true;
+      # Bind container ports to specific host IPs. Listener-binding is the
+      # primary exposure control on srv because the kvm module's INPUT-
+      # accept override neuters firewall scoping. LAN ports bind to enp3s0;
+      # admin UI binds LAN + Tailscale.
+      lanAddress = "192.168.168.1";
+      adminAddresses = [
+        "192.168.168.1"
+        globals.hosts.srv.tailscale_ip
+      ];
+    };
 
     nfs = {
       enable = true;

--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -114,13 +114,20 @@
       enable = true;
       # Bind container ports to specific host IPs. Listener-binding is the
       # primary exposure control on srv because the kvm module's INPUT-
-      # accept override neuters firewall scoping. LAN ports bind to enp3s0;
-      # admin UI binds LAN + Tailscale.
+      # accept override neuters per-interface firewall scoping. LAN ports
+      # bind to enp3s0; admin UI binds LAN + Tailscale.
       lanAddress = "192.168.168.1";
       adminAddresses = [
         "192.168.168.1"
         globals.hosts.srv.tailscale_ip
       ];
+      # Docker's published-port DNAT in nat/PREROUTING does not filter by
+      # input interface, so a libvirt guest routing through srv toward
+      # 192.168.168.1 would otherwise reach the unauthenticated admin UI.
+      # blockBridges installs PREROUTING RETURN rules that bypass Docker's
+      # DNAT for traffic arriving on any virbr*, so guest VMs cannot hit
+      # the netboot.xyz listeners.
+      blockBridges = [ "virbr+" ];
     };
 
     nfs = {

--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -112,6 +112,10 @@
 
     netbootXyz = {
       enable = true;
+      # NB: pairs with `virtualisation.docker.daemon.settings.userland-proxy
+      # = false` below. Without that, docker-proxy opens a real userspace
+      # listener on `192.168.168.1:3000` that bypasses the PREROUTING RETURN
+      # rule installed by `blockBridges`.
       # Bind container ports to specific host IPs. Listener-binding is the
       # primary exposure control on srv because the kvm module's INPUT-
       # accept override neuters per-interface firewall scoping. LAN ports
@@ -152,6 +156,16 @@
     };
 
   };
+
+  # Disable docker-proxy on srv: Docker's userspace fallback for published
+  # ports would otherwise open a real listening socket on the published host
+  # IPs (e.g. 192.168.168.1:3000), which a cross-interface guest packet
+  # delivered to INPUT would still hit -- bypassing the nat/PREROUTING
+  # RETURN rules installed by server.netbootXyz.blockBridges. With this
+  # flag off Docker uses iptables NAT exclusively, so the RETURN rule is
+  # actually load-bearing. Scoped to srv because workstations rely on
+  # docker-proxy for localhost-to-published-port patterns in dev.
+  virtualisation.docker.daemon.settings.userland-proxy = false;
 
   apps.cli.restic = {
     enable = true;

--- a/modules/apps/cli/docker/default.nix
+++ b/modules/apps/cli/docker/default.nix
@@ -38,6 +38,9 @@ in
           };
         };
       };
+      # If any module pulls in oci-containers, default it to docker. mkDefault
+      # so a host can switch to podman without flipping this back manually.
+      oci-containers.backend = lib.mkDefault "docker";
     };
 
     # Grant user direct socket access so systemd user services can reach Docker

--- a/modules/server/netboot-xyz/default.nix
+++ b/modules/server/netboot-xyz/default.nix
@@ -54,15 +54,19 @@ let
     }
   ];
 
+  # Wrap interpolations in single quotes so a future hostile/typo'd option
+  # value (e.g. lanAddress = "1.2.3.4; echo pwn") cannot break out of the
+  # iptables argv into shell. iptables itself tolerates quoted args; the
+  # `virbr+` wildcard works inside quotes too.
   bridgeBlockLine =
     iface:
     { proto, port }:
-    "iptables -t nat -I PREROUTING -i ${iface} -d ${cfg.lanAddress} -p ${proto} --dport ${toString port} -j RETURN";
+    "iptables -t nat -I PREROUTING -i '${iface}' -d '${cfg.lanAddress}' -p '${proto}' --dport '${toString port}' -j RETURN";
 
   bridgeBlockStopLine =
     iface:
     { proto, port }:
-    "iptables -t nat -D PREROUTING -i ${iface} -d ${cfg.lanAddress} -p ${proto} --dport ${toString port} -j RETURN 2>/dev/null || true";
+    "iptables -t nat -D PREROUTING -i '${iface}' -d '${cfg.lanAddress}' -p '${proto}' --dport '${toString port}' -j RETURN 2>/dev/null || true";
 
   bridgeBlockEnabled = cfg.blockBridges != [ ] && cfg.lanAddress != "";
 

--- a/modules/server/netboot-xyz/default.nix
+++ b/modules/server/netboot-xyz/default.nix
@@ -1,0 +1,155 @@
+{
+  lib,
+  config,
+  globals,
+  ...
+}:
+let
+  cfg = config.server.netbootXyz;
+in
+{
+  options.server.netbootXyz = {
+    enable = lib.mkEnableOption "netboot.xyz iPXE boot menu server (LinuxServer container)";
+
+    image = lib.mkOption {
+      type = lib.types.str;
+      default = "lscr.io/linuxserver/netbootxyz:latest";
+      description = ''
+        OCI image to run. Pin to a tag (e.g. `:0.7.5`) for reproducible
+        deployments; `:latest` is fine for a personal lab where menu
+        churn is desirable.
+      '';
+    };
+
+    lanInterface = lib.mkOption {
+      type = lib.types.str;
+      default = "enp3s0";
+      description = ''
+        LAN interface on which PXE clients live. TFTP and the boot-file
+        HTTP port are opened on this interface only.
+      '';
+    };
+
+    adminInterfaces = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "enp3s0"
+        "tailscale0"
+      ];
+      description = ''
+        Interfaces on which the web admin UI port is reachable. The UI
+        has no authentication, so restrict to trusted interfaces only.
+      '';
+    };
+
+    tftpPort = lib.mkOption {
+      type = lib.types.port;
+      default = 69;
+      description = "UDP TFTP port for PXE bootstrap.";
+    };
+
+    httpPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8080;
+      description = ''
+        TCP port the container's boot-file HTTP server is published on.
+        Defaults to 8080 to avoid colliding with Caddy on 80. iPXE
+        chainload URLs must include this port.
+      '';
+    };
+
+    adminPort = lib.mkOption {
+      type = lib.types.port;
+      default = 3000;
+      description = "TCP port for the netboot.xyz web admin UI.";
+    };
+
+    stateDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/srv/netboot.xyz";
+      description = ''
+        Host directory for persistent container state. `<stateDir>/config`
+        holds menus and settings, `<stateDir>/assets` holds locally
+        cached ISOs.
+      '';
+    };
+
+    puid = lib.mkOption {
+      type = lib.types.int;
+      default = 1000;
+      description = "PUID env var passed to the LinuxServer container (file ownership inside bind mounts).";
+    };
+
+    pgid = lib.mkOption {
+      type = lib.types.int;
+      default = 100;
+      description = "PGID env var passed to the LinuxServer container.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.virtualisation.docker.enable;
+        message = ''
+          server.netbootXyz.enable = true requires virtualisation.docker.enable = true.
+          Enable apps.cli.docker on this host (or set the Docker option directly).
+        '';
+      }
+    ];
+
+    virtualisation.oci-containers.backend = lib.mkDefault "docker";
+
+    systemd.tmpfiles.settings."10-netboot-xyz" = {
+      "${cfg.stateDir}".d = {
+        mode = "0755";
+        user = toString cfg.puid;
+        group = toString cfg.pgid;
+      };
+      "${cfg.stateDir}/config".d = {
+        mode = "0755";
+        user = toString cfg.puid;
+        group = toString cfg.pgid;
+      };
+      "${cfg.stateDir}/assets".d = {
+        mode = "0755";
+        user = toString cfg.puid;
+        group = toString cfg.pgid;
+      };
+    };
+
+    virtualisation.oci-containers.containers."netboot-xyz" = {
+      inherit (cfg) image;
+      autoStart = true;
+      environment = {
+        PUID = toString cfg.puid;
+        PGID = toString cfg.pgid;
+        TZ = globals.defaults.timeZone;
+      };
+      volumes = [
+        "${cfg.stateDir}/config:/config"
+        "${cfg.stateDir}/assets:/assets"
+      ];
+      ports = [
+        "${toString cfg.adminPort}:3000"
+        "${toString cfg.tftpPort}:69/udp"
+        "${toString cfg.httpPort}:80"
+      ];
+    };
+
+    # mkMerge (not `//`) so an interface listed in both lanInterface and
+    # adminInterfaces (the default for enp3s0) gets its TCP port lists
+    # concatenated rather than overwritten.
+    networking.firewall.interfaces = lib.mkMerge [
+      {
+        ${cfg.lanInterface} = {
+          allowedUDPPorts = [ cfg.tftpPort ];
+          allowedTCPPorts = [ cfg.httpPort ];
+        };
+      }
+      (lib.genAttrs cfg.adminInterfaces (_: {
+        allowedTCPPorts = [ cfg.adminPort ];
+      }))
+    ];
+  };
+}

--- a/modules/server/netboot-xyz/default.nix
+++ b/modules/server/netboot-xyz/default.nix
@@ -32,6 +32,47 @@ let
       [ (bindSpec "" cfg.adminPort 3000 "") ]
     else
       map (ip: bindSpec ip cfg.adminPort 3000 "") cfg.adminAddresses;
+
+  # Ports this module wants to block from a given interface pattern via a
+  # nat/PREROUTING RETURN, so Docker's published-port DNAT (which has no
+  # input-interface predicate) doesn't expose the listeners to traffic
+  # arriving on bridges we don't trust.
+  bridgeBlockPorts = [
+    {
+      proto = "tcp";
+      port = cfg.adminPort;
+    }
+  ]
+  ++ lib.optional cfg.localMirror.enable {
+    proto = "tcp";
+    port = cfg.httpPort;
+  }
+  ++ [
+    {
+      proto = "udp";
+      port = cfg.tftpPort;
+    }
+  ];
+
+  bridgeBlockLine =
+    iface:
+    { proto, port }:
+    "iptables -t nat -I PREROUTING -i ${iface} -d ${cfg.lanAddress} -p ${proto} --dport ${toString port} -j RETURN";
+
+  bridgeBlockStopLine =
+    iface:
+    { proto, port }:
+    "iptables -t nat -D PREROUTING -i ${iface} -d ${cfg.lanAddress} -p ${proto} --dport ${toString port} -j RETURN 2>/dev/null || true";
+
+  bridgeBlockEnabled = cfg.blockBridges != [ ] && cfg.lanAddress != "";
+
+  bridgeBlockCommands = lib.concatStringsSep "\n" (
+    lib.concatMap (iface: map (bridgeBlockLine iface) bridgeBlockPorts) cfg.blockBridges
+  );
+
+  bridgeBlockStopCommands = lib.concatStringsSep "\n" (
+    lib.concatMap (iface: map (bridgeBlockStopLine iface) bridgeBlockPorts) cfg.blockBridges
+  );
 in
 {
   options.server.netbootXyz = {
@@ -39,11 +80,17 @@ in
 
     image = lib.mkOption {
       type = lib.types.str;
-      default = "ghcr.io/netbootxyz/netbootxyz:latest";
+      # Digest-pinned to ghcr.io/netbootxyz/netbootxyz:latest as of 2026-05-27
+      # (tag 0.7.6-nbxyz23). Bump by looking up the new digest, e.g.
+      #   docker manifest inspect ghcr.io/netbootxyz/netbootxyz:latest | head
+      # and updating both this default and the docs upgrade snippet.
+      default = "ghcr.io/netbootxyz/netbootxyz@sha256:39bb40c85d1f6e500b3df1871460f88609215735c224b234b9e6e4e849faf92b";
       description = ''
-        OCI image to run. Defaults to the official upstream image. Pin to a
-        tag (e.g. `:0.7.5`) for reproducible deployments; `:latest` is fine
-        for a personal lab where menu churn is desirable.
+        OCI image to run. Defaults to a digest-pinned reference of the
+        official upstream image. Bump the digest when you want a newer
+        build -- a floating `:latest` tag would let a compromised
+        upstream silently push code that runs root-equivalent inside
+        the container with a bind mount on `/config` and `/assets`.
       '';
     };
 
@@ -76,11 +123,12 @@ in
       default = "";
       example = "192.168.168.1";
       description = ''
-        Host IP to bind the LAN-facing container ports (TFTP and boot-file
-        HTTP) to. Empty means Docker binds 0.0.0.0 and host-firewall
-        scoping is the only exposure control -- not safe on hosts that
-        otherwise have a permissive INPUT chain (e.g. KVM routing). Set
-        to the IP of `lanInterface` for proper isolation.
+        Host IP to bind the LAN-facing container ports (TFTP and, if
+        `localMirror.enable`, the boot-file HTTP port) to. Empty means
+        Docker binds 0.0.0.0 and host-firewall scoping is the only
+        exposure control -- not safe on hosts that otherwise have a
+        permissive INPUT chain (e.g. KVM routing). Set to the IP of
+        `lanInterface` for proper isolation.
       '';
     };
 
@@ -98,6 +146,21 @@ in
       '';
     };
 
+    blockBridges = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "virbr+" ];
+      description = ''
+        Bridge interface patterns whose source traffic must NOT be able
+        to reach the container's published ports via Docker's DNAT.
+        Each pattern gets a `nat/PREROUTING -j RETURN` rule that bypasses
+        Docker's port DNAT for packets arriving on that bridge, so e.g.
+        libvirt guests cannot hit the unauthenticated admin UI even
+        though the host's INPUT chain is otherwise permissive. Requires
+        `lanAddress` to be set (the rules match on destination IP).
+      '';
+    };
+
     tftpPort = lib.mkOption {
       type = lib.types.port;
       default = 69;
@@ -109,10 +172,9 @@ in
       default = 8080;
       description = ''
         TCP port the container's boot-file HTTP server is published on.
-        Defaults to 8080 to avoid colliding with Caddy on 80. Only useful
-        if you configure local-mirror menus -- see
-        `extras/docs/netboot.md` for how to point `boot.cfg` at this
-        endpoint.
+        Defaults to 8080 to avoid colliding with Caddy on 80. Only
+        published and opened in the firewall when
+        `localMirror.enable = true`.
       '';
     };
 
@@ -122,13 +184,28 @@ in
       description = "TCP port for the netboot.xyz web admin UI.";
     };
 
+    localMirror.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Publish the container's nginx (boot-file HTTP) port and open it
+        in the firewall. Only useful once you've edited the admin UI's
+        `boot.cfg` so `live_endpoint = http://<lanAddress>:<httpPort>`.
+        Until then the listener is reachable LAN-wide but does nothing,
+        so it's gated off by default to avoid exposing an unused
+        attack surface (any future nginx CVE in the container build
+        would otherwise be unauthenticated-reachable).
+      '';
+    };
+
     stateDir = lib.mkOption {
       type = lib.types.str;
       default = "/srv/netboot.xyz";
       description = ''
         Host directory for persistent container state. `<stateDir>/config`
         holds menus and settings, `<stateDir>/assets` holds locally
-        cached ISOs.
+        cached ISOs. Created with mode 0750 so non-`puid` host users
+        can't read menus or cached assets without `sudo`.
       '';
     };
 
@@ -176,21 +253,28 @@ in
           Enable apps.cli.docker on this host (or set the Docker option directly).
         '';
       }
+      {
+        assertion = cfg.blockBridges == [ ] || cfg.lanAddress != "";
+        message = ''
+          server.netbootXyz.blockBridges requires server.netbootXyz.lanAddress to be
+          set -- the PREROUTING RETURN rules need a destination IP to match against.
+        '';
+      }
     ];
 
     systemd.tmpfiles.settings."10-netboot-xyz" = {
       "${cfg.stateDir}".d = {
-        mode = "0755";
+        mode = "0750";
         user = toString cfg.puid;
         group = toString cfg.pgid;
       };
       "${cfg.stateDir}/config".d = {
-        mode = "0755";
+        mode = "0750";
         user = toString cfg.puid;
         group = toString cfg.pgid;
       };
       "${cfg.stateDir}/assets".d = {
-        mode = "0755";
+        mode = "0750";
         user = toString cfg.puid;
         group = toString cfg.pgid;
       };
@@ -216,21 +300,22 @@ in
       ];
       ports = [
         (bindSpec cfg.lanAddress cfg.tftpPort 69 "udp")
-        (bindSpec cfg.lanAddress cfg.httpPort 80 "")
       ]
+      ++ lib.optional cfg.localMirror.enable (bindSpec cfg.lanAddress cfg.httpPort 80 "")
       ++ adminPortMappings;
     };
 
     # mkMerge (not `//`) so an interface listed in both lanInterface and
     # adminInterfaces (the default for enp3s0) gets its TCP port lists
-    # concatenated rather than overwritten. Note: on a host whose INPUT
-    # chain is already permissively open (e.g. KVM routing), per-interface
-    # firewall scoping is decorative -- the listener-binding controlled by
-    # lanAddress / adminAddresses is the primary exposure control.
+    # concatenated rather than overwritten. Listener-binding via
+    # lanAddress / adminAddresses is the primary exposure control; this
+    # firewall scope is defense-in-depth.
     networking.firewall.interfaces = lib.mkMerge [
       {
         ${cfg.lanInterface} = {
           allowedUDPPorts = [ cfg.tftpPort ];
+        }
+        // lib.optionalAttrs cfg.localMirror.enable {
           allowedTCPPorts = [ cfg.httpPort ];
         };
       }
@@ -238,5 +323,16 @@ in
         allowedTCPPorts = [ cfg.adminPort ];
       }))
     ];
+
+    # Block libvirt-bridge traffic from reaching the container's published
+    # ports. Docker's DNAT lives in nat/PREROUTING with no input-interface
+    # predicate, so without these rules a guest VM that routes through srv
+    # toward `lanAddress` would hit the unauthenticated admin UI before
+    # any INPUT/FORWARD ACL runs. RETURN bypasses Docker's chain for that
+    # source; the kernel then tries to deliver locally, finds no listener
+    # on lanAddress (Docker's listener is on docker0), and the packet is
+    # dropped by the firewall.
+    networking.firewall.extraCommands = lib.mkIf bridgeBlockEnabled bridgeBlockCommands;
+    networking.firewall.extraStopCommands = lib.mkIf bridgeBlockEnabled bridgeBlockStopCommands;
   };
 }

--- a/modules/server/netboot-xyz/default.nix
+++ b/modules/server/netboot-xyz/default.nix
@@ -8,11 +8,19 @@ let
   cfg = config.server.netbootXyz;
 
   # Build a Docker `-p [HOSTIP:]HOSTPORT:CONTAINERPORT[/proto]` token.
-  # When hostIp is empty, Docker binds to 0.0.0.0 (the default).
+  # When hostIp is empty, Docker binds to 0.0.0.0 (the default). IPv6
+  # literals must be bracketed so Docker doesn't mis-parse the colons.
   bindSpec =
     hostIp: hostPort: containerPort: proto:
     let
-      prefix = if hostIp == "" then "" else "${hostIp}:";
+      isIpv6 = lib.hasInfix ":" hostIp;
+      prefix =
+        if hostIp == "" then
+          ""
+        else if isIpv6 then
+          "[${hostIp}]:"
+        else
+          "${hostIp}:";
       suffix = if proto == "" then "" else "/${proto}";
     in
     "${prefix}${toString hostPort}:${toString containerPort}${suffix}";
@@ -191,11 +199,16 @@ in
     virtualisation.oci-containers.containers."netboot-xyz" = {
       inherit (cfg) image;
       autoStart = true;
+      # TFTPD_OPTS is only set when the toggle is on -- an empty env var
+      # could be passed as a literal empty arg to dnsmasq inside the
+      # container, which dnsmasq rejects with "bad command line options".
       environment = {
         PUID = toString cfg.puid;
         PGID = toString cfg.pgid;
         TZ = globals.defaults.timeZone;
-        TFTPD_OPTS = lib.optionalString cfg.tftpSinglePort "--tftp-single-port";
+      }
+      // lib.optionalAttrs cfg.tftpSinglePort {
+        TFTPD_OPTS = "--tftp-single-port";
       };
       volumes = [
         "${cfg.stateDir}/config:/config"

--- a/modules/server/netboot-xyz/default.nix
+++ b/modules/server/netboot-xyz/default.nix
@@ -6,18 +6,36 @@
 }:
 let
   cfg = config.server.netbootXyz;
+
+  # Build a Docker `-p [HOSTIP:]HOSTPORT:CONTAINERPORT[/proto]` token.
+  # When hostIp is empty, Docker binds to 0.0.0.0 (the default).
+  bindSpec =
+    hostIp: hostPort: containerPort: proto:
+    let
+      prefix = if hostIp == "" then "" else "${hostIp}:";
+      suffix = if proto == "" then "" else "/${proto}";
+    in
+    "${prefix}${toString hostPort}:${toString containerPort}${suffix}";
+
+  # Admin port may be bound to multiple host IPs (LAN + Tailscale). When
+  # adminAddresses is empty fall back to 0.0.0.0 and rely on firewall scoping.
+  adminPortMappings =
+    if cfg.adminAddresses == [ ] then
+      [ (bindSpec "" cfg.adminPort 3000 "") ]
+    else
+      map (ip: bindSpec ip cfg.adminPort 3000 "") cfg.adminAddresses;
 in
 {
   options.server.netbootXyz = {
-    enable = lib.mkEnableOption "netboot.xyz iPXE boot menu server (LinuxServer container)";
+    enable = lib.mkEnableOption "netboot.xyz iPXE boot menu server";
 
     image = lib.mkOption {
       type = lib.types.str;
-      default = "lscr.io/linuxserver/netbootxyz:latest";
+      default = "ghcr.io/netbootxyz/netbootxyz:latest";
       description = ''
-        OCI image to run. Pin to a tag (e.g. `:0.7.5`) for reproducible
-        deployments; `:latest` is fine for a personal lab where menu
-        churn is desirable.
+        OCI image to run. Defaults to the official upstream image. Pin to a
+        tag (e.g. `:0.7.5`) for reproducible deployments; `:latest` is fine
+        for a personal lab where menu churn is desirable.
       '';
     };
 
@@ -25,8 +43,10 @@ in
       type = lib.types.str;
       default = "enp3s0";
       description = ''
-        LAN interface on which PXE clients live. TFTP and the boot-file
-        HTTP port are opened on this interface only.
+        LAN interface PXE clients live on. TFTP and the boot-file HTTP
+        port are opened on this interface in the host firewall. Pairs
+        with `lanAddress` for defense-in-depth -- listener-binding is
+        the primary control, the firewall is the backstop.
       '';
     };
 
@@ -37,8 +57,36 @@ in
         "tailscale0"
       ];
       description = ''
-        Interfaces on which the web admin UI port is reachable. The UI
-        has no authentication, so restrict to trusted interfaces only.
+        Interfaces on which the web admin UI port is reachable in the host
+        firewall. The UI has no authentication so restrict to trusted
+        interfaces. Pairs with `adminAddresses` for defense-in-depth.
+      '';
+    };
+
+    lanAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      example = "192.168.168.1";
+      description = ''
+        Host IP to bind the LAN-facing container ports (TFTP and boot-file
+        HTTP) to. Empty means Docker binds 0.0.0.0 and host-firewall
+        scoping is the only exposure control -- not safe on hosts that
+        otherwise have a permissive INPUT chain (e.g. KVM routing). Set
+        to the IP of `lanInterface` for proper isolation.
+      '';
+    };
+
+    adminAddresses = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "192.168.168.1"
+        "100.64.187.14"
+      ];
+      description = ''
+        Host IPs to bind the admin UI port to. Empty means Docker binds
+        0.0.0.0 (firewall-only control). Set to the IPs of the admin-
+        accessible interfaces for proper isolation.
       '';
     };
 
@@ -53,8 +101,10 @@ in
       default = 8080;
       description = ''
         TCP port the container's boot-file HTTP server is published on.
-        Defaults to 8080 to avoid colliding with Caddy on 80. iPXE
-        chainload URLs must include this port.
+        Defaults to 8080 to avoid colliding with Caddy on 80. Only useful
+        if you configure local-mirror menus -- see
+        `extras/docs/netboot.md` for how to point `boot.cfg` at this
+        endpoint.
       '';
     };
 
@@ -77,13 +127,35 @@ in
     puid = lib.mkOption {
       type = lib.types.int;
       default = 1000;
-      description = "PUID env var passed to the LinuxServer container (file ownership inside bind mounts).";
+      description = ''
+        PUID env var passed to the container (file ownership inside bind
+        mounts). Defaults to 1000 to match a typical first NixOS normal
+        user. Adjust if your shell user has a different UID.
+      '';
     };
 
     pgid = lib.mkOption {
       type = lib.types.int;
-      default = 100;
-      description = "PGID env var passed to the LinuxServer container.";
+      default = 1000;
+      description = ''
+        PGID env var passed to the container. Defaults to 1000 (matches
+        upstream image default). If you need SSH-side edits to
+        `<stateDir>/config/menus`, either align this to your shell
+        user's primary group, or `chmod g+w` after first run.
+      '';
+    };
+
+    tftpSinglePort = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Pass `--tftp-single-port` to dnsmasq inside the container so all
+        TFTP traffic uses port 69 instead of negotiating an ephemeral
+        data port. Required when the container is reached via Docker NAT
+        (the default) because conntrack does not auto-attach the TFTP
+        helper on modern kernels. Disable only if you have configured a
+        TFTP conntrack helper out-of-band.
+      '';
     };
   };
 
@@ -97,8 +169,6 @@ in
         '';
       }
     ];
-
-    virtualisation.oci-containers.backend = lib.mkDefault "docker";
 
     systemd.tmpfiles.settings."10-netboot-xyz" = {
       "${cfg.stateDir}".d = {
@@ -125,21 +195,25 @@ in
         PUID = toString cfg.puid;
         PGID = toString cfg.pgid;
         TZ = globals.defaults.timeZone;
+        TFTPD_OPTS = lib.optionalString cfg.tftpSinglePort "--tftp-single-port";
       };
       volumes = [
         "${cfg.stateDir}/config:/config"
         "${cfg.stateDir}/assets:/assets"
       ];
       ports = [
-        "${toString cfg.adminPort}:3000"
-        "${toString cfg.tftpPort}:69/udp"
-        "${toString cfg.httpPort}:80"
-      ];
+        (bindSpec cfg.lanAddress cfg.tftpPort 69 "udp")
+        (bindSpec cfg.lanAddress cfg.httpPort 80 "")
+      ]
+      ++ adminPortMappings;
     };
 
     # mkMerge (not `//`) so an interface listed in both lanInterface and
     # adminInterfaces (the default for enp3s0) gets its TCP port lists
-    # concatenated rather than overwritten.
+    # concatenated rather than overwritten. Note: on a host whose INPUT
+    # chain is already permissively open (e.g. KVM routing), per-interface
+    # firewall scoping is decorative -- the listener-binding controlled by
+    # lanAddress / adminAddresses is the primary exposure control.
     networking.firewall.interfaces = lib.mkMerge [
       {
         ${cfg.lanInterface} = {


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge order:** PR 1 of 1 in this autonomous batch.
> This PR is **not** set to auto-merge — review and merge manually.

## Summary
Closes #77: Setup https://netboot.xyz/docs

- feat(server): add netboot.xyz module on srv
  Run the LinuxServer netboot.xyz container on srv so any client on the
  main LAN can iPXE-chainload installers and rescue ISOs without
  maintaining local images. Pre-pinned items (NixOS, Talos, SystemRescue,
  GParted Live, Memtest86+, Clonezilla, Ubuntu LTS) are all in the
  upstream netboot.xyz default menu, so no custom .ipxe is shipped.
  
  - modules/server/netboot-xyz/default.nix: new module under server.netbootXyz
    namespace; OCI container backed by lscr.io/linuxserver/netbootxyz, options
    for ports, interfaces, state directory, PUID/PGID. Per-interface firewall
    scoping via lib.mkMerge so an interface appearing in both lanInterface
    and adminInterfaces keeps both port lists.
  - hosts/srv/modules.nix: import the module and enable it (srv manually
    imports modules per its convention).
  - extras/docs/netboot.md: deployment notes plus UniFi DHCP option 66/67
    setup, including a config.gateway.json snippet for arch-conditional
    (BIOS vs UEFI) boot file selection.
