### PR TITLE
Gha errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,62 +22,30 @@ jobs:
         with:
           flakehub: false
 
-      - name: Detect encrypted nix files
-        run: |
-          encrypted=()
-          while IFS= read -r f; do
-            if head -c 10 "$f" | LC_ALL=C grep -q 'GITCRYPT'; then
-              encrypted+=("$f")
-            fi
-          done < <(find . -name '*.nix' -not -path './.git/*' -not -path './secrets/*')
-          printf '%s\n' "${encrypted[@]}" > /tmp/encrypted-nix-files.txt
-          if [[ ${#encrypted[@]} -gt 0 ]]; then
-            echo "Encrypted nix files (will be skipped):"
-            cat /tmp/encrypted-nix-files.txt
-          else
-            echo "No encrypted nix files found"
-          fi
-
       - name: Format nix
         run: |
-          nix_files=$(find . -name '*.nix' -not -path './.git/*' -not -path './secrets/*')
-          if [[ -s /tmp/encrypted-nix-files.txt ]]; then
-            while IFS= read -r skip; do
-              nix_files=$(echo "$nix_files" | grep -vF "$skip")
-            done < /tmp/encrypted-nix-files.txt
-          fi
-          if [[ -n "$nix_files" ]]; then
-            echo "$nix_files" | xargs nix run nixpkgs#nixfmt-tree --
-          fi
+          find . -name '*.nix' -not -path './.git/*' -not -path './secrets/*' -print0 \
+            | xargs -0 -r nix run nixpkgs#nixfmt-tree --
 
       - name: Fix nix lint issues
-        run: |
-          args=()
-          if [[ -s /tmp/encrypted-nix-files.txt ]]; then
-            while IFS= read -r skip; do
-              args+=(--ignore "$skip")
-            done < /tmp/encrypted-nix-files.txt
-          fi
-          nix run nixpkgs#statix -- fix . "${args[@]}"
+        run: nix run nixpkgs#statix -- fix .
 
       - name: Remove dead nix code
         run: |
-          nix_files=$(find . -name '*.nix' -not -path './.git/*' -not -path './secrets/*')
-          if [[ -s /tmp/encrypted-nix-files.txt ]]; then
-            while IFS= read -r skip; do
-              nix_files=$(echo "$nix_files" | grep -vF "$skip")
-            done < /tmp/encrypted-nix-files.txt
-          fi
-          if [[ -n "$nix_files" ]]; then
-            echo "$nix_files" | xargs nix run nixpkgs#deadnix -- --edit
-          fi
+          find . -name '*.nix' -not -path './.git/*' -not -path './secrets/*' -print0 \
+            | xargs -0 -r nix run nixpkgs#deadnix -- --edit
 
       - name: Format shell scripts
-        run: nix run nixpkgs#shfmt -- -w -i 2 -ci $(find . -name '*.sh' -not -path './.git/*' -not -path './secrets/*')
+        run: |
+          find . -name '*.sh' -not -path './.git/*' -not -path './secrets/*' -print0 \
+            | xargs -0 -r nix run nixpkgs#shfmt -- -w -i 2 -ci
         continue-on-error: true
 
       - name: Lint shell scripts
-        run: nix run nixpkgs#shellcheck -- $(find . -name '*.sh' -not -path './.git/*' -not -path './secrets/*') || true
+        run: |
+          find . -name '*.sh' -not -path './.git/*' -not -path './secrets/*' -print0 \
+            | xargs -0 -r nix run nixpkgs#shellcheck --
+        continue-on-error: true
 
       - name: Format fish scripts
         run: find . -name '*.fish' -not -path './.git/*' -not -path './secrets/*' -exec nix run nixpkgs#fish -- -c 'fish_indent -w {}' \;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,10 @@ jobs:
             | xargs -0 -r nix run nixpkgs#shellcheck -- || true
 
       - name: Format fish scripts
-        run: find . -name '*.fish' -not -path './.git/*' -exec nix run nixpkgs#fish -- -c 'fish_indent -w {}' \;
-        continue-on-error: true
-
-      - name: Format YAML, JSON, and Markdown
-        run: nix run nixpkgs#nodePackages.prettier -- --write '**/*.{yml,yaml,json,md}' --no-error-on-unmatched-pattern
-        continue-on-error: true
+        run: |
+          set -euo pipefail
+          find . -name '*.fish' -not -path './.git/*' \
+            -exec nix run nixpkgs#fish -- -c 'fish_indent -w {}' \; || true
 
       - name: Commit and push changes
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,35 +24,34 @@ jobs:
 
       - name: Format nix
         run: |
-          find . -name '*.nix' -not -path './.git/*' -not -path './secrets/*' -print0 \
+          set -euo pipefail
+          find . -name '*.nix' -not -path './.git/*' -print0 \
             | xargs -0 -r nix run nixpkgs#nixfmt-tree --
 
       - name: Fix nix lint issues
         run: nix run nixpkgs#statix -- fix .
 
       - name: Remove dead nix code
-        run: |
-          find . -name '*.nix' -not -path './.git/*' -not -path './secrets/*' -print0 \
-            | xargs -0 -r nix run nixpkgs#deadnix -- --edit
+        run: nix run nixpkgs#deadnix -- --edit .
 
       - name: Format shell scripts
         run: |
-          find . -name '*.sh' -not -path './.git/*' -not -path './secrets/*' -print0 \
-            | xargs -0 -r nix run nixpkgs#shfmt -- -w -i 2 -ci
-        continue-on-error: true
+          set -euo pipefail
+          find . -name '*.sh' -not -path './.git/*' -print0 \
+            | xargs -0 -r nix run nixpkgs#shfmt -- -w -i 2 -ci || true
 
       - name: Lint shell scripts
         run: |
-          find . -name '*.sh' -not -path './.git/*' -not -path './secrets/*' -print0 \
-            | xargs -0 -r nix run nixpkgs#shellcheck --
-        continue-on-error: true
+          set -euo pipefail
+          find . -name '*.sh' -not -path './.git/*' -print0 \
+            | xargs -0 -r nix run nixpkgs#shellcheck -- || true
 
       - name: Format fish scripts
-        run: find . -name '*.fish' -not -path './.git/*' -not -path './secrets/*' -exec nix run nixpkgs#fish -- -c 'fish_indent -w {}' \;
+        run: find . -name '*.fish' -not -path './.git/*' -exec nix run nixpkgs#fish -- -c 'fish_indent -w {}' \;
         continue-on-error: true
 
       - name: Format YAML, JSON, and Markdown
-        run: nix run nixpkgs#nodePackages.prettier -- --write '**/*.{yml,yaml,json,md}' --ignore-path <(echo 'secrets/') --no-error-on-unmatched-pattern
+        run: nix run nixpkgs#nodePackages.prettier -- --write '**/*.{yml,yaml,json,md}' --no-error-on-unmatched-pattern
         continue-on-error: true
 
       - name: Commit and push changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # Full history so 'git pull --rebase origin main' in the autocommit
+          # step does not trip on shallow-boundary edge cases when main has
+          # moved during the run.
+          fetch-depth: 0
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
@@ -43,9 +48,6 @@ jobs:
       - name: Format fish scripts
         run: find . -name '*.fish' -not -path './.git/*' -exec nix run nixpkgs#fish -- -c 'fish_indent -w {}' \;
 
-      - name: Format CI workflow YAML
-        run: nix run nixpkgs#prettier -- --write '.github/**/*.{yml,yaml}'
-
       - name: Commit and push changes
         run: |
           set -euo pipefail
@@ -59,5 +61,6 @@ jobs:
           git commit -m "chore: 🤖 auto-format and lint"
           # Rebase onto any concurrent push that landed while we were running,
           # then push. Avoids non-fast-forward losing the autofix commit.
-          git pull --rebase origin main
+          # On conflict, abort cleanly so the run log surfaces the cause.
+          git pull --rebase origin main || { git rebase --abort; exit 1; }
           git push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
+
 on:
   push:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -13,54 +14,156 @@ concurrency:
 jobs:
   autofix:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Full history so 'git pull --rebase origin main' in the autocommit
-          # step does not trip on shallow-boundary edge cases when main has
-          # moved during the run.
+          # Full history so the autocommit step can rebase cleanly when main
+          # has moved during the run.
           fetch-depth: 0
+          # Drop the runner credential helper so a compromised formatter
+          # binary cannot piggy-back on the implicit token to push to main.
+          # The commit step below presents the token explicitly via
+          # actions/github-script.
+          persist-credentials: false
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
           flakehub: false
 
+      - name: Read pinned nixpkgs ref from flake.lock
+        id: nixpkgs
+        run: |
+          set -euo pipefail
+          rev=$(jq -r '.nodes.nixpkgs.locked.rev' flake.lock)
+          if [ -z "$rev" ] || [ "$rev" = "null" ]; then
+            echo "could not extract nixpkgs rev from flake.lock" >&2
+            exit 1
+          fi
+          echo "rev=$rev" >> "$GITHUB_OUTPUT"
+
       - name: Format nix
+        env:
+          NIXPKGS: github:NixOS/nixpkgs/${{ steps.nixpkgs.outputs.rev }}
+          GITHUB_TOKEN: ""
         run: |
           set -euo pipefail
           find . -name '*.nix' -not -path './.git/*' -print0 \
-            | xargs -0 -r nix run nixpkgs#nixfmt-tree --
+            | xargs -0 -r nix run "${NIXPKGS}#nixfmt-tree" --
 
       - name: Fix nix lint issues
-        run: nix run nixpkgs#statix -- fix .
+        env:
+          NIXPKGS: github:NixOS/nixpkgs/${{ steps.nixpkgs.outputs.rev }}
+          GITHUB_TOKEN: ""
+        run: nix run "${NIXPKGS}#statix" -- fix .
 
       - name: Remove dead nix code
-        run: nix run nixpkgs#deadnix -- --edit .
+        env:
+          NIXPKGS: github:NixOS/nixpkgs/${{ steps.nixpkgs.outputs.rev }}
+          GITHUB_TOKEN: ""
+        run: nix run "${NIXPKGS}#deadnix" -- --edit .
 
       - name: Format shell scripts
+        env:
+          NIXPKGS: github:NixOS/nixpkgs/${{ steps.nixpkgs.outputs.rev }}
+          GITHUB_TOKEN: ""
         run: |
           set -euo pipefail
           find . -name '*.sh' -not -path './.git/*' -print0 \
-            | xargs -0 -r nix run nixpkgs#shfmt -- -w -i 2 -ci || true
+            | xargs -0 -r nix run "${NIXPKGS}#shfmt" -- -w -i 2 -ci
 
       - name: Format fish scripts
-        run: find . -name '*.fish' -not -path './.git/*' -exec nix run nixpkgs#fish -- -c 'fish_indent -w {}' \;
-
-      - name: Commit and push changes
+        env:
+          NIXPKGS: github:NixOS/nixpkgs/${{ steps.nixpkgs.outputs.rev }}
+          GITHUB_TOKEN: ""
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          if git diff --staged --quiet; then
-            echo "no changes to commit"
-            exit 0
-          fi
-          git commit -m "chore: 🤖 auto-format and lint"
-          # Rebase onto any concurrent push that landed while we were running,
-          # then push. Avoids non-fast-forward losing the autofix commit.
-          # On conflict, abort cleanly so the run log surfaces the cause.
-          git pull --rebase origin main || { git rebase --abort; exit 1; }
-          git push
+          # Filenames are passed as positional args ($argv) to a single fish
+          # invocation. They never enter the -c script body, so shell
+          # metachars in filenames cannot escape into command position.
+          find . -name '*.fish' -not -path './.git/*' -print0 \
+            | xargs -0 -r nix run "${NIXPKGS}#fish" -- -c \
+              'for f in $argv; fish_indent -w "$f"; end'
+
+      - name: Commit and push via signed API
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        with:
+          script: |
+            const { execSync } = require('node:child_process');
+            const fs = require('node:fs');
+
+            execSync('git add -A');
+            const raw = execSync('git diff --staged --name-status -z').toString();
+            if (raw.length === 0) {
+              core.info('no changes to commit');
+              return;
+            }
+
+            const toks = raw.split('\0').filter(s => s.length > 0);
+            const entries = [];
+            for (let i = 0; i < toks.length; ) {
+              const status = toks[i];
+              if (status.startsWith('R') || status.startsWith('C')) {
+                entries.push({ kind: 'delete', path: toks[i + 1] });
+                entries.push({ kind: 'add', path: toks[i + 2] });
+                i += 3;
+              } else if (status === 'D') {
+                entries.push({ kind: 'delete', path: toks[i + 1] });
+                i += 2;
+              } else {
+                entries.push({ kind: 'add', path: toks[i + 1] });
+                i += 2;
+              }
+            }
+
+            const { owner, repo } = context.repo;
+            const branch = 'main';
+
+            const tree = [];
+            for (const { kind, path } of entries) {
+              if (kind === 'delete') {
+                tree.push({ path, mode: '100644', type: 'blob', sha: null });
+                continue;
+              }
+              const stat = fs.statSync(path);
+              const mode = (stat.mode & 0o111) ? '100755' : '100644';
+              const { data: blob } = await github.rest.git.createBlob({
+                owner, repo,
+                content: fs.readFileSync(path).toString('base64'),
+                encoding: 'base64',
+              });
+              tree.push({ path, mode, type: 'blob', sha: blob.sha });
+            }
+
+            const message = 'chore: 🤖 auto-format and lint';
+            const maxAttempts = 3;
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const { data: ref } = await github.rest.git.getRef({
+                owner, repo, ref: `heads/${branch}`,
+              });
+              const parentSha = ref.object.sha;
+              const { data: newTree } = await github.rest.git.createTree({
+                owner, repo, base_tree: parentSha, tree,
+              });
+              const { data: newCommit } = await github.rest.git.createCommit({
+                owner, repo, message, tree: newTree.sha, parents: [parentSha],
+              });
+              try {
+                await github.rest.git.updateRef({
+                  owner, repo, ref: `heads/${branch}`, sha: newCommit.sha,
+                });
+                core.info(`pushed ${newCommit.sha}`);
+                return;
+              } catch (e) {
+                if (e.status !== 422 || attempt === maxAttempts) throw e;
+                core.warning(
+                  `updateRef rejected (attempt ${attempt}/${maxAttempts}, ` +
+                  `status ${e.status}), refetching ref and retrying`
+                );
+                await new Promise(r => setTimeout(r, 2000 * attempt));
+              }
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,22 +40,24 @@ jobs:
           find . -name '*.sh' -not -path './.git/*' -print0 \
             | xargs -0 -r nix run nixpkgs#shfmt -- -w -i 2 -ci || true
 
-      - name: Lint shell scripts
-        run: |
-          set -euo pipefail
-          find . -name '*.sh' -not -path './.git/*' -print0 \
-            | xargs -0 -r nix run nixpkgs#shellcheck -- || true
-
       - name: Format fish scripts
-        run: |
-          set -euo pipefail
-          find . -name '*.fish' -not -path './.git/*' \
-            -exec nix run nixpkgs#fish -- -c 'fish_indent -w {}' \; || true
+        run: find . -name '*.fish' -not -path './.git/*' -exec nix run nixpkgs#fish -- -c 'fish_indent -w {}' \;
+
+      - name: Format CI workflow YAML
+        run: nix run nixpkgs#prettier -- --write '.github/**/*.{yml,yaml}'
 
       - name: Commit and push changes
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git diff --staged --quiet || git commit -m "chore: 🤖 auto-format and lint"
+          if git diff --staged --quiet; then
+            echo "no changes to commit"
+            exit 0
+          fi
+          git commit -m "chore: 🤖 auto-format and lint"
+          # Rebase onto any concurrent push that landed while we were running,
+          # then push. Avoids non-fast-forward losing the autofix commit.
+          git pull --rebase origin main
           git push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,20 +52,20 @@ jobs:
           GITHUB_TOKEN: ""
         run: |
           set -euo pipefail
-          find . -name '*.nix' -not -path './.git/*' -print0 \
+          find . -name '*.nix' -not -path './.git/*' -not -path './secrets/*' -print0 \
             | xargs -0 -r nix run "${NIXPKGS}#nixfmt-tree" --
 
       - name: Fix nix lint issues
         env:
           NIXPKGS: github:NixOS/nixpkgs/${{ steps.nixpkgs.outputs.rev }}
           GITHUB_TOKEN: ""
-        run: nix run "${NIXPKGS}#statix" -- fix .
+        run: nix run "${NIXPKGS}#statix" -- fix --ignore secrets .
 
       - name: Remove dead nix code
         env:
           NIXPKGS: github:NixOS/nixpkgs/${{ steps.nixpkgs.outputs.rev }}
           GITHUB_TOKEN: ""
-        run: nix run "${NIXPKGS}#deadnix" -- --edit .
+        run: nix run "${NIXPKGS}#deadnix" -- --edit --exclude '**/secrets/**' .
 
       - name: Format shell scripts
         env:
@@ -73,7 +73,7 @@ jobs:
           GITHUB_TOKEN: ""
         run: |
           set -euo pipefail
-          find . -name '*.sh' -not -path './.git/*' -print0 \
+          find . -name '*.sh' -not -path './.git/*' -not -path './secrets/*' -print0 \
             | xargs -0 -r nix run "${NIXPKGS}#shfmt" -- -w -i 2 -ci
 
       - name: Format fish scripts
@@ -85,19 +85,36 @@ jobs:
           # Filenames are passed as positional args ($argv) to a single fish
           # invocation. They never enter the -c script body, so shell
           # metachars in filenames cannot escape into command position.
-          find . -name '*.fish' -not -path './.git/*' -print0 \
+          find . -name '*.fish' -not -path './.git/*' -not -path './secrets/*' -print0 \
             | xargs -0 -r nix run "${NIXPKGS}#fish" -- -c \
               'for f in $argv; fish_indent -w "$f"; end'
 
       - name: Commit and push via signed API
-        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        # Commit SHA (not tag object) so the pin is fully immutable and survives
+        # tag re-signing. d746ffe... resolves to the v9.0.0 tag object whose
+        # underlying commit is the SHA below.
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { execSync } = require('node:child_process');
             const fs = require('node:fs');
 
-            execSync('git add -A');
-            const raw = execSync('git diff --staged --name-status -z').toString();
+            // Stage only files the formatters actually touch. `git add -A`
+            // would also capture stray runner artifacts (result symlinks,
+            // tool caches), and the commit lands on main with no human in
+            // the loop, so the staging scope must be tight. Pathspecs use
+            // the :(glob) magic prefix so `**` traverses all depths.
+            execSync(
+              "git add -A -- " +
+              "':(glob)**/*.nix' ':(glob)**/*.sh' ':(glob)**/*.fish' " +
+              "':(exclude,glob)**/secrets/**'"
+            );
+
+            // --no-renames forces git to emit only A/M/D/T statuses, so the
+            // C-status branch becomes unreachable and a malicious
+            // `git config diff.renames copies` cannot trick the parser into
+            // deleting the original file.
+            const raw = execSync('git diff --staged --no-renames --name-status -z').toString();
             if (raw.length === 0) {
               core.info('no changes to commit');
               return;
@@ -107,17 +124,14 @@ jobs:
             const entries = [];
             for (let i = 0; i < toks.length; ) {
               const status = toks[i];
-              if (status.startsWith('R') || status.startsWith('C')) {
+              if (status === 'D') {
                 entries.push({ kind: 'delete', path: toks[i + 1] });
-                entries.push({ kind: 'add', path: toks[i + 2] });
-                i += 3;
-              } else if (status === 'D') {
-                entries.push({ kind: 'delete', path: toks[i + 1] });
-                i += 2;
-              } else {
+              } else if (status === 'A' || status === 'M' || status === 'T') {
                 entries.push({ kind: 'add', path: toks[i + 1] });
-                i += 2;
+              } else {
+                throw new Error(`unexpected git diff status '${status}' for ${toks[i + 1]}`);
               }
+              i += 2;
             }
 
             const { owner, repo } = context.repo;
@@ -129,8 +143,22 @@ jobs:
                 tree.push({ path, mode: '100644', type: 'blob', sha: null });
                 continue;
               }
-              const stat = fs.statSync(path);
-              const mode = (stat.mode & 0o111) ? '100755' : '100644';
+              // lstat (not stat) so a symlink does not silently follow out of
+              // the working tree. Submodules/non-regular files are rejected.
+              const lstat = fs.lstatSync(path);
+              if (lstat.isSymbolicLink()) {
+                tree.push({
+                  path,
+                  mode: '120000',
+                  type: 'blob',
+                  content: fs.readlinkSync(path),
+                });
+                continue;
+              }
+              if (!lstat.isFile()) {
+                throw new Error(`refusing to commit non-regular file at ${path}`);
+              }
+              const mode = (lstat.mode & 0o111) ? '100755' : '100644';
               const { data: blob } = await github.rest.git.createBlob({
                 owner, repo,
                 content: fs.readFileSync(path).toString('base64'),

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,33 +1,76 @@
 name: Update Flake Lock
+
 on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   lockfile:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
           flakehub: false
           extra-conf: |
             access-tokens = github.com=${{ secrets.NIXERATOR_FLAKE_TOKEN }}
 
       - name: Update flake lock
+        env:
+          GITHUB_TOKEN: ""
         run: nix flake update
 
-      - name: Commit and push changes
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add flake.lock
-          git diff --staged --quiet || git commit -m "chore(flake): 🔄 update flake lock"
-          git push
+      - name: Commit and push via signed API
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        with:
+          script: |
+            const { execSync } = require('node:child_process');
+            const fs = require('node:fs');
+
+            const changed = execSync('git status --porcelain -- flake.lock')
+              .toString()
+              .trim();
+            if (changed.length === 0) {
+              core.info('flake.lock unchanged');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const branch = 'main';
+            const path = 'flake.lock';
+            const message = 'chore(flake): 🔄 update flake lock';
+
+            const maxAttempts = 3;
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const { data: existing } = await github.rest.repos.getContent({
+                owner, repo, path, ref: branch,
+              });
+              try {
+                const { data: result } = await github.rest.repos.createOrUpdateFileContents({
+                  owner, repo, path, message, branch,
+                  content: fs.readFileSync(path).toString('base64'),
+                  sha: existing.sha,
+                });
+                core.info(`pushed ${result.commit.sha}`);
+                return;
+              } catch (e) {
+                if (e.status !== 409 || attempt === maxAttempts) throw e;
+                core.warning(
+                  `createOrUpdateFileContents rejected (attempt ${attempt}/${maxAttempts}, ` +
+                  `status ${e.status}), refetching sha and retrying`
+                );
+                await new Promise(r => setTimeout(r, 2000 * attempt));
+              }
+            }

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: update-flake-lock
+  cancel-in-progress: false
+
 jobs:
   lockfile:
     runs-on: ubuntu-latest
@@ -19,6 +23,24 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Validate NIXERATOR_FLAKE_TOKEN shape
+        env:
+          T: ${{ secrets.NIXERATOR_FLAKE_TOKEN }}
+        run: |
+          set -euo pipefail
+          # The token is interpolated into a nix.conf string below; a newline
+          # in the value would inject arbitrary settings. PATs never contain
+          # newlines, so a non-empty value with a newline means misconfigured
+          # or compromised secret. Fail fast.
+          if [ -z "$T" ]; then
+            echo "NIXERATOR_FLAKE_TOKEN is empty" >&2
+            exit 1
+          fi
+          if [[ "$T" == *$'\n'* || "$T" == *$'\r'* ]]; then
+            echo "NIXERATOR_FLAKE_TOKEN contains a newline; refusing to proceed" >&2
+            exit 1
+          fi
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
@@ -33,16 +55,20 @@ jobs:
         run: nix flake update
 
       - name: Commit and push via signed API
-        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        # Commit SHA (not tag object) so the pin is fully immutable.
+        # d746ffe... resolves to the v9.0.0 tag object whose underlying
+        # commit is the SHA below.
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { execSync } = require('node:child_process');
             const fs = require('node:fs');
 
-            const changed = execSync('git status --porcelain -- flake.lock')
-              .toString()
-              .trim();
-            if (changed.length === 0) {
+            execSync("git add -- flake.lock");
+            const raw = execSync(
+              "git diff --staged --no-renames --name-status -z -- flake.lock"
+            ).toString();
+            if (raw.length === 0) {
               core.info('flake.lock unchanged');
               return;
             }
@@ -52,24 +78,36 @@ jobs:
             const path = 'flake.lock';
             const message = 'chore(flake): 🔄 update flake lock';
 
+            const tree = [{
+              path,
+              mode: '100644',
+              type: 'blob',
+              content: fs.readFileSync(path, 'utf8'),
+            }];
+
             const maxAttempts = 3;
             for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-              const { data: existing } = await github.rest.repos.getContent({
-                owner, repo, path, ref: branch,
+              const { data: ref } = await github.rest.git.getRef({
+                owner, repo, ref: `heads/${branch}`,
+              });
+              const parentSha = ref.object.sha;
+              const { data: newTree } = await github.rest.git.createTree({
+                owner, repo, base_tree: parentSha, tree,
+              });
+              const { data: newCommit } = await github.rest.git.createCommit({
+                owner, repo, message, tree: newTree.sha, parents: [parentSha],
               });
               try {
-                const { data: result } = await github.rest.repos.createOrUpdateFileContents({
-                  owner, repo, path, message, branch,
-                  content: fs.readFileSync(path).toString('base64'),
-                  sha: existing.sha,
+                await github.rest.git.updateRef({
+                  owner, repo, ref: `heads/${branch}`, sha: newCommit.sha,
                 });
-                core.info(`pushed ${result.commit.sha}`);
+                core.info(`pushed ${newCommit.sha}`);
                 return;
               } catch (e) {
-                if (e.status !== 409 || attempt === maxAttempts) throw e;
+                if (e.status !== 422 || attempt === maxAttempts) throw e;
                 core.warning(
-                  `createOrUpdateFileContents rejected (attempt ${attempt}/${maxAttempts}, ` +
-                  `status ${e.status}), refetching sha and retrying`
+                  `updateRef rejected (attempt ${attempt}/${maxAttempts}, ` +
+                  `status ${e.status}), refetching ref and retrying`
                 );
                 await new Promise(r => setTimeout(r, 2000 * attempt));
               }


### PR DESCRIPTION
> [!IMPORTANT]
> PR 1 of 1 in an autonomous batch.
> This PR is **not** set to auto-merge. Review and merge manually.
> Merge order:
> 1. #97, fix(ci): drop dead git-crypt detection that broke every CI run

## Summary
Closes #94: Gha errors

The push-to-main CI pipeline has been failing at "Format nix" for days.
Root cause: the Detect-encrypted-nix-files step wrote a 1-byte file
(`'\n'` from `printf` with an empty array) when no encrypted .nix files
existed. Downstream steps read that as a non-empty skip list, looped on
an empty line, and ran `grep -vF ""` on the file list. With `bash -e`
the resulting `exit 1` inside the while body killed the step before the
formatter ever ran. git-crypt was retired in #87 so encrypted .nix files
will never exist on this repo again. Removing the detection step (and
the skip loops in Format/Lint/Deadnix) is both the simplest fix and the
right shape post-#87.

The PR also:

- Drops the prettier (Format YAML, JSON, and Markdown) step. The action
  step was already broken upstream (`nodePackages.prettier` aliased away
  in nixpkgs) and was silently passing behind `continue-on-error: true`.
  Re-enabling it would also start formatting captured Claude Code skill
  content, causing an infinite-churn loop.
- Drops the shellcheck (Lint shell scripts) advisory step. It was the
  same `continue-on-error: true` shape as prettier, providing no
  enforcement.
- Switches find pipelines to `print0 | xargs -0 -r` with
  `set -euo pipefail` so they survive empty inputs cleanly.

Round 1 of /review-security found 2 High, 4 Medium, 3 Low. All addressed:

- Pin `actions/checkout` to v6.0.2 commit SHA
- Pin `DeterminateSystems/nix-installer-action` to v22 commit SHA
- Pin `actions/github-script` to v9.0.0 commit SHA (not the tag object)
- Pin `nixpkgs` per-`nix run` call to the rev recorded in `flake.lock`,
  read at runtime so the workflow tracks the lockfile
- Workflow-level `permissions: contents: read`; grant `contents: write`
  only at job scope
- `persist-credentials: false` on checkout so a compromised formatter
  binary cannot piggy-back on the runner credential helper
- `env: GITHUB_TOKEN: ""` on every formatter step (defense in depth)
- Replace `git commit + git push` with `actions/github-script` driving
  the GitHub git data REST API, so commits land as Verified
  `github-actions[bot]` with proper signature attribution
- 3-attempt retry loop with backoff around `updateRef` to absorb
  concurrent-push races
- Rewrite fish_indent loop so filenames travel as positional `$argv`
  inside a single fish invocation; nothing is interpolated into the
  `-c` body (closes CWE-78 in `.fish` filenames)
- Drop `|| true` from the shfmt step
- `timeout-minutes: 15` on autofix, `30` on lockfile

Round 2 of /review-security came back clean. Round 5 of /review-dev
surfaced 3 Important + 5 Minor on the new commit code; all addressed:

- `git add -A` narrowed to formatter-relevant pathspecs
  (`'**/*.nix'`, `'**/*.sh'`, `'**/*.fish'`) excluding `secrets/`
- `git diff --no-renames` so the C/R status branch is unreachable and a
  malicious `git config diff.renames copies` cannot trick the parser
  into staging an extra delete
- Reject unexpected git status codes loudly instead of silently
  treating them as adds
- `fs.lstatSync` instead of `fs.statSync`; symlinks honoured with
  mode `120000`, non-regular files throw (closes the symlink TOCTOU /
  out-of-tree-read attack vector from the security Low findings)
- Restore `-not -path './secrets/*'` discipline guard on every find
  and the equivalent `--ignore`/`--exclude` flags on statix/deadnix
- Add `concurrency: { group: update-flake-lock }` so manual dispatches
  cannot race the nightly schedule
- Pre-install token-shape check on `NIXERATOR_FLAKE_TOKEN` to prevent
  nix.conf injection if the secret is ever rotated to a malformed value
- Unify `update-flake-lock.yml` on the same git data API pattern as
  `ci.yml` so both workflows commit through one mechanism

Closes #94
