### PR TITLE
yaml-schema-router (Helix/zed)

### DIFF
--- a/modules/apps/cli/helix/default.nix
+++ b/modules/apps/cli/helix/default.nix
@@ -10,6 +10,7 @@
 let
   cfg = config.apps.cli.helix;
   kotlin-lsp = pkgs.callPackage ../kotlin-lsp/build { inherit versions; };
+  yaml-schema-router = pkgs.callPackage ../yaml-schema-router/build { inherit versions; };
 in
 {
   options = {
@@ -52,6 +53,7 @@ in
           statix
           kotlin-lsp
           yaml-language-server
+          yaml-schema-router
         ];
 
         settings = lib.mkMerge [
@@ -135,8 +137,11 @@ in
               command = "${kotlin-lsp}/bin/kotlin-lsp";
             };
             yaml = {
-              command = "yaml-language-server";
-              args = [ "--stdio" ];
+              command = "${yaml-schema-router}/bin/yaml-schema-router";
+              args = [
+                "--lsp-path"
+                "${pkgs.yaml-language-server}/bin/yaml-language-server"
+              ];
               scope = "source.yaml";
             };
           };

--- a/modules/apps/cli/yaml-schema-router/build/default.nix
+++ b/modules/apps/cli/yaml-schema-router/build/default.nix
@@ -4,39 +4,30 @@
   versions,
   ...
 }:
