### PR TITLE
Ddns

### DIFF
--- a/extras/docs/secrets.md
+++ b/extras/docs/secrets.md
@@ -110,6 +110,7 @@ Names are pinned — they must match `secrets.json.tpl` exactly.
 | `tailscale-caddy-authkey` | API Credential | `credential` | `secrets.tailscale.caddyAuthKey` |
 | `github-pat` | API Credential | `credential` | `secrets.github.accessToken` |
 | `todoist` | API Credential | `credential` | `secrets.todoist_token` |
+| `cloudflare-ddns` | API Credential | `api_token` | `secrets.cloudflareDdns.apiToken` |
 | `syncthing-gui` | Login | `username` + `password` | `secrets.syncthing.gui.*` |
 | `b2-credentials` | Secure Note | `keyID` + `applicationKey` | `secrets.{restic,plakar}.*.b2_account_*` (shared) |
 | `restic-password` | Password | `password` | `secrets.restic.{srv,workstation}.restic_password` (shared) |

--- a/extras/docs/secrets.md
+++ b/extras/docs/secrets.md
@@ -110,7 +110,7 @@ Names are pinned — they must match `secrets.json.tpl` exactly.
 | `tailscale-caddy-authkey` | API Credential | `credential` | `secrets.tailscale.caddyAuthKey` |
 | `github-pat` | API Credential | `credential` | `secrets.github.accessToken` |
 | `todoist` | API Credential | `credential` | `secrets.todoist_token` |
-| `cloudflare-ddns` | API Credential | `api_token` | `secrets.cloudflareDdns.apiToken` |
+| `cloudflare-ddns` | API Credential | `credential` | `secrets.cloudflareDdns.apiToken` (scope: `Zone / DNS / Edit` on the target zones only) |
 | `syncthing-gui` | Login | `username` + `password` | `secrets.syncthing.gui.*` |
 | `b2-credentials` | Secure Note | `keyID` + `applicationKey` | `secrets.{restic,plakar}.*.b2_account_*` (shared) |
 | `restic-password` | Password | `password` | `secrets.restic.{srv,workstation}.restic_password` (shared) |

--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -24,6 +24,7 @@
     ../../modules/apps/cli/work-launcher
     ../../modules/apps/cli/zellij
     ../../modules/archetypes/claudeWorkHost
+    ../../modules/server/cloudflare-ddns
     ../../modules/server/kvm
     ../../modules/server/netboot-xyz
     ../../modules/server/nfs

--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -24,6 +24,14 @@
     ../../modules/apps/cli/work-launcher
     ../../modules/apps/cli/zellij
     ../../modules/archetypes/claudeWorkHost
+    # Imported-not-enabled. Activate by creating the `nixerator/cloudflare-ddns`
+    # 1Password item (API Credential, default `credential` field, value: a
+    # Cloudflare token scoped to `Zone / DNS / Edit`), running
+    # `just render-secrets`, and adding to this file:
+    #   server.cloudflareDdns = {
+    #     enable  = true;
+    #     domains = [ "your.zone.example.com" ];
+    #   };
     ../../modules/server/cloudflare-ddns
     ../../modules/server/kvm
     ../../modules/server/netboot-xyz

