### PR TITLE
fix(restic): keep backup credentials out of /nix/store + run scheduled backups

### DIFF
--- a/extras/docs/secrets-agenix-evaluation.md
+++ b/extras/docs/secrets-agenix-evaluation.md
@@ -1,0 +1,238 @@
+# Porting secrets to agenix / sops-nix — an evaluation
+
+> Prompted by Isabel Roses' write-up: <https://isabelroses.com/blog/nixos-and-secrets/>.
+> This is a decision document, not a migration plan. It inventories where
+> nixerator actually needs secrets today, then asks whether agenix or sops-nix
+> would cover those cases — and whether the move is worth it.
+
+## TL;DR
+
+- **The one thing a move buys you:** plaintext secrets out of `/nix/store`.
+  Today every secret value is string-interpolated into the store at eval time
+  (it is world-readable to any local process). Your current system keeps
+  secrets out of **git**, but not out of the **store**. That gap is exactly
+  what agenix/sops-nix close, and it is the *only* security property they add
+  over what you have.
+- **Would agenix cover all your use cases? No.** Neither tool does, natively.
+  Both are fundamentally "decrypt to a file path, hand the path to a service."
+  Roughly half of nixerator's secrets are consumed as **env vars** or
+  **values templated into a config file** for user-facing CLI tools — the
+  category where path-based secret managers are weakest.
+- **Between the two, sops-nix fits this repo better than agenix** — because it
+  keeps your single-blob model, its *templates* handle the "secret embedded in
+  a JSON/conf file" cases, and its home-manager module covers the user-level
+  secrets. agenix is conceptually cleaner (one secret = one file) but its
+  no-templating, one-file-per-secret model fights most of your consumers.
+- **The real decision isn't agenix-vs-sops. It's whether you give up 1Password
+  as the source of truth**, or run two systems. See "The 1Password tension".
+
+## What the blog post actually argues
+
+Roses' position, condensed:
+
+- Never put plaintext secrets in the config, a private repo, or git-crypt —
+  they end up world-readable in `/nix/store`.
+- Hand services a **path** (`/run/secrets/<name>`) that is decrypted at
+  **runtime** onto tmpfs, never the value itself at eval time.
+- **agenix for simpler setups** ("one secret, one file, one list of
+  recipients", no schema), **sops-nix for complex deployments** (bundles many
+  related values, supports templates mixing plaintext + secrets).
+- Both are host-key (SSH/age) based and work system-wide via their NixOS
+  modules. The post glosses over user-vs-system and home-manager nuances —
+  which, as it happens, is precisely where nixerator's hard cases live.
+
+## How nixerator does secrets today (the relevant mechanics)
+
+`flake.nix:133`:
+
+```nix
+secrets = builtins.fromJSON (builtins.readFile secretsFile);
+```
+
+A single `~/.config/nixos-secrets/secrets.json` (rendered from 1Password via
+`op inject`) is read at eval time into a `secrets` attrset, passed to every
+module through `specialArgs`. Modules then **interpolate the value**:
+
+```nix
+nix.settings.access-tokens = "github.com=${secrets.github.accessToken}";   # → /etc/nix/nix.conf
+"TS_AUTHKEY=${secrets.tailscale.caddyAuthKey}"                             # → systemd unit Environment=
+environment.etc."cloudflare-ddns/token".text = secrets.cloudflareDdns...   # → /nix/store, /etc (0400)
+RESTIC_PASSWORD "${bcfg.password}"                                          # → writeScriptBin in /nix/store
+TODOIST_API_TOKEN = secrets.todoist_token;                                  # → env var, system + user
+Authorization = "Bearer ${secrets.kong.kongKonnectPAT}";                   # → MCP servers JSON config
+```
+
+**Every one of those interpolations lands the plaintext in `/nix/store`,**
+which is `0755`/world-readable. The repo even documents this as an accepted
+trade-off (`modules/server/cloudflare-ddns/default.nix:265`: *"the plaintext
+copy in /nix/store is the documented trade-off for inline secrets"*).
+
+So the current model's security posture is:
+
+| Property | Status today |
+|---|---|
+| Secrets out of git history | ✅ Yes (rendered file is off-tree, off-store-as-input) |
+| Secrets out of the AI agent's reach | ✅ Yes (deny-listed paths, hard rule) |
+| Single source of truth + nice rotation UX | ✅ Yes (1Password + `render-secrets`) |
+| Secrets out of `/nix/store` (not world-readable locally) | ❌ **No** |
+| Secrets decrypted at runtime onto tmpfs | ❌ No |
+
+A migration to agenix/sops only moves the bottom two rows. **If a local
+unprivileged reader of `/nix/store` is not in your threat model, the migration
+buys you very little.** On single-user workstations (`donkeykong`, `qbert`)
+you're effectively the only principal anyway. On `srv` — a server with more
+surface and potentially more service accounts — the property is worth more.
+
+## Inventory: every consumer, and how cleanly it ports
+
+Bucketed by how the secret is consumed, because that — not the secret itself —
+determines fit.
+
+### Bucket A — service credential *files*. Clean fit for either tool.
+
+These map directly onto `age.secrets.<x>.path` / `sops.secrets.<x>.path`:
+
+| Consumer | Today | Ported |
+|---|---|---|
+| `harmonia` signing key | `environment.etc` text, `0400` | harmonia's `settings.signKeyPaths` already wants a **path** → point it at the decrypted path. Textbook fit. |
+| `cloudflare-ddns` token | `environment.etc."cloudflare-ddns/token"` | mount the decrypted file at that path instead. |
+| `caddy` `TS_AUTHKEY` | systemd `Environment=` | `serviceConfig.EnvironmentFile = <decrypted path>`. Clean. |
+
+### Bucket B — restic / plakar. Should be clean, but needs a rewrite.
+
+`restic` is the textbook agenix use case (`passwordFile`, `environmentFile`,
+`repositoryFile` all take paths). But you're **not** using
+`services.restic.backups`; you hand-rolled a `writeScriptBin "backup-mgr"`
+fish script with the password, repo, and B2 keys **interpolated straight into
+the store path** (`modules/apps/cli/restic/default.nix:17-21`). This is the
+single worst exposure in the repo.
+
+Porting means rewriting `backup-mgr` to read `RESTIC_PASSWORD` / `AWS_*` from
+an `EnvironmentFile` / decrypted paths at runtime (or adopting the upstream
+`services.restic` module, which already does this). Worth doing regardless of
+which secrets tool you pick — even reading from the existing `secrets.json` at
+runtime instead of baking values in would be an improvement.
+
+Shared values (`b2-credentials`, `restic-password`) currently fan out to
+srv/qbert/donkeykong via the JSON blob. agenix would push you to one `.age`
+file per (host × value) or duplicate; sops keeps the single-doc fan-out.
+
+### Bucket C — env vars for interactive shells. **Neither tool covers this natively.**
+
+| Consumer | Today |
+|---|---|
+| `todoist-cli` | `environment.variables` + `home.sessionVariables.TODOIST_API_TOKEN` |
+| `claude-code` | `GEMINI_API_KEY`, `AHA_API_TOKEN`, `WAVE_FULL_ACCESS_TOKEN` env |
+| `gemini-cli`, `agent-scan` (snyk) | env / wrapper |
+
+agenix and sops both produce **files**, not environment variables. For systemd
+services you bridge with `EnvironmentFile=`. But there is **no clean
+file→env-var path for an interactive login shell** (`home.sessionVariables`).
+Porting these means a shell-init shim that `source`s a decrypted env file on
+every shell start — which you'd have to write and maintain *yourself*,
+identically, no matter which tool you choose. This bucket is the main reason
+"agenix covers everything" is false for nixerator.
+
+### Bucket D — secrets templated into config *files*. Needs sops templates (or activation rendering).
+
+| Consumer | Today |
+|---|---|
+| `claude-code` MCP servers (`context7`, `kong`) | `Authorization: Bearer …` baked into an MCP JSON config |
+| `nix.settings.access-tokens` (github) | `github.com=<token>` in `/etc/nix/nix.conf` |
+| `syncthing` GUI user/password | `services.syncthing.settings.gui.{user,password}` |
+
+These need a secret *interpolated into a larger file*. agenix has no
+templating — you'd render these at home-manager **activation** time yourself.
+sops-nix has **`sops.templates`** (system) and a home-manager equivalent that
+does exactly this: render a file mixing plaintext + `placeholder."x"`,
+decrypted to a runtime path. `nix.conf` specifically supports `!include
+<path>` so the github token can live in an included, decrypted file.
+syncthing has no `passwordFile`, so it stays awkward either way (its password
+gets hashed into config regardless).
+
+### Bucket E — already out-of-band. No change needed.
+
+`okular-signature` / `okular-initials` PNGs and `gmailctl` credentials.json are
+rendered **straight to disk** by `just` recipes, never through Nix. They never
+touch the store today. Leave them alone; they're already doing the right thing
+and are a decent template for the env-var cases (render to a runtime path,
+don't go through eval).
+
+### Scorecard
+
+| Bucket | # of secrets (approx) | agenix | sops-nix |
+|---|---|---|---|
+| A: service files | 3 | ✅ clean | ✅ clean |
+| B: restic/plakar | 4 | ✅ after rewrite | ✅ after rewrite |
+| C: shell env vars | 5–6 | ⚠️ DIY shim | ⚠️ DIY shim |
+| D: templated configs | 3 | ❌ DIY activation | ✅ native templates |
+| E: out-of-band | 2 | n/a | n/a |
+
+## agenix vs sops-nix, for *this* repo specifically
+
+**agenix**
+- *Pros:* tiny, no schema, one secret = one file; easy to reason about; great
+  if you were mostly Bucket A.
+- *Cons here:* no templating (Bucket D becomes hand-rolled activation scripts);
+  one-file-per-secret multiplies ~20 secrets × hosts into a lot of `.age`
+  files and a `secrets.nix` recipients map; shared values (b2, restic password)
+  duplicate; home-manager support is community/less-trodden.
+
+**sops-nix**
+- *Pros here:* keeps your **single-blob** mental model (one encrypted
+  YAML/JSON ≈ your current `secrets.json`); **templates** solve Bucket D
+  natively; mature **home-manager module** for the user-level secrets;
+  per-key access. Closest structural match to what you already have.
+- *Cons:* a schema/format to maintain; more concepts (key groups, creation
+  rules, templates) than agenix; YAML.
+
+**For nixerator, sops-nix is the better technical fit** — driven entirely by
+Buckets C and D, which dominate your consumer list. agenix would leave you
+writing the same templating/activation glue by hand.
+
+## The 1Password tension (the actual decision)
+
+This is the part the blog post doesn't touch and it matters more than the
+tool choice. agenix/sops want the **source of truth** to be encrypted files
+**in your repo**, encrypted to **host SSH/age keys**. Today your source of
+truth is **1Password**, with biometric/SA-token UX and one-place rotation.
+
+Three ways to reconcile:
+
+1. **Replace 1Password with sops/agenix.** Source of truth becomes the
+   encrypted files; you manage age keys and recipients. You *lose* the
+   1Password UX (biometrics, rotation in one place, the item table, mobile
+   access) for these secrets. Cleanest tooling, biggest workflow change.
+2. **Keep 1Password, add sops/agenix as the deploy path.** A script pulls from
+   1Password and re-encrypts into the repo (`op read … | sops --encrypt`).
+   You keep the nice human UX *and* get store-free runtime — but you now run
+   **two systems** and a sync step. More moving parts than today.
+3. **Don't migrate; close the gap in place.** Keep 1Password + `render-secrets`,
+   but stop interpolating values into the store: render the relevant secrets to
+   **runtime paths** (you already do exactly this for okular/gmailctl) and feed
+   services `EnvironmentFile=`/`passwordFile=` pointing at them. This gets you
+   ~80% of the security benefit (plaintext out of the store) with **zero new
+   dependencies** and no change to your source of truth. It does *not* give you
+   age-encrypted-at-rest-in-repo or runtime decryption from ciphertext — but
+   you don't have ciphertext in the repo today anyway, so that's not a
+   regression.
+
+## Recommendation
+
+1. **First, fix the worst offender regardless of any tool decision:** rewrite
+   `backup-mgr` so restic creds aren't interpolated into a store-path script.
+   That's the highest-value, lowest-risk change and it's independent of
+   agenix/sops.
+2. **Decide on the 1Password question before the tool question.** If you're not
+   willing to give up the 1Password UX, **option 3 (close the gap in place)**
+   is the pragmatic win and keeps your whole existing flow. If you *want*
+   encrypted-in-repo + runtime decryption as a first-class property (most
+   defensible on `srv`), go **sops-nix**, not agenix, because of Buckets C/D.
+3. **Don't expect any tool to cover the shell-env-var secrets (Bucket C)
+   cleanly.** Plan a small `source`-an-env-file shim for those whichever path
+   you take, and model it on the okular/gmailctl out-of-band pattern you
+   already trust.
+
+In one line: *agenix would not cover all your cases; sops-nix covers more of
+them; but the highest-leverage move is getting plaintext out of `/nix/store`,
+which you can do without adopting either tool.*

--- a/extras/docs/secrets-agenix-evaluation.md
+++ b/extras/docs/secrets-agenix-evaluation.md
@@ -5,6 +5,25 @@
 > nixerator actually needs secrets today, then asks whether agenix or sops-nix
 > would cover those cases — and whether the move is worth it.
 
+## Decision (2026-06-21): stay on 1Password as-is
+
+Evaluated agenix and sops-nix; **decided not to migrate.** Rationale:
+
+- The current 1Password + `render-secrets` flow is the only mechanism that
+  covers **100%** of nixerator's use cases, because it produces secret
+  *values* (which can go into files, env vars, inline config, or syncthing)
+  rather than *file paths* (which can't cover the env-var / inline-config /
+  syncthing cases). agenix/sops cover ~70% cleanly and would require building
+  adapter glue to re-cover the rest — strictly more work for less coverage.
+- The only property the current model lacks is plaintext-out-of-`/nix/store`,
+  which is a local-read exposure that barely matters on single-user hosts.
+- Migrating would also cost the 1Password UX (biometrics, one-place rotation,
+  no ciphertext-in-git history tail).
+
+**Revisit only if** a fresh host must bootstrap with **no 1Password available**
+(decrypt everything from just its host key). Until that's a real requirement,
+no change. The analysis below is retained as the reasoning record.
+
 ## TL;DR
 
 - **The one thing a move buys you:** plaintext secrets out of `/nix/store`.

--- a/extras/docs/secrets-agenix-evaluation.md
+++ b/extras/docs/secrets-agenix-evaluation.md
@@ -132,6 +132,11 @@ an `EnvironmentFile` / decrypted paths at runtime (or adopting the upstream
 which secrets tool you pick — even reading from the existing `secrets.json` at
 runtime instead of baking values in would be an improvement.
 
+**Done (2026-06-21):** `backup-mgr` now reads the repo/password/B2 keys/region
+from the off-store `secrets.json` at runtime via `jq` (host call sites pass a
+`secretsProfile` instead of the values), so they no longer land in the
+world-readable store script. No new tool, 1Password unchanged.
+
 Shared values (`b2-credentials`, `restic-password`) currently fan out to
 srv/qbert/donkeykong via the JSON blob. agenix would push you to one `.age`
 file per (host × value) or duplicate; sops keeps the single-doc fan-out.

--- a/hosts/donkeykong/modules.nix
+++ b/hosts/donkeykong/modules.nix
@@ -1,4 +1,4 @@
-{ secrets, ... }:
+{ ... }:
 
 {
   apps.cli = {
@@ -25,11 +25,7 @@
 
     restic.backup = {
       enable = true;
-      repository = secrets.restic.workstation.restic_repository;
-      password = secrets.restic.workstation.restic_password;
-      awsAccessKeyId = secrets.restic.workstation.b2_account_id;
-      awsSecretAccessKey = secrets.restic.workstation.b2_account_key;
-      awsRegion = secrets.restic.workstation.region;
+      secretsProfile = "workstation";
       backupPaths = [
         "/home/dustin/Desktop"
         "/home/dustin/dev"

--- a/hosts/qbert/modules.nix
+++ b/hosts/qbert/modules.nix
@@ -1,4 +1,4 @@
-{ secrets, ... }:
+{ ... }:
 
 {
   # Adopt the Claude work-host archetype (symmetric peer to srv): zellij
@@ -15,11 +15,7 @@
     # Apps
     restic.backup = {
       enable = true;
-      repository = secrets.restic.workstation.restic_repository;
-      password = secrets.restic.workstation.restic_password;
-      awsAccessKeyId = secrets.restic.workstation.b2_account_id;
-      awsSecretAccessKey = secrets.restic.workstation.b2_account_key;
-      awsRegion = secrets.restic.workstation.region;
+      secretsProfile = "workstation";
       backupPaths = [
         "/home/dustin/Desktop"
         "/home/dustin/dev"

--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -1,4 +1,4 @@
-{ secrets, globals, ... }:
+{ globals, ... }:
 
 {
   # Import only modules that srv used in nixcfg, plus the cherry-picked
@@ -191,11 +191,7 @@
     enable = true;
     backup = {
       enable = true;
-      repository = secrets.restic.srv.restic_repository;
-      password = secrets.restic.srv.restic_password;
-      awsAccessKeyId = secrets.restic.srv.b2_account_id;
-      awsSecretAccessKey = secrets.restic.srv.b2_account_key;
-      awsRegion = secrets.restic.srv.region;
+      secretsProfile = "srv";
       backupPaths = [ "/srv/nfs" ];
       restorePath = "/srv/nfs/restores";
       schedule = "*-*-* 03:00:00";

--- a/modules/apps/cli/restic/default.nix
+++ b/modules/apps/cli/restic/default.nix
@@ -2,37 +2,59 @@
   pkgs,
   config,
   lib,
+  globals,
   ...
 }:
 let
   cfg = config.apps.cli.restic;
   bcfg = cfg.backup;
 
+  profile = bcfg.secretsProfile;
+  secretsFile = bcfg.secretsFile;
+  jqBin = "${pkgs.jq}/bin/jq";
+
   backup-mgr = ''
     #!/run/current-system/sw/bin/env fish
 
     set -x RESTIC_BIN "/run/current-system/sw/bin/restic"
-
     set -x RESTIC_HOST (hostname)
-    set -x RESTIC_REPOSITORY "${bcfg.repository}"
-    set -x AWS_ACCESS_KEY_ID "${bcfg.awsAccessKeyId}"
-    set -x AWS_SECRET_ACCESS_KEY "${bcfg.awsSecretAccessKey}"
-    set -x AWS_DEFAULT_REGION "${bcfg.awsRegion}"
-    set -x RESTIC_PASSWORD "${bcfg.password}"
+
+    # Credentials are NOT baked into this script (it lives world-readable in
+    # /nix/store, on every user's PATH). load_secrets reads them at runtime
+    # from the off-store, 0600 file written by render-secrets, so the B2 keys
+    # and restic password never enter the store. See extras/docs/secrets.md.
+    function load_secrets
+      set -l secrets_file "${secretsFile}"
+      if not test -r "$secrets_file"
+        echo "backup-mgr: secrets file $secrets_file is missing or unreadable." >&2
+        echo "Run 'just render-secrets' (or push from a peer) and retry." >&2
+        exit 1
+      end
+      set -l jq "${jqBin}"
+      set -gx RESTIC_REPOSITORY ($jq -r '.restic.${profile}.restic_repository' "$secrets_file")
+      set -gx AWS_ACCESS_KEY_ID ($jq -r '.restic.${profile}.b2_account_id' "$secrets_file")
+      set -gx AWS_SECRET_ACCESS_KEY ($jq -r '.restic.${profile}.b2_account_key' "$secrets_file")
+      set -gx AWS_DEFAULT_REGION ($jq -r '.restic.${profile}.region' "$secrets_file")
+      set -gx RESTIC_PASSWORD ($jq -r '.restic.${profile}.restic_password' "$secrets_file")
+    end
 
     function init_repo
+      load_secrets
       $RESTIC_BIN -r $RESTIC_REPOSITORY init
     end
 
     function restore_backup
+      load_secrets
       $RESTIC_BIN -r $RESTIC_REPOSITORY restore latest --target ${bcfg.restorePath}
     end
 
     function list_backups
+      load_secrets
       $RESTIC_BIN -r $RESTIC_REPOSITORY snapshots
     end
 
     function run_backup
+      load_secrets
       $RESTIC_BIN -r $RESTIC_REPOSITORY backup ${lib.concatStringsSep " " bcfg.backupPaths}
       $RESTIC_BIN -r $RESTIC_REPOSITORY forget --prune --host $RESTIC_HOST --keep-daily ${toString bcfg.keepDaily} --keep-weekly ${toString bcfg.keepWeekly} --keep-monthly ${toString bcfg.keepMonthly} --keep-yearly ${toString bcfg.keepYearly}
     end
@@ -109,29 +131,24 @@ in
           description = "Enable scheduled restic backups with backup-mgr.";
         };
 
-        repository = lib.mkOption {
+        secretsProfile = lib.mkOption {
           type = lib.types.str;
-          description = "Restic repository URL (e.g., s3:s3.us-west-000.backblazeb2.com/bucket-name).";
+          description = ''
+            Key under `.restic` in the rendered secrets file selecting this
+            host's credential set (e.g. "srv" or "workstation"). The
+            repository, password, B2 keys, and region are read from
+            `<secretsFile>.restic.<secretsProfile>.*` at runtime by backup-mgr,
+            so they never enter the world-readable /nix/store.
+          '';
         };
 
-        password = lib.mkOption {
+        secretsFile = lib.mkOption {
           type = lib.types.str;
-          description = "Restic repository password.";
-        };
-
-        awsAccessKeyId = lib.mkOption {
-          type = lib.types.str;
-          description = "AWS/B2 access key ID.";
-        };
-
-        awsSecretAccessKey = lib.mkOption {
-          type = lib.types.str;
-          description = "AWS/B2 secret access key.";
-        };
-
-        awsRegion = lib.mkOption {
-          type = lib.types.str;
-          description = "AWS/B2 region.";
+          default = "${globals.user.homeDirectory}/.config/nixos-secrets/secrets.json";
+          description = ''
+            Path to the off-store JSON secrets file (rendered by
+            render-secrets) that backup-mgr reads credentials from at runtime.
+          '';
         };
 
         backupPaths = lib.mkOption {

--- a/modules/apps/cli/restic/default.nix
+++ b/modules/apps/cli/restic/default.nix
@@ -224,7 +224,9 @@ in
           enable = true;
           serviceConfig = {
             Type = "simple";
-            ExecStart = "/run/current-system/sw/bin/fish /run/current-system/sw/bin/backup-mgr";
+            # Pass -backup so the timer actually runs a backup; with no
+            # argument backup-mgr falls through to show_help and does nothing.
+            ExecStart = "/run/current-system/sw/bin/fish /run/current-system/sw/bin/backup-mgr -backup";
           };
           wantedBy = [ "multi-user.target" ];
         };


### PR DESCRIPTION
## Why

While evaluating whether to port secrets to agenix/sops-nix (eval doc included), the standout finding was an in-place exposure independent of any tool decision: `backup-mgr` baked the restic password, B2 key ID, B2 application key, repository, and region straight into a `writeScriptBin`. That store path is world-readable (`0555`) and on every user's PATH, so any local process on `srv`/`qbert`/`donkeykong` could read the offsite backup credentials in plaintext.

A second, unrelated bug surfaced in the same module: the scheduled service ran the script with no arguments, falling through to `show_help` — so timed backups never actually ran.

## What changed

- **Credentials read at runtime, never in the store.** A new `load_secrets` fish function reads repo/password/B2 keys/region from the off-store, `0600` `secrets.json` (already rendered on every host by `render-secrets`) via `jq`, keyed by a new `secretsProfile` option. It's called only from the commands that need creds (`-init`/`-backup`/`-restore`/`-list`), so `-status`/`-logs`/`-help` still work even if the file is absent, with a clear error otherwise.
- **Host call sites** pass `secretsProfile = "srv"` / `"workstation"` instead of the five secret values. `secrets` is no longer needed in any host module signature (restic was its only consumer there).
- **Timer actually backs up.** `ExecStart` now passes `-backup`.
- **Docs:** adds `extras/docs/secrets-agenix-evaluation.md` — the agenix/sops-nix evaluation and the decision to stay on 1Password, with this fix recorded.

## Net effect

The B2 application key and restic password no longer exist in any world-readable `/nix/store` path — the one store-exposure that mattered — with **no new tool and 1Password untouched**. The runtime contract is unchanged: `secrets.json` already lives at the path the flake reads at eval, so no new render step is needed.

## Note

Nix isn't available in the environment these changes were authored in, so they were **not** built/evaluated here — please run a dry build (`just <host>`) before switching. Changes were manually reviewed for syntax and interpolation correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGb6MNNdP1xYLwjMwu3eoD)_