-pkgs.stdenv.mkDerivation {
+pkgs.buildGoModule {
   pname = "yaml-schema-router";
-  inherit (versions.cli.yaml-schema-router) version;
+  inherit (versions.cli.yaml-schema-router) version vendorHash;
 
-  src = pkgs.fetchurl {
-    url = "https://github.com/tepea-code/yaml-schema-router/releases/download/v${versions.cli.yaml-schema-router.version}/yaml-schema-router_${versions.cli.yaml-schema-router.version}_linux_x86_64.tar.gz";
+  src = pkgs.fetchFromGitHub {
+    owner = "tepea-code";
+    repo = "yaml-schema-router";
+    rev = "v${versions.cli.yaml-schema-router.version}";
     inherit (versions.cli.yaml-schema-router) hash;
   };
 
-  nativeBuildInputs = [
-    pkgs.autoPatchelfHook
+  subPackages = [ "cmd/yaml-schema-router" ];
+
+  ldflags = [
+    "-s"
+    "-w"
   ];
-
-  buildInputs = [
-    pkgs.stdenv.cc.cc.lib
-  ];
-
-  sourceRoot = ".";
-
-  dontBuild = true;
-
-  installPhase = ''
-    runHook preInstall
-    install -Dm755 yaml-schema-router $out/bin/yaml-schema-router
-    install -Dm644 LICENSE $out/share/doc/yaml-schema-router/LICENSE
-    install -Dm644 README.md $out/share/doc/yaml-schema-router/README.md
-    runHook postInstall
-  '';
 
   meta = with lib; {
-    description = "Content-based JSON schema routing proxy for yaml-language-server - https://github.com/tepea-code/yaml-schema-router";
+    description = "Content-based JSON schema routing proxy for yaml-language-server";
+    homepage = "https://github.com/tepea-code/yaml-schema-router";
     license = licenses.mit;
+    mainProgram = "yaml-schema-router";
     maintainers = [ ];
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.unix;
   };
 }

--- a/modules/apps/cli/yaml-schema-router/build/default.nix
+++ b/modules/apps/cli/yaml-schema-router/build/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  pkgs,
+  versions,
+  ...
+}:
+pkgs.stdenv.mkDerivation {
+  pname = "yaml-schema-router";
+  inherit (versions.cli.yaml-schema-router) version;
+
+  src = pkgs.fetchurl {
+    url = "https://github.com/tepea-code/yaml-schema-router/releases/download/v${versions.cli.yaml-schema-router.version}/yaml-schema-router_${versions.cli.yaml-schema-router.version}_linux_x86_64.tar.gz";
+    inherit (versions.cli.yaml-schema-router) hash;
+  };
+
+  nativeBuildInputs = [
+    pkgs.autoPatchelfHook
+  ];
+
+  buildInputs = [
+    pkgs.stdenv.cc.cc.lib
+  ];
+
+  sourceRoot = ".";
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 yaml-schema-router $out/bin/yaml-schema-router
+    install -Dm644 LICENSE $out/share/doc/yaml-schema-router/LICENSE
+    install -Dm644 README.md $out/share/doc/yaml-schema-router/README.md
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Content-based JSON schema routing proxy for yaml-language-server - https://github.com/tepea-code/yaml-schema-router";
+    license = licenses.mit;
+    maintainers = [ ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/modules/apps/cli/yaml-schema-router/build/default.nix
+++ b/modules/apps/cli/yaml-schema-router/build/default.nix
@@ -29,5 +29,6 @@ pkgs.buildGoModule {
     mainProgram = "yaml-schema-router";
     maintainers = [ ];
     platforms = platforms.unix;
+    sourceProvenance = with sourceTypes; [ fromSource ];
   };
 }

--- a/modules/apps/cli/yaml-schema-router/default.nix
+++ b/modules/apps/cli/yaml-schema-router/default.nix
@@ -1,0 +1,25 @@
+{
+  pkgs,
+  config,
+  lib,
+  versions,
+  ...
+}:
+
+let
+  cfg = config.apps.cli.yaml-schema-router;
+  yaml-schema-router = pkgs.callPackage ./build { inherit versions; };
+in
+{
+  options = {
+    apps.cli.yaml-schema-router.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable yaml-schema-router - content-based JSON schema routing proxy for yaml-language-server.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ yaml-schema-router ];
+  };
+}

--- a/modules/apps/gui/zed/default.nix
+++ b/modules/apps/gui/zed/default.nix
@@ -9,6 +9,7 @@
 let
   cfg = config.apps.gui.zed;
   kotlin-lsp = pkgs.callPackage ../../cli/kotlin-lsp/build { inherit versions; };
+  yaml-schema-router = pkgs.callPackage ../../cli/yaml-schema-router/build { inherit versions; };
 in
 {
   options = {
@@ -90,6 +91,7 @@ in
           terraform-ls
           vscode-langservers-extracted # JSON/HTML/CSS/ESLint
           yaml-language-server
+          yaml-schema-router
 
           # Formatters and linters
           nixfmt
@@ -272,7 +274,11 @@ in
             };
             yaml-language-server = {
               binary = {
-                path = "${pkgs.yaml-language-server}/bin/yaml-language-server";
+                path = "${yaml-schema-router}/bin/yaml-schema-router";
+                arguments = [
+                  "--lsp-path"
+                  "${pkgs.yaml-language-server}/bin/yaml-language-server"
+                ];
               };
             };
             markdown-oxide = {

--- a/settings/versions.nix
+++ b/settings/versions.nix
@@ -207,7 +207,11 @@
       repo = "tepea-code/yaml-schema-router";
       version = "0.2.0";
       tagPrefix = "v";
-      hash = "sha256-kXRkuQuihQrDEwptpCMELvpPCdeho0tniKo4mvdMUfU=";
+      # Source build via buildGoModule; `hash` is the GitHub source archive
+      # for the tag. Upstream has no external Go deps (pure stdlib), so
+      # vendorHash is null.
+      hash = "sha256-GFe5NPW8nxv+bQsG5G26WCf2Z6qrW1WAZBMWFZD8MFI=";
+      vendorHash = null;
     };
 
   };

--- a/settings/versions.nix
+++ b/settings/versions.nix
@@ -202,6 +202,14 @@
       npmDepsHash = "sha256-n+lu7f2rsMEOCnzj1nmzGRZo3WcwhBUeamTexCOs0xM=";
     };
 
+    yaml-schema-router = {
+      source = "github-release";
+      repo = "tepea-code/yaml-schema-router";
+      version = "0.2.0";
+      tagPrefix = "v";
+      hash = "sha256-kXRkuQuihQrDEwptpCMELvpPCdeho0tniKo4mvdMUfU=";
+    };
+
   };
 
   gui = {


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge order:** PR 1 of 2 in an autonomous batch (`/github-issues-auto 79 59`).
> This PR is **not** set to auto-merge — review and merge manually.
> Merge in this order to avoid conflicts:
> 1. #89 — yaml-schema-router (Helix/zed)
> 2. #90 — Git-cliff changelog generation

## Summary
Closes #79: yaml-schema-router (Helix/zed)

- feat(yaml-schema-router): wire content-based YAML schema proxy into Helix and Zed
  Add tepea-code/yaml-schema-router 0.2.0 as a stdio proxy between the
  editor and yaml-language-server. The router inspects file contents
  (apiVersion/kind for K8s, directory context for GH Workflows, etc.) and
  dynamically injects the correct JSON schema, eliminating manual
  `# yaml-language-server: $schema=...` modelines and glob-based mappings.
  
  - New version pin in settings/versions.nix (github-release, prebuilt
    linux x86_64 tarball).
  - New apps.cli.yaml-schema-router module + build derivation following
    the kotlin-lsp pattern (callable standalone or from other modules).
  - Helix: yaml language-server now spawns yaml-schema-router with
    --lsp-path pointing at the nixpkgs yaml-language-server.
  - Zed: same wiring via lsp.yaml-language-server.binary.{path,arguments}.
  
  Closes #79