### PR TITLE
Buds link for AirPods

### DIFF
--- a/hosts/clanker/home.nix
+++ b/hosts/clanker/home.nix
@@ -30,48 +30,50 @@
     };
   };
 
-  programs.home-manager.enable = true;
+  programs = {
+    home-manager.enable = true;
 
-  programs.bash = {
-    enable = true;
-    enableCompletion = true;
-  };
+    bash = {
+      enable = true;
+      enableCompletion = true;
+    };
 
-  # --- Fish: autostart headless Sway, bridge SSH shells, unlock op ---
-  programs.fish = {
-    # On TTY1, the login shell starts the headless Sway session. The wlroots
-    # headless backend creates a virtual output with no display device, which
-    # grim captures. Guarded on XDG_VTNR=1 so SSH and other TTYs never exec
-    # sway. If sway exits, the tty session ends, getty respawns, and autologin
-    # restarts it — a self-healing always-up session.
-    loginShellInit = ''
-      if status is-login; and test -z "$WAYLAND_DISPLAY"; and test "$XDG_VTNR" = 1
-          set -gx WLR_BACKENDS headless
-          set -gx WLR_LIBINPUT_NO_DEVICES 1
-          exec sway
-      end
-    '';
+    # --- Fish: autostart headless Sway, bridge SSH shells, unlock op ---
+    fish = {
+      # On TTY1, the login shell starts the headless Sway session. The wlroots
+      # headless backend creates a virtual output with no display device, which
+      # grim captures. Guarded on XDG_VTNR=1 so SSH and other TTYs never exec
+      # sway. If sway exits, the tty session ends, getty respawns, and autologin
+      # restarts it — a self-healing always-up session.
+      loginShellInit = ''
+        if status is-login; and test -z "$WAYLAND_DISPLAY"; and test "$XDG_VTNR" = 1
+            set -gx WLR_BACKENDS headless
+            set -gx WLR_LIBINPUT_NO_DEVICES 1
+            exec sway
+        end
+      '';
 
-    interactiveShellInit = ''
-      # Bridge SSH shells to the running headless Sway session so grim and GUI
-      # launches target it with no manual env setup.
-      if set -q SSH_CONNECTION; and not set -q WAYLAND_DISPLAY
-          set -l rt /run/user/(id -u)
-          if test -d "$rt"
-              set -l sock (command ls $rt/wayland-* 2>/dev/null | string match -rv '\.lock$' | head -n1)
-              if test -n "$sock"
-                  set -gx XDG_RUNTIME_DIR $rt
-                  set -gx WAYLAND_DISPLAY (basename $sock)
-              end
-          end
-      end
+      interactiveShellInit = ''
+        # Bridge SSH shells to the running headless Sway session so grim and GUI
+        # launches target it with no manual env setup.
+        if set -q SSH_CONNECTION; and not set -q WAYLAND_DISPLAY
+            set -l rt /run/user/(id -u)
+            if test -d "$rt"
+                set -l sock (command ls $rt/wayland-* 2>/dev/null | string match -rv '\.lock$' | head -n1)
+                if test -n "$sock"
+                    set -gx XDG_RUNTIME_DIR $rt
+                    set -gx WAYLAND_DISPLAY (basename $sock)
+                end
+            end
+        end
 
-      # Make `op` authenticated from boot via the service-account token
-      # (installed once with `just setup-op-token`). Enables headless op/direnv.
-      if not set -q OP_SERVICE_ACCOUNT_TOKEN; and test -r ~/.config/op/service-account-token
-          set -gx OP_SERVICE_ACCOUNT_TOKEN (cat ~/.config/op/service-account-token)
-      end
-    '';
+        # Make `op` authenticated from boot via the service-account token
+        # (installed once with `just setup-op-token`). Enables headless op/direnv.
+        if not set -q OP_SERVICE_ACCOUNT_TOKEN; and test -r ~/.config/op/service-account-token
+            set -gx OP_SERVICE_ACCOUNT_TOKEN (cat ~/.config/op/service-account-token)
+        end
+      '';
+    };
   };
 
   # --- Minimal headless Sway: one terminal keybind, a fixed virtual output ---

--- a/modules/apps/gui/budslink/default.nix
+++ b/modules/apps/gui/budslink/default.nix
@@ -1,0 +1,20 @@
+{ lib, config, ... }:
+
+let
+  cfg = config.apps.gui.budslink;
+in
+{
+  options = {
+    apps.gui.budslink.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable BudsLink - desktop control for Bluetooth earbuds (AirPods, Galaxy Buds, etc.).";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.flatpak.packages = [
+      "io.github.maniacx.BudsLink"
+    ];
+  };
+}

--- a/modules/suites/av/default.nix
+++ b/modules/suites/av/default.nix
@@ -20,6 +20,7 @@ in
   config = lib.mkIf cfg.enable {
     apps.gui = {
       # affinity: removed
+      budslink.enable = true;
       cameractrls.enable = true;
       comics.enable = true;
     };


### PR DESCRIPTION
## Summary
Closes #115: Buds link for AirPods

- feat(apps): add BudsLink earbud control app via av suite
  New declarative Flatpak module modules/apps/gui/budslink (io.github.maniacx.BudsLink),
  enabled in the av suite so the workstation archetype picks it up. BudsLink is a
  GTK4/libadwaita app for controlling Bluetooth earbuds (AirPods, Galaxy Buds, etc.).
  
  Also consolidate the three repeated programs.* assignments in hosts/clanker/home.nix
  into a single programs block to clear a statix repeated-keys warning.
  
  Closes #115