--- a/modules/server/cloudflare-ddns/default.nix
+++ b/modules/server/cloudflare-ddns/default.nix
@@ -1,0 +1,179 @@
+{
+  lib,
+  config,
+  secrets,
+  ...
+}:
+let
+  cfg = config.server.cloudflareDdns;
+
+  hasToken =
+    secrets ? cloudflareDdns
+    && secrets.cloudflareDdns ? apiToken
+    && secrets.cloudflareDdns.apiToken != "";
+
+  joinCsv = items: lib.concatStringsSep "," items;
+
+  # Only emit DOMAINS / IP4_DOMAINS / IP6_DOMAINS when the corresponding list
+  # is non-empty. An empty env var would be passed through to the container
+  # and ambiguously parsed by upstream.
+  domainEnv =
+    lib.optionalAttrs (cfg.domains != [ ]) { DOMAINS = joinCsv cfg.domains; }
+    // lib.optionalAttrs (cfg.ip4Domains != [ ]) { IP4_DOMAINS = joinCsv cfg.ip4Domains; }
+    // lib.optionalAttrs (cfg.ip6Domains != [ ]) { IP6_DOMAINS = joinCsv cfg.ip6Domains; };
+in
+{
+  options.server.cloudflareDdns = {
+    enable = lib.mkEnableOption "timothymiller/cloudflare-ddns dynamic DNS updater";
+
+    image = lib.mkOption {
+      type = lib.types.str;
+      # Digest-pinned to docker.io/timothyjmiller/cloudflare-ddns:latest as of
+      # 2026-05-18 (tag 2.1.2). Bump by:
+      #   curl -sS https://hub.docker.com/v2/repositories/timothyjmiller/cloudflare-ddns/tags/ \
+      #     | jq -r '.results[0] | "\(.name)  \(.digest // .images[0].digest)"'
+      # and updating this default to the new digest.
+      default = "docker.io/timothyjmiller/cloudflare-ddns@sha256:37c99677e997710c1bbe9d74c93f2e3b8de3457a5ca6e28643e251b38ed05311";
+      description = ''
+        OCI image to run. Defaults to a digest-pinned reference of the
+        upstream image. Bump the digest deliberately; a floating `:latest`
+        would let a compromised upstream silently push code that runs
+        with the Cloudflare API token in env.
+      '';
+    };
+
+    domains = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "example.com"
+        "www.example.com"
+      ];
+      description = ''
+        Domains to update for both IPv4 and IPv6 (`DOMAINS` env var).
+        At least one of `domains`, `ip4Domains`, or `ip6Domains` must be set.
+      '';
+    };
+
+    ip4Domains = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Domains to update for IPv4 only (`IP4_DOMAINS` env var).";
+    };
+
+    ip6Domains = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Domains to update for IPv6 only (`IP6_DOMAINS` env var).";
+    };
+
+    network = lib.mkOption {
+      type = lib.types.str;
+      default = "host";
+      example = "bridge";
+      description = ''
+        Docker network mode. Upstream documents that `host` is required for
+        IPv6 detection because the container reads the host's routing table.
+        Override to `bridge` only if IPv6 is disabled via `ip6Provider = "none"`;
+        an assertion below enforces that pairing.
+      '';
+    };
+
+    ip4Provider = lib.mkOption {
+      type = lib.types.str;
+      default = "ipify";
+      example = "cloudflare.trace";
+      description = ''
+        Source for the host's public IPv4 (`IP4_PROVIDER` env var). Defaults
+        to the upstream default. Set to `"none"` to disable IPv4 updates.
+      '';
+    };
+
+    ip6Provider = lib.mkOption {
+      type = lib.types.str;
+      default = "cloudflare.trace";
+      example = "none";
+      description = ''
+        Source for the host's public IPv6 (`IP6_PROVIDER` env var). Defaults
+        to the upstream default. Set to `"none"` to disable IPv6 updates;
+        required if `network` is not `"host"`.
+      '';
+    };
+
+    updateCron = lib.mkOption {
+      type = lib.types.str;
+      default = "@every 5m";
+      example = "@every 1h";
+      description = ''
+        Update schedule (`UPDATE_CRON` env var). Accepts cron expressions
+        and `@every <duration>` shortcuts. Default matches upstream.
+      '';
+    };
+
+    extraEnv = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = {
+        SHOUTRRR = "discord://token@id";
+        HEALTHCHECKS = "https://hc-ping.com/abc-123";
+      };
+      description = ''
+        Additional environment variables passed verbatim into the container.
+        See upstream README for the full list (WAF_LISTS, SHOUTRRR,
+        HEALTHCHECKS, TTL, PROXIED, etc.).
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.virtualisation.docker.enable;
+        message = ''
+          server.cloudflareDdns.enable = true requires
+          virtualisation.docker.enable = true. Enable apps.cli.docker on
+          this host (or set the Docker option directly).
+        '';
+      }
+      {
+        assertion = hasToken;
+        message = ''
+          server.cloudflareDdns.enable = true requires
+          secrets.cloudflareDdns.apiToken to be set. Add the
+          `cloudflareDdns.apiToken` entry to secrets.json.tpl and run
+          `just render-secrets`.
+        '';
+      }
+      {
+        assertion = cfg.domains != [ ] || cfg.ip4Domains != [ ] || cfg.ip6Domains != [ ];
+        message = ''
+          server.cloudflareDdns.enable = true requires at least one of
+          `domains`, `ip4Domains`, or `ip6Domains` to be non-empty.
+        '';
+      }
+      {
+        assertion = cfg.network == "host" || cfg.ip6Provider == "none";
+        message = ''
+          server.cloudflareDdns.network must be "host" whenever
+          server.cloudflareDdns.ip6Provider is anything other than "none".
+          Upstream reads the host routing table for IPv6 detection and only
+          works with host networking.
+        '';
+      }
+    ];
+
+    virtualisation.oci-containers.containers."cloudflare-ddns" = {
+      inherit (cfg) image;
+      autoStart = true;
+      extraOptions = [ "--network=${cfg.network}" ];
+      environment = {
+        CLOUDFLARE_API_TOKEN = secrets.cloudflareDdns.apiToken;
+        IP4_PROVIDER = cfg.ip4Provider;
+        IP6_PROVIDER = cfg.ip6Provider;
+        UPDATE_CRON = cfg.updateCron;
+      }
+      // domainEnv
+      // cfg.extraEnv;
+    };
+  };
+}

