### PR TITLE
fix(ci): address review-dev minors from #97 (base_tree, fetch-depth)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Full history so the autocommit step can rebase cleanly when main
-          # has moved during the run.
-          fetch-depth: 0
           # Drop the runner credential helper so a compromised formatter
           # binary cannot piggy-back on the implicit token to push to main.
           # The commit step below presents the token explicitly via
@@ -174,8 +171,13 @@ jobs:
                 owner, repo, ref: `heads/${branch}`,
               });
               const parentSha = ref.object.sha;
+              // base_tree wants a tree SHA per the REST docs. The API does
+              // dereference a commit SHA today, but pin the spec contract.
+              const { data: parentCommit } = await github.rest.git.getCommit({
+                owner, repo, commit_sha: parentSha,
+              });
               const { data: newTree } = await github.rest.git.createTree({
-                owner, repo, base_tree: parentSha, tree,
+                owner, repo, base_tree: parentCommit.tree.sha, tree,
               });
               const { data: newCommit } = await github.rest.git.createCommit({
                 owner, repo, message, tree: newTree.sha, parents: [parentSha],

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -91,8 +91,13 @@ jobs:
                 owner, repo, ref: `heads/${branch}`,
               });
               const parentSha = ref.object.sha;
+              // base_tree wants a tree SHA per the REST docs. The API does
+              // dereference a commit SHA today, but pin the spec contract.
+              const { data: parentCommit } = await github.rest.git.getCommit({
+                owner, repo, commit_sha: parentSha,
+              });
               const { data: newTree } = await github.rest.git.createTree({
-                owner, repo, base_tree: parentSha, tree,
+                owner, repo, base_tree: parentCommit.tree.sha, tree,
               });
               const { data: newCommit } = await github.rest.git.createCommit({
                 owner, repo, message, tree: newTree.sha, parents: [parentSha],


### PR DESCRIPTION
Two follow-ups from the round-6 dev review on #97. Verdict was clean on both rounds so neither blocked merge; this is the standalone fix the reviewer recommended queueing.

## Changes

- **`base_tree` argument now passes a tree SHA, not a commit SHA**, in both `ci.yml` and `update-flake-lock.yml`. The GitHub REST docs for `POST /repos/{owner}/{repo}/git/trees` state "`base_tree` is the SHA1 of an existing Git tree object". Both workflows were passing `ref.object.sha` (a commit SHA), relying on undocumented permissive behavior that dereferences a commit SHA to its tree. Adds one `git.getCommit` call per attempt so the contract matches the spec; if GitHub ever tightens validation, both workflows stay correct.

- **Dropped `fetch-depth: 0` on the autofix checkout** in `ci.yml`. The inline comment ("rebase cleanly when main has moved during the run") was stale: the autocommit step now uses the git data REST API and never consults the working tree's history. Default `fetch-depth: 1` is enough for the formatter-then-API-commit flow. Saves clone time and bandwidth on every push.

## Not addressed (intentional)

The third reviewer note (duplicated API-commit script across the two workflows) is left as-is. Per CLAUDE.md DRY rule: two occurrences is a coincidence, three is a pattern. If a third workflow ever needs the same `createBlob/createTree/createCommit/updateRef` pattern, extract `.github/actions/api-commit/` then.