### PR TITLE
feat(tailscale): auto-join tailnet via auth key, retire Tailscale SSH

### DIFF
--- a/extras/docs/secrets.md
+++ b/extras/docs/secrets.md
@@ -137,6 +137,7 @@ Names are pinned — they must match `secrets.json.tpl` exactly.
 | `gemini` | API Credential | `credential` | `secrets.gemini.apiKey` |
 | `snyk` | API Credential | `credential` | `secrets.snyk.token` |
 | `tailscale-caddy-authkey` | API Credential | `credential` | `secrets.tailscale.caddyAuthKey` |
+| `tailscale-node-authkey` | API Credential | `credential` | `secrets.tailscale.nodeAuthKey` (reusable, pre-approved tailnet auth key for host auto-join; materialized to a 0600 runtime file by the `tailscale` module — issue #107) |
 | `github-pat` | API Credential | `credential` | `secrets.github.accessToken` |
 | `todoist` | API Credential | `credential` | `secrets.todoist_token` |
 | `cloudflare-ddns` | API Credential | `credential` | `secrets.cloudflareDdns.apiToken` (scope: `Zone / DNS / Edit` on the target zones only) |

--- a/modules/apps/cli/tailscale/default.nix
+++ b/modules/apps/cli/tailscale/default.nix
@@ -2,11 +2,30 @@
   lib,
   pkgs,
   config,
+  globals,
+  secrets,
   ...
 }:
 
 let
   cfg = config.apps.cli.tailscale;