--- a/modules/server/cloudflare-ddns/default.nix
+++ b/modules/server/cloudflare-ddns/default.nix
@@ -14,14 +14,17 @@ let
 
   joinCsv = items: lib.concatStringsSep "," items;
 
-  # Token-file paths. The host file is rendered at activation time so the
-  # value lives outside `docker run` argv (which would otherwise expose
-  # the token in /proc/<pid>/cmdline for every reader). The container sees
-  # it via a read-only bind mount, and CLOUDFLARE_API_TOKEN_FILE in env
-  # tells upstream to read from that path. This is the upstream-documented
-  # "Docker secrets compatible" path.
-  hostTokenDir = "/var/lib/cloudflare-ddns";
-  hostTokenPath = "${hostTokenDir}/token";
+  # Token-file paths. The host file is materialised through
+  # `environment.etc` at activation time so the value never enters
+  # `docker run` argv (which would otherwise expose it in
+  # /proc/<pid>/cmdline) and never lands in a world-readable file under
+  # /etc/tmpfiles.d. `environment.etc` rewrites the file on every
+  # activation, so a rotated 1Password value propagates on the next
+  # `nixos-rebuild switch` without any manual cleanup. The container
+  # sees the file via a read-only bind mount; CLOUDFLARE_API_TOKEN_FILE
+  # in env tells upstream to read it (the documented "Docker secrets
+  # compatible" path).
+  hostTokenPath = "/etc/cloudflare-ddns/token";
   containerTokenPath = "/run/secrets/cloudflare-ddns-token";
 
   # Env keys the module owns. Passing any of these via `extraEnv` would
@@ -184,98 +187,102 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    assertions = [
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
       {
-        assertion = config.virtualisation.docker.enable;
-        message = ''
-          server.cloudflareDdns.enable = true requires
-          virtualisation.docker.enable = true. Enable apps.cli.docker on
-          this host (or set the Docker option directly).
-        '';
-      }
-      {
-        assertion = hasToken;
-        message = ''
-          server.cloudflareDdns.enable = true requires
-          secrets.cloudflareDdns.apiToken to be set. Create the
-          `nixerator/cloudflare-ddns` 1Password item (type: API Credential,
-          field: `credential`, value: a Cloudflare API token scoped to
-          `Zone / DNS / Edit` on the target zones) and run
-          `just render-secrets`.
-        '';
-      }
-      {
-        assertion =
-          cfg.domains != [ ] || cfg.ip4Domains != [ ] || cfg.ip6Domains != [ ] || cfg.wafLists != [ ];
-        message = ''
-          server.cloudflareDdns.enable = true requires at least one of
-          `domains`, `ip4Domains`, `ip6Domains`, or `wafLists` to be
-          non-empty.
-        '';
-      }
-      {
-        assertion = cfg.network == "host" || cfg.ip6Provider == "none";
-        message = ''
-          server.cloudflareDdns.network must be "host" whenever
-          server.cloudflareDdns.ip6Provider is anything other than "none".
-          Upstream reads the host routing table for IPv6 detection and only
-          works with host networking.
-        '';
-      }
-      {
-        assertion = cfg.ip6Provider != "none" || cfg.ip6Domains == [ ];
-        message = ''
-          server.cloudflareDdns.ip6Domains is non-empty but ip6Provider is
-          "none". Upstream silently skips AAAA updates in that combination.
-          Set ip6Provider to a real provider (e.g. "cloudflare.trace") or
-          drop the IPv6-only domains.
-        '';
-      }
-    ];
+        assertions = [
+          {
+            assertion = config.virtualisation.docker.enable;
+            message = ''
+              server.cloudflareDdns.enable = true requires
+              virtualisation.docker.enable = true. Enable apps.cli.docker on
+              this host (or set the Docker option directly).
+            '';
+          }
+          {
+            assertion = hasToken;
+            message = ''
+              server.cloudflareDdns.enable = true requires
+              secrets.cloudflareDdns.apiToken to be set. Create the
+              `nixerator/cloudflare-ddns` 1Password item (type: API Credential,
+              field: `credential`, value: a Cloudflare API token scoped to
+              `Zone / DNS / Edit` on the target zones) and run
+              `just render-secrets`.
+            '';
+          }
+          {
+            assertion =
+              cfg.domains != [ ] || cfg.ip4Domains != [ ] || cfg.ip6Domains != [ ] || cfg.wafLists != [ ];
+            message = ''
+              server.cloudflareDdns.enable = true requires at least one of
+              `domains`, `ip4Domains`, `ip6Domains`, or `wafLists` to be
+              non-empty.
+            '';
+          }
+          {
+            assertion = cfg.network == "host" || cfg.ip6Provider == "none";
+            message = ''
+              server.cloudflareDdns.network must be "host" whenever
+              server.cloudflareDdns.ip6Provider is anything other than "none".
+              Upstream reads the host routing table for IPv6 detection and only
+              works with host networking.
+            '';
+          }
+          {
+            # `domains` is a both-stack list upstream: every entry contributes
+            # to the IPv6 update set, so an empty `ip6Domains` is not enough
+            # to make ip6Provider = "none" safe.
+            assertion = cfg.ip6Provider != "none" || (cfg.ip6Domains == [ ] && cfg.domains == [ ]);
+            message = ''
+              server.cloudflareDdns.ip6Provider is "none" but `domains` or
+              `ip6Domains` is non-empty. Upstream treats both as IPv6 targets
+              and silently skips AAAA updates in this combination. Either set
+              ip6Provider to a real provider (e.g. "cloudflare.trace") or move
+              both-stack entries into `ip4Domains`.
+            '';
+          }
+        ];
 