+
+  # The rendered Nix-eval secrets file on the target host (0600). Read at
+  # runtime by tailscale-node-authkey.service below -- NOT interpolated at
+  # eval time -- so the tailnet auth key never lands in the world-readable
+  # Nix store. See extras/docs/secrets.md.
+  secretsFile = "${globals.user.homeDirectory}/.config/nixos-secrets/secrets.json";
+
+  # Eval-time gate: only wire up tailnet auto-join once a node auth key has
+  # been rendered. This derives a boolean from the secret (existence /
+  # non-emptiness) and keeps the value itself out of the config. Until the
+  # `tailscale-node-authkey` 1Password item is wired (issue #107), this is
+  # false and auto-join stays inert -- disabling Tailscale SSH (below) still
+  # applies.
+  hasNodeAuthKey = (secrets.tailscale.nodeAuthKey or "") != "";
+
+  # Runtime location of the materialized bare auth key (root-only).
+  nodeAuthKeyFile = "/run/tailscale/node-authkey";
 in
 {
   options = {
@@ -18,12 +37,54 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    # Enable Tailscale
-    services.tailscale.enable = true;
+    services.tailscale = {
+      enable = true;
+
+      # Auto-join the tailnet with a reusable auth key (issue #107). The bare
+      # key is materialized to a 0600 runtime file by
+      # tailscale-node-authkey.service; the module's tailscaled-autoconnect
+      # service only runs `tailscale up` when the node is NOT already logged
+      # in, so nodes already on the tailnet are left undisturbed.
+      authKeyFile = if hasNodeAuthKey then nodeAuthKeyFile else null;
+
+      # Use the regular OpenSSH daemon (system.ssh) for SSH access, NOT the
+      # Tailscale SSH server (issue #107). `tailscale set --ssh=false` runs on
+      # every activation via the module's tailscaled-set service, so any node
+      # that previously had Tailscale SSH enabled gets it switched off. We also
+      # never pass `--ssh` to `tailscale up`, so fresh joins never enable it.
+      extraSetFlags = [ "--ssh=false" ];
+    };
 
     environment.systemPackages = with pkgs; [
       tailscale # zero-config VPN
     ];
+
+    # Materialize the bare node auth key from the rendered secrets file into a
+    # root-only runtime file, ordered before tailscaled-autoconnect consumes
+    # it. Extracting at runtime (rather than interpolating the eval-time
+    # secret) keeps the tailnet auth key out of the world-readable Nix store.
+    systemd.services.tailscale-node-authkey = lib.mkIf hasNodeAuthKey {
+      description = "Materialize Tailscale node auth key for autoconnect";
+      after = [ "tailscaled.service" ];
+      before = [ "tailscaled-autoconnect.service" ];
+      wantedBy = [ "tailscaled-autoconnect.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      script = ''
+        umask 077
+        install -d -m 0700 /run/tailscale
+        ${pkgs.jq}/bin/jq -r '.tailscale.nodeAuthKey // empty' ${secretsFile} \
+          > ${nodeAuthKeyFile}
+        chmod 0600 ${nodeAuthKeyFile}
+      '';
+    };
+
+    # Run the `--ssh=false` set after any auto-join completes, so the node is
+    # logged in by the time `tailscale set` runs (avoids a spurious failed
+    # unit on first boot). Harmless no-op ordering when autoconnect is absent.
+    systemd.services.tailscaled-set.after = [ "tailscaled-autoconnect.service" ];
 
     # https://github.com/NixOS/nixpkgs/issues/180175#issuecomment-2372305193
     systemd.services.tailscaled.after = [

--- a/modules/system/ssh/default.nix
+++ b/modules/system/ssh/default.nix
@@ -23,6 +23,14 @@ in
     # Enable OpenSSH server
     services.openssh.enable = true;
 
+    # Authorize key-based login for the primary user. With Tailscale SSH
+    # retired (issue #107), regular OpenSSH is the only SSH path, so the login
+    # key must be declared here -- otherwise the only way in is password auth.
+    # Password auth stays enabled as a fallback; disable it once key login is
+    # verified on every host.
+    users.users.${globals.user.name}.openssh.authorizedKeys.keys =
+      globals.user.sshAuthorizedKeys;
+
     # Remote-agent interpreter for SSH-driven tools. `fresh` (and similar
     # python-over-ssh agents) pipe a bootstrap script into `python3` on the
     # remote side and fail with "python3 was not found on the remote host"

--- a/secrets.json.tpl
+++ b/secrets.json.tpl
@@ -51,7 +51,8 @@
     "apiKey": "{{ op://nixerator/gemini/credential }}"
   },
   "tailscale": {
-    "caddyAuthKey": "{{ op://nixerator/tailscale-caddy-authkey/credential }}"
+    "caddyAuthKey": "{{ op://nixerator/tailscale-caddy-authkey/credential }}",
+    "nodeAuthKey": "{{ op://nixerator/tailscale-node-authkey/credential }}"
   },
   "harmonia": {
     "privateKey": "{{ op://nixerator/harmonia-signing-key/credential }}"

--- a/settings/globals.nix
+++ b/settings/globals.nix
@@ -7,6 +7,16 @@ rec {
     fullName = "Dustin Krysak";
     email = "dustin@bashfulrobot.com";
     homeDirectory = "/home/dustin";
+
+    # Public keys permitted to log in over regular OpenSSH (issue #107: moved
+    # off the Tailscale SSH server). Reuses the ed25519 key also used for git
+    # commit signing (git.gitPubSigningKey) -- the public half of the
+    # ~/.ssh/id_ed25519 pair SSH'd with on the workstations. Add more keys
+    # here as needed. VERIFY this matches the private key you actually SSH
+    # with before disabling password auth.
+    sshAuthorizedKeys = [
+      git.gitPubSigningKey
+    ];
   };
 
   # Common repository and development paths


### PR DESCRIPTION
Closes #107.

Revamps Tailscale so NixOS-defined hosts auto-join the tailnet with a reusable auth key, and moves SSH off the Tailscale SSH server onto regular OpenSSH with key-based login (no more constant re-authentication).

## Changes
- **`modules/apps/cli/tailscale/default.nix`**
  - `services.tailscale.authKeyFile` (gated on a rendered `secrets.tailscale.nodeAuthKey`) so `tailscaled-autoconnect` runs `tailscale up` **only when the node isn't already logged in** — existing nodes are undisturbed, fresh/re-imaged hosts auto-join.
  - The bare key is materialized to a `0600` `/run/tailscale/node-authkey` at runtime from the on-disk secrets file, so the tailnet auth key **never enters the world-readable Nix store**.
  - `extraSetFlags = [ "--ssh=false" ]` disables Tailscale SSH on every activation; `--ssh` is never passed to `tailscale up`.
- **`modules/system/ssh/default.nix`** — declares `users.users.<user>.openssh.authorizedKeys.keys` from globals so key login works once Tailscale SSH is gone. Password auth left on as a fallback to avoid lockout.
- **`settings/globals.nix`** — adds `user.sshAuthorizedKeys` (reuses the ed25519 signing key).
- **`secrets.json.tpl` / `extras/docs/secrets.md`** — `tailscale-node-authkey` placeholder + item-table row.

## ⚠️ Required before this is functional
`just render-secrets` will **fail** until the `nixerator/tailscale-node-authkey` 1Password item exists (reusable, pre-approved auth key). Full steps are in [issue #107](https://github.com/bashfulrobot/nixerator/issues/107#issuecomment-4755493226). The auto-join path stays inert until the secret is wired; `--ssh=false` applies regardless.

## Verify
- Confirm `globals.user.sshAuthorizedKeys` matches the private key you SSH with (`~/.ssh/id_ed25519`) before relying on key login.
- **Not build-validated** — authored in a remote container with no `nix` and no rendered secrets file. Run `just qr` on a host to confirm eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)