-    warnings = lib.optional (conflictingExtraKeys != [ ]) ''
-      server.cloudflareDdns.extraEnv contains keys the module manages
-      directly: ${lib.concatStringsSep ", " conflictingExtraKeys}. These
-      are dropped from extraEnv. Set them via the typed options instead
-      (or remove them).
-    '';
-
-    # Render the API token to a host-side file so the value never enters
-    # `docker run` argv. The bind mount makes the same path readable
-    # inside the container under a fixed location, and
-    # CLOUDFLARE_API_TOKEN_FILE in env tells upstream to consume it
-    # there. Per the project threat model, the token still lives in
-    # /nix/store via the tmpfiles rule (acceptable on single-user hosts);
-    # the win here is removing it from /proc/<pid>/cmdline.
-    systemd.tmpfiles.settings."10-cloudflare-ddns" = {
-      "${hostTokenDir}".d = {
-        mode = "0700";
-        user = "root";
-        group = "root";
-      };
-      "${hostTokenPath}".f = {
-        mode = "0400";
-        user = "root";
-        group = "root";
-        argument = secrets.cloudflareDdns.apiToken;
-      };
-    };
-
-    virtualisation.oci-containers.containers."cloudflare-ddns" = {
-      inherit (cfg) image;
-      autoStart = true;
-      hostname = "cloudflare-ddns";
-      extraOptions = [ "--network=${cfg.network}" ];
-      volumes = [ "${hostTokenPath}:${containerTokenPath}:ro" ];
-      environment = {
-        CLOUDFLARE_API_TOKEN_FILE = containerTokenPath;
-        IP4_PROVIDER = cfg.ip4Provider;
-        IP6_PROVIDER = cfg.ip6Provider;
-        UPDATE_CRON = cfg.updateCron;
+        warnings = lib.optional (conflictingExtraKeys != [ ]) ''
+          server.cloudflareDdns.extraEnv contains keys the module manages
+          directly: ${lib.concatStringsSep ", " conflictingExtraKeys}. These
+          are dropped from extraEnv. Set them via the typed options instead
+          (or remove them).
+        '';
       }
-      // domainEnv
-      // sanitizedExtraEnv;
-    };
-  };
+
+      # Everything below touches the token value, so guard the whole block
+      # behind hasToken. The strict assertion above fires first with an
+      # actionable message; without this guard, evaluating `text =
+      # secrets.cloudflareDdns.apiToken` would throw a cryptic
+      # `attribute 'cloudflareDdns' missing` before the assertion machinery
+      # could surface anything.
+      (lib.mkIf hasToken {
+        # `environment.etc` materialises /etc/cloudflare-ddns/token at
+        # activation time with the configured mode, so the value never enters
+        # `docker run` argv and never lands in a world-readable file under
+        # /etc/tmpfiles.d. Per the project threat model the plaintext copy
+        # in /nix/store is the documented trade-off for inline secrets.
+        environment.etc."cloudflare-ddns/token" = {
+          text = secrets.cloudflareDdns.apiToken;
+          mode = "0400";
+        };
+
+        virtualisation.oci-containers.containers."cloudflare-ddns" = {
+          inherit (cfg) image;
+          autoStart = true;
+          extraOptions = [ "--network=${cfg.network}" ];
+          volumes = [ "${hostTokenPath}:${containerTokenPath}:ro" ];
+          environment = {
+            CLOUDFLARE_API_TOKEN_FILE = containerTokenPath;
+            IP4_PROVIDER = cfg.ip4Provider;
+            IP6_PROVIDER = cfg.ip6Provider;
+            UPDATE_CRON = cfg.updateCron;
+          }
+          // domainEnv
+          // sanitizedExtraEnv;
+        };
+      })
+    ]
+  );
 }

--- a/modules/server/cloudflare-ddns/default.nix
+++ b/modules/server/cloudflare-ddns/default.nix
@@ -14,13 +14,43 @@ let
 
   joinCsv = items: lib.concatStringsSep "," items;
 
-  # Only emit DOMAINS / IP4_DOMAINS / IP6_DOMAINS when the corresponding list
-  # is non-empty. An empty env var would be passed through to the container
-  # and ambiguously parsed by upstream.
+  # Token-file paths. The host file is rendered at activation time so the
+  # value lives outside `docker run` argv (which would otherwise expose
+  # the token in /proc/<pid>/cmdline for every reader). The container sees
+  # it via a read-only bind mount, and CLOUDFLARE_API_TOKEN_FILE in env
+  # tells upstream to read from that path. This is the upstream-documented
+  # "Docker secrets compatible" path.
+  hostTokenDir = "/var/lib/cloudflare-ddns";
+  hostTokenPath = "${hostTokenDir}/token";
+  containerTokenPath = "/run/secrets/cloudflare-ddns-token";
+
+  # Env keys the module owns. Passing any of these via `extraEnv` would
+  # silently override the typed options below (including the API token).
+  # We strip them from `extraEnv` and surface a warning so a config that
+  # tries to set them is loud rather than silent.
+  reservedEnvKeys = [
+    "CLOUDFLARE_API_TOKEN"
+    "CLOUDFLARE_API_TOKEN_FILE"
+    "DOMAINS"
+    "IP4_DOMAINS"
+    "IP6_DOMAINS"
+    "WAF_LISTS"
+    "IP4_PROVIDER"
+    "IP6_PROVIDER"
+    "UPDATE_CRON"
+  ];
+
+  conflictingExtraKeys = lib.intersectLists reservedEnvKeys (lib.attrNames cfg.extraEnv);
+  sanitizedExtraEnv = removeAttrs cfg.extraEnv reservedEnvKeys;
+
+  # Only emit DOMAINS / IP4_DOMAINS / IP6_DOMAINS / WAF_LISTS when the
+  # corresponding list is non-empty. An empty env var would be passed
+  # through to the container and ambiguously parsed by upstream.
   domainEnv =
     lib.optionalAttrs (cfg.domains != [ ]) { DOMAINS = joinCsv cfg.domains; }
     // lib.optionalAttrs (cfg.ip4Domains != [ ]) { IP4_DOMAINS = joinCsv cfg.ip4Domains; }
-    // lib.optionalAttrs (cfg.ip6Domains != [ ]) { IP6_DOMAINS = joinCsv cfg.ip6Domains; };
+    // lib.optionalAttrs (cfg.ip6Domains != [ ]) { IP6_DOMAINS = joinCsv cfg.ip6Domains; }
+    // lib.optionalAttrs (cfg.wafLists != [ ]) { WAF_LISTS = joinCsv cfg.wafLists; };
 in
 {
   options.server.cloudflareDdns = {
@@ -28,11 +58,17 @@ in
 
     image = lib.mkOption {
       type = lib.types.str;
-      # Digest-pinned to docker.io/timothyjmiller/cloudflare-ddns:latest as of
-      # 2026-05-18 (tag 2.1.2). Bump by:
-      #   curl -sS https://hub.docker.com/v2/repositories/timothyjmiller/cloudflare-ddns/tags/ \
-      #     | jq -r '.results[0] | "\(.name)  \(.digest // .images[0].digest)"'
-      # and updating this default to the new digest.
+      # Digest-pinned to docker.io/timothyjmiller/cloudflare-ddns 2.1.2 as of
+      # 2026-05-18. Bump to a real semver tag, not `:latest`, so the pin
+      # narrative stays meaningful:
+      #   curl -sS https://hub.docker.com/v2/repositories/timothyjmiller/cloudflare-ddns/tags/?page_size=20 \
+      #     | jq -r '.results | map(select(.name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))) | .[0] | "\(.name)  \(.digest // .images[0].digest)"'
+      # then update this default to the new digest. When bumping, also
+      # re-check that the upstream binary has not added any inbound
+      # listener (`docker run --rm <new-image> --help` or `ss -tlnp`
+      # inside the container). `--network host` shares srv's interfaces,
+      # so any new listener would be exposed on every interface without
+      # firewall scoping.
       default = "docker.io/timothyjmiller/cloudflare-ddns@sha256:37c99677e997710c1bbe9d74c93f2e3b8de3457a5ca6e28643e251b38ed05311";
       description = ''
         OCI image to run. Defaults to a digest-pinned reference of the
@@ -51,7 +87,8 @@ in
       ];
       description = ''
         Domains to update for both IPv4 and IPv6 (`DOMAINS` env var).
-        At least one of `domains`, `ip4Domains`, or `ip6Domains` must be set.
+        At least one of `domains`, `ip4Domains`, `ip6Domains`, or `wafLists`
+        must be set.
       '';
     };
 
@@ -67,6 +104,18 @@ in
       description = "Domains to update for IPv6 only (`IP6_DOMAINS` env var).";
     };
 
+    wafLists = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "abc123/my-blocklist" ];
+      description = ''
+        Cloudflare WAF lists to manage (`WAF_LISTS` env var). Each entry is
+        `account-id/list-name`. Upstream treats WAF lists as an alternative
+        to the domain options for satisfying the "at least one thing to
+        update" requirement.
+      '';
+    };
+
     network = lib.mkOption {
       type = lib.types.str;
       default = "host";
@@ -74,8 +123,14 @@ in
       description = ''
         Docker network mode. Upstream documents that `host` is required for
         IPv6 detection because the container reads the host's routing table.
-        Override to `bridge` only if IPv6 is disabled via `ip6Provider = "none"`;
-        an assertion below enforces that pairing.
+        Override to `bridge` only if IPv6 is disabled via
+        `ip6Provider = "none"`; an assertion below enforces that pairing.
+
+        `host` networking on srv means the container shares every host
+        interface (LAN, Tailscale, libvirt bridges) without per-interface
+        firewall scoping. Today the upstream binary has no inbound
+        listener, but the image-bump checklist above flags this so the
+        assumption is re-verified on every upgrade.
       '';
     };
 
@@ -119,8 +174,12 @@ in
       };
       description = ''
         Additional environment variables passed verbatim into the container.
-        See upstream README for the full list (WAF_LISTS, SHOUTRRR,
-        HEALTHCHECKS, TTL, PROXIED, etc.).
+        See upstream README for the full list (SHOUTRRR, HEALTHCHECKS, TTL,
+        PROXIED, etc.). Keys the module manages directly (`DOMAINS`,
+        `WAF_LISTS`, `CLOUDFLARE_API_TOKEN*`, `IP[46]_*`, `UPDATE_CRON`)
+        are stripped from this attrset before merge so this option cannot
+        override the typed options; a build-time warning fires when any
+        reserved key appears here.
       '';
     };
   };
@@ -139,16 +198,20 @@ in
         assertion = hasToken;
         message = ''
           server.cloudflareDdns.enable = true requires
-          secrets.cloudflareDdns.apiToken to be set. Add the
-          `cloudflareDdns.apiToken` entry to secrets.json.tpl and run
+          secrets.cloudflareDdns.apiToken to be set. Create the
+          `nixerator/cloudflare-ddns` 1Password item (type: API Credential,
+          field: `credential`, value: a Cloudflare API token scoped to
+          `Zone / DNS / Edit` on the target zones) and run
           `just render-secrets`.
         '';
       }
       {
-        assertion = cfg.domains != [ ] || cfg.ip4Domains != [ ] || cfg.ip6Domains != [ ];
+        assertion =
+          cfg.domains != [ ] || cfg.ip4Domains != [ ] || cfg.ip6Domains != [ ] || cfg.wafLists != [ ];
         message = ''
           server.cloudflareDdns.enable = true requires at least one of
-          `domains`, `ip4Domains`, or `ip6Domains` to be non-empty.
+          `domains`, `ip4Domains`, `ip6Domains`, or `wafLists` to be
+          non-empty.
         '';
       }
       {
@@ -160,20 +223,59 @@ in
           works with host networking.
         '';
       }
+      {
+        assertion = cfg.ip6Provider != "none" || cfg.ip6Domains == [ ];
+        message = ''
+          server.cloudflareDdns.ip6Domains is non-empty but ip6Provider is
+          "none". Upstream silently skips AAAA updates in that combination.
+          Set ip6Provider to a real provider (e.g. "cloudflare.trace") or
+          drop the IPv6-only domains.
+        '';
+      }
     ];
+
+    warnings = lib.optional (conflictingExtraKeys != [ ]) ''
+      server.cloudflareDdns.extraEnv contains keys the module manages
+      directly: ${lib.concatStringsSep ", " conflictingExtraKeys}. These
+      are dropped from extraEnv. Set them via the typed options instead
+      (or remove them).
+    '';
+
+    # Render the API token to a host-side file so the value never enters
+    # `docker run` argv. The bind mount makes the same path readable
+    # inside the container under a fixed location, and
+    # CLOUDFLARE_API_TOKEN_FILE in env tells upstream to consume it
+    # there. Per the project threat model, the token still lives in
+    # /nix/store via the tmpfiles rule (acceptable on single-user hosts);
+    # the win here is removing it from /proc/<pid>/cmdline.
+    systemd.tmpfiles.settings."10-cloudflare-ddns" = {
+      "${hostTokenDir}".d = {
+        mode = "0700";
+        user = "root";
+        group = "root";
+      };
+      "${hostTokenPath}".f = {
+        mode = "0400";
+        user = "root";
+        group = "root";
+        argument = secrets.cloudflareDdns.apiToken;
+      };
+    };
 
     virtualisation.oci-containers.containers."cloudflare-ddns" = {
       inherit (cfg) image;
       autoStart = true;
+      hostname = "cloudflare-ddns";
       extraOptions = [ "--network=${cfg.network}" ];
+      volumes = [ "${hostTokenPath}:${containerTokenPath}:ro" ];
       environment = {
-        CLOUDFLARE_API_TOKEN = secrets.cloudflareDdns.apiToken;
+        CLOUDFLARE_API_TOKEN_FILE = containerTokenPath;
         IP4_PROVIDER = cfg.ip4Provider;
         IP6_PROVIDER = cfg.ip6Provider;
         UPDATE_CRON = cfg.updateCron;
       }
       // domainEnv
-      // cfg.extraEnv;
+      // sanitizedExtraEnv;
     };
   };
 }

--- a/secrets.json.tpl
+++ b/secrets.json.tpl
@@ -53,5 +53,8 @@
   "snyk": {
     "token": "{{ op://nixerator/snyk/credential }}"
   },
-  "todoist_token": "{{ op://nixerator/todoist/credential }}"
+  "todoist_token": "{{ op://nixerator/todoist/credential }}",
+  "cloudflareDdns": {
+    "apiToken": "{{ op://nixerator/cloudflare-ddns/api_token }}"
+  }
 }

--- a/secrets.json.tpl
+++ b/secrets.json.tpl
@@ -55,6 +55,6 @@
   },
   "todoist_token": "{{ op://nixerator/todoist/credential }}",
   "cloudflareDdns": {
-    "apiToken": "{{ op://nixerator/cloudflare-ddns/api_token }}"
+    "apiToken": "{{ op://nixerator/cloudflare-ddns/credential }}"
   }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> PR 1 of 1 in an autonomous batch.
> This PR is **not** set to auto-merge. Review and merge manually.
> Merge order:
> 1. #99, feat(server): add cloudflare-ddns module for srv

## Summary
Closes #93: Ddns

- feat(server): add cloudflare-ddns module for srv
  Wires the timothymiller/cloudflare-ddns (Rust, env-var driven) Docker
  image into srv via the same oci-container template used for
  netboot-xyz. Module imported but enable=false; user activates by
  setting domains + creating the 1P item.
  
  What lands:
  - modules/server/cloudflare-ddns/default.nix
    Digest-pinned to docker.io/timothyjmiller/cloudflare-ddns@sha256:
    37c99... (tag 2.1.2, 2026-05-18). Options for domains / ip4Domains /
    ip6Domains, IP providers, update cron, network mode, and an extraEnv
    passthrough for SHOUTRRR / HEALTHCHECKS / TTL / etc. Token comes from
    secrets.cloudflareDdns.apiToken (Nix-eval secrets pipeline). Four
    assertions: Docker enabled, token present, at least one domain set,
    network=host whenever ip6 detection is on.
  - hosts/srv/modules.nix imports the module but leaves enable=false. To
    activate: create the 1P item, render secrets, set
      server.cloudflareDdns = { enable = true; domains = [ ... ]; };
  - secrets.json.tpl gets a cloudflareDdns.apiToken slot pointing at
    op://nixerator/cloudflare-ddns/api_token.
  - extras/docs/secrets.md item table gets the new 1P item row.
  
  The module is leaner than netboot-xyz: no published ports (outbound
  only), no firewall surface, no persistent state, no bind mounts.
