### PR TITLE
ISO topology maker

### DIFF
--- a/extras/docs/local-packages.md
+++ b/extras/docs/local-packages.md
@@ -121,6 +121,12 @@ gh release list -R MarkovWangRR/iso-topology --limit 5
 gh api repos/MarkovWangRR/iso-topology/compare/vOLD...vNEW \
   --jq '.files[] | select(.filename | test("icons.go|cmd/isotopo-mcp/main.go|go.mod")) | .filename'
 
+# 2a. Run govulncheck against the new source tree to catch CVEs in transitive deps
+#     (requires govulncheck: nix shell nixpkgs#govulncheck)
+cd /tmp && gh repo clone MarkovWangRR/iso-topology iso-topology-audit -- --branch vNEW --depth 1
+cd iso-topology-audit && govulncheck ./...
+cd /tmp && rm -rf iso-topology-audit
+
 # 3. If the diff is acceptable, sync the fork's default branch
 gh repo sync bashfulrobot/iso-topology
 

--- a/extras/docs/local-packages.md
+++ b/extras/docs/local-packages.md
@@ -6,6 +6,7 @@ Package derivations live next to the modules that consume them:
 - `modules/apps/cli/claude-code/build/default.nix` (kubernetes-mcp-server)
 - `modules/apps/cli/claude-code/build/gsd/default.nix`
 - `modules/apps/cli/cpx/build/default.nix`
+- `modules/apps/cli/iso-topology/build/default.nix`
 - `modules/apps/cli/lswt/build/default.nix`
 - `modules/apps/cli/meetsum/build/default.nix`
 - `modules/apps/cli/restic/build/lazyrestic.nix`
@@ -73,3 +74,69 @@ just setup::update-pkg --all       # update all release-tracked packages
 just setup::update-pkg --all --include-commits   # also update commit-pinned packages
 just qr                            # rebuild to verify
 ```
+
+### Go modules (two-rebuild cycle)
+
+When `update-pkg` bumps a Go package that has `vendorHash` in `versions.nix`, the source hash and the vendor hash must be refreshed separately. The script warns you, but will not clear `vendorHash` automatically.
+
+After running `update-pkg <name>`:
+
+1. In `settings/versions.nix`, set `vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";` for the package.
+2. `just qr` -- fails with the correct source hash. Copy it into `hash`.
+3. `just qr` -- fails with the correct vendor hash. Copy it into `vendorHash`.
+4. `just qr` -- passes.
+
+## Forked Packages
+
+Some packages are pinned through a personal fork rather than the upstream repo. The fork is used when the upstream author is unverified or the supply-chain risk warrants an audit gate before pulling in changes.
+
+Current forked packages:
+
+| Package | Fork | Upstream | Audited at |
+|---------|------|----------|------------|
+| iso-topology | `bashfulrobot/iso-topology` | `MarkovWangRR/iso-topology` | v0.15.0 |
+
+### Why fork instead of pointing directly at upstream
+
+A fork gives a fixed, auditable point in the graph. The `repo` field in `versions.nix` points to the fork, so `check-updates` and `update-pkg` operate against controlled releases on that fork. Nothing changes unless you explicitly pull from upstream and tag the fork.
+
+### Security-sensitive files for iso-topology
+
+Before accepting any upstream release, diff these three files between the old and new version:
+
+- `icons.go` -- contains `inlineLocalIcon`, which reads arbitrary image files from the filesystem via the `icon:` DSL field. Watch for new read paths or any exec calls.
+- `cmd/isotopo-mcp/main.go` -- the MCP server entry point. Watch for new tools, new shell exec calls, or changes to the `output_dir` parameter (which controls write targets).
+- `go.mod` -- tracks all transitive dependencies. Watch for new modules that weren't there before.
+
+If any of these change in a way that expands attack surface, read the full diff before proceeding.
+
+### Updating a forked package
+
+```bash
+# 1. Check whether upstream has a new release
+gh release list -R MarkovWangRR/iso-topology --limit 5
+
+# 2. Review the diff on the three sensitive files between old and new version
+#    (substitute OLD and NEW version tags)
+gh api repos/MarkovWangRR/iso-topology/compare/vOLD...vNEW \
+  --jq '.files[] | select(.filename | test("icons.go|cmd/isotopo-mcp/main.go|go.mod")) | .filename'
+
+# 3. If the diff is acceptable, sync the fork's default branch
+gh repo sync bashfulrobot/iso-topology
+
+# 4. Create a matching release on the fork (this creates the tag the update
+#    scripts look for)
+gh release create vNEW \
+  --repo bashfulrobot/iso-topology \
+  --title "vNEW" \
+  --notes "Synced from upstream MarkovWangRR/iso-topology vNEW. Audited: icons.go, cmd/isotopo-mcp/main.go, go.mod."
+
+# 5. In settings/versions.nix set vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+#    then run the standard update workflow
+just setup::update-pkg iso-topology   # bumps version, clears source hash
+just qr                                # get correct source hash, update versions.nix
+just qr                                # get correct vendor hash, update versions.nix
+just qr                                # passes
+```
+
+After the rebuild passes, update the `# fork of ...; audited at vNEW` comments in both `settings/versions.nix` and `modules/apps/cli/iso-topology/build/default.nix`.

--- a/extras/scripts/update-pkg.bash
+++ b/extras/scripts/update-pkg.bash
@@ -170,6 +170,13 @@ update_github_release() {
         update_hash "$name" ""
         warn "$name: version updated to $latest, hash cleared -- rebuild to get correct hash"
     fi
+
+    # Check if package uses vendorHash (Go modules)
+    local vendor_hash
+    vendor_hash=$(echo "$pkg_json" | jq -r '.vendorHash // empty' 2>/dev/null) || true
+    if [[ -n "$vendor_hash" ]]; then
+        warn "$name: has vendorHash -- also set vendorHash = \"sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\" in versions.nix, then rebuild twice (source hash first, vendor hash second)"
+    fi
 }
 
 update_npm() {

--- a/modules/apps/cli/claude-code/cfg/mcp-servers.nix
+++ b/modules/apps/cli/claude-code/cfg/mcp-servers.nix
@@ -3,6 +3,7 @@
   pkgs,
   secrets,
   kubernetesMcpServer,
+  isoTopologyPkg,
   kubeconfigFile,
   serverProfile,
 }:
@@ -62,6 +63,13 @@ let
     gitmcp = {
       type = "http";
       url = "https://gitmcp.io/docs";
+    };
+    # iso-topology MCP server -- generate isometric 2.5D architecture diagrams
+    # from a text DSL. Exposes capabilities, validate, evaluate, render, and
+    # preview tools so agents can discover the DSL and produce design-grade SVGs
+    # without any external service call.
+    iso-topology = {
+      command = "${isoTopologyPkg}/bin/isotopo-mcp";
     };
   }
   // lib.optionalAttrs (serverProfile == "full") {

--- a/modules/apps/cli/claude-code/cfg/mcp-servers.nix
+++ b/modules/apps/cli/claude-code/cfg/mcp-servers.nix
@@ -71,8 +71,28 @@ let
     # preview tools so agents can discover the DSL and produce design-grade SVGs
     # without any external service call. Workstation-only: headless hosts have
     # no use for SVG generation.
+    #
+    # Sandboxed with bubblewrap: read-only filesystem view (icon: DSL can read
+    # local images but cannot write), network namespace isolated (no exfiltration
+    # path even if the read path is exploited). The output_dir write path is
+    # intentionally disabled in the sandbox; SVG content is returned inline in
+    # MCP responses instead.
     iso-topology = {
-      command = "${isoTopologyPkg}/bin/isotopo-mcp";
+      command = "${pkgs.bubblewrap}/bin/bwrap";
+      args = [
+        "--ro-bind"
+        "/"
+        "/"
+        "--dev"
+        "/dev"
+        "--proc"
+        "/proc"
+        "--tmpfs"
+        "/tmp"
+        "--unshare-net"
+        "--"
+        "${isoTopologyPkg}/bin/isotopo-mcp"
+      ];
     };
     # kubernetes-mcp-server requires a host-local kubeconfig at ${kubeconfigFile};
     # omitted on minimal-profile hosts (e.g. headless servers) where no

--- a/modules/apps/cli/claude-code/cfg/mcp-servers.nix
+++ b/modules/apps/cli/claude-code/cfg/mcp-servers.nix
@@ -64,15 +64,16 @@ let
       type = "http";
       url = "https://gitmcp.io/docs";
     };
+  }
+  // lib.optionalAttrs (serverProfile == "full") {
     # iso-topology MCP server -- generate isometric 2.5D architecture diagrams
     # from a text DSL. Exposes capabilities, validate, evaluate, render, and
     # preview tools so agents can discover the DSL and produce design-grade SVGs
-    # without any external service call.
+    # without any external service call. Workstation-only: headless hosts have
+    # no use for SVG generation.
     iso-topology = {
       command = "${isoTopologyPkg}/bin/isotopo-mcp";
     };
-  }
-  // lib.optionalAttrs (serverProfile == "full") {
     # kubernetes-mcp-server requires a host-local kubeconfig at ${kubeconfigFile};
     # omitted on minimal-profile hosts (e.g. headless servers) where no
     # cluster access is wired.

--- a/modules/apps/cli/claude-code/default.nix
+++ b/modules/apps/cli/claude-code/default.nix
@@ -249,42 +249,40 @@ in
 
   config = lib.mkIf cfg.enable {
     # System packages for MCP tooling and LSP servers
-    environment.systemPackages = [
-      isoTopologyPkg # isotopo CLI + isotopo-mcp server
-    ]
-    ++ (with pkgs; [
-      (writeScriptBin "mcp-pick" mcpPick)
-      llm-agents.claude-plugins # Plugin & skills manager
-      fzf
-      jq
-      rsync # used by claude-capture + activation to mirror skills
+    environment.systemPackages =
+      (with pkgs; [
+        (writeScriptBin "mcp-pick" mcpPick)
+        llm-agents.claude-plugins # Plugin & skills manager
+        fzf
+        jq
+        rsync # used by claude-capture + activation to mirror skills
 
-      # Language servers for Claude Code LSP integration
-      bash-language-server
-      dart
-      gopls
-      lua-language-server
-      pyright
-      rust-analyzer
-      terraform-ls
-      vtsls
-      yaml-language-server
-    ])
-    ++ lib.optionals (cfg.serverProfile == "full") [
-      # k8s-mcp-setup is the operator script that wires kubernetes-mcp-server
-      # against a host-local kubeconfig. Pointless on minimal-profile hosts
-      # where the kubernetes MCP server itself is gated out.
-      (pkgs.writeScriptBin "k8s-mcp-setup" k8s-mcp-setup)
-    ]
-    ++ lib.optionals hasHyperframes [
-      # Hyperframes plugin invokes `npx hyperframes` which spawns ffmpeg
-      # for rendering and a Chromium-family browser via puppeteer for HTML
-      # capture. The browser binary itself is whatever the user nominates
-      # via `globals.preferences.browser` (provisioned by suites.browsers
-      # or equivalent) -- not added here. Puppeteer is pointed at it via
-      # PUPPETEER_EXECUTABLE_PATH below.
-      pkgs.ffmpeg-full
-    ];
+        # Language servers for Claude Code LSP integration
+        bash-language-server
+        dart
+        gopls
+        lua-language-server
+        pyright
+        rust-analyzer
+        terraform-ls
+        vtsls
+        yaml-language-server
+      ])
+      ++ lib.optionals (cfg.serverProfile == "full") [
+        # k8s-mcp-setup is the operator script that wires kubernetes-mcp-server
+        # against a host-local kubeconfig. Pointless on minimal-profile hosts
+        # where the kubernetes MCP server itself is gated out.
+        (pkgs.writeScriptBin "k8s-mcp-setup" k8s-mcp-setup)
+      ]
+      ++ lib.optionals hasHyperframes [
+        # Hyperframes plugin invokes `npx hyperframes` which spawns ffmpeg
+        # for rendering and a Chromium-family browser via puppeteer for HTML
+        # capture. The browser binary itself is whatever the user nominates
+        # via `globals.preferences.browser` (provisioned by suites.browsers
+        # or equivalent) -- not added here. Puppeteer is pointed at it via
+        # PUPPETEER_EXECUTABLE_PATH below.
+        pkgs.ffmpeg-full
+      ];
 
     # Gemini API key for generate-images / visual-explainer skills.
     # Puppeteer env vars only applied when the hyperframes plugin is enabled --

--- a/modules/apps/cli/claude-code/default.nix
+++ b/modules/apps/cli/claude-code/default.nix
@@ -12,6 +12,7 @@
 let
   cfg = config.apps.cli.claude-code;
   kubernetesMcpServer = pkgs.callPackage ./build { inherit versions; };
+  isoTopologyPkg = pkgs.callPackage ../iso-topology/build { inherit versions; };
   homeDir = globals.user.homeDirectory;
   kubeconfigFile = "${homeDir}/.kube/mcp-viewer.kubeconfig";
 
@@ -22,6 +23,7 @@ let
       pkgs
       secrets
       kubernetesMcpServer
+      isoTopologyPkg
       kubeconfigFile
       ;
     inherit (cfg) serverProfile;
@@ -247,40 +249,42 @@ in
 
   config = lib.mkIf cfg.enable {
     # System packages for MCP tooling and LSP servers
-    environment.systemPackages =
-      (with pkgs; [
-        (writeScriptBin "mcp-pick" mcpPick)
-        llm-agents.claude-plugins # Plugin & skills manager
-        fzf
-        jq
-        rsync # used by claude-capture + activation to mirror skills
+    environment.systemPackages = [
+      isoTopologyPkg # isotopo CLI + isotopo-mcp server
+    ]
+    ++ (with pkgs; [
+      (writeScriptBin "mcp-pick" mcpPick)
+      llm-agents.claude-plugins # Plugin & skills manager
+      fzf
+      jq
+      rsync # used by claude-capture + activation to mirror skills
 
-        # Language servers for Claude Code LSP integration
-        bash-language-server
-        dart
-        gopls
-        lua-language-server
-        pyright
-        rust-analyzer
-        terraform-ls
-        vtsls
-        yaml-language-server
-      ])
-      ++ lib.optionals (cfg.serverProfile == "full") [
-        # k8s-mcp-setup is the operator script that wires kubernetes-mcp-server
-        # against a host-local kubeconfig. Pointless on minimal-profile hosts
-        # where the kubernetes MCP server itself is gated out.
-        (pkgs.writeScriptBin "k8s-mcp-setup" k8s-mcp-setup)
-      ]
-      ++ lib.optionals hasHyperframes [
-        # Hyperframes plugin invokes `npx hyperframes` which spawns ffmpeg
-        # for rendering and a Chromium-family browser via puppeteer for HTML
-        # capture. The browser binary itself is whatever the user nominates
-        # via `globals.preferences.browser` (provisioned by suites.browsers
-        # or equivalent) -- not added here. Puppeteer is pointed at it via
-        # PUPPETEER_EXECUTABLE_PATH below.
-        pkgs.ffmpeg-full
-      ];
+      # Language servers for Claude Code LSP integration
+      bash-language-server
+      dart
+      gopls
+      lua-language-server
+      pyright
+      rust-analyzer
+      terraform-ls
+      vtsls
+      yaml-language-server
+    ])
+    ++ lib.optionals (cfg.serverProfile == "full") [
+      # k8s-mcp-setup is the operator script that wires kubernetes-mcp-server
+      # against a host-local kubeconfig. Pointless on minimal-profile hosts
+      # where the kubernetes MCP server itself is gated out.
+      (pkgs.writeScriptBin "k8s-mcp-setup" k8s-mcp-setup)
+    ]
+    ++ lib.optionals hasHyperframes [
+      # Hyperframes plugin invokes `npx hyperframes` which spawns ffmpeg
+      # for rendering and a Chromium-family browser via puppeteer for HTML
+      # capture. The browser binary itself is whatever the user nominates
+      # via `globals.preferences.browser` (provisioned by suites.browsers
+      # or equivalent) -- not added here. Puppeteer is pointed at it via
+      # PUPPETEER_EXECUTABLE_PATH below.
+      pkgs.ffmpeg-full
+    ];
 
     # Gemini API key for generate-images / visual-explainer skills.
     # Puppeteer env vars only applied when the hyperframes plugin is enabled --

--- a/modules/apps/cli/iso-topology/build/default.nix
+++ b/modules/apps/cli/iso-topology/build/default.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
     "-w"
   ];
 
-  doCheck = false; # upstream test suite requires network access
+  doCheck = false; # d2 rendering dependency fetches fonts/assets; tests fail in sandbox
 
   meta = with lib; {
     description = "Isometric 2.5D architecture diagrams from a text DSL, with an MCP server for agent use";

--- a/modules/apps/cli/iso-topology/build/default.nix
+++ b/modules/apps/cli/iso-topology/build/default.nix
@@ -33,13 +33,12 @@ buildGoModule rec {
     "-w"
   ];
 
-  doCheck = false;
+  doCheck = false; # upstream test suite requires network access
 
   meta = with lib; {
     description = "Isometric 2.5D architecture diagrams from a text DSL, with an MCP server for agent use";
     homepage = "https://github.com/MarkovWangRR/iso-topology";
     license = licenses.asl20;
-    maintainers = [ ];
     mainProgram = "isotopo";
   };
 }

--- a/modules/apps/cli/iso-topology/build/default.nix
+++ b/modules/apps/cli/iso-topology/build/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   inherit (v) version;
 
   src = fetchFromGitHub {
-    owner = "MarkovWangRR";
+    owner = "bashfulrobot"; # fork of MarkovWangRR/iso-topology; audited at v0.15.0
     repo = "iso-topology";
     rev = "v${version}";
     inherit (v) hash;
@@ -37,7 +37,7 @@ buildGoModule rec {
 
   meta = with lib; {
     description = "Isometric 2.5D architecture diagrams from a text DSL, with an MCP server for agent use";
-    homepage = "https://github.com/MarkovWangRR/iso-topology";
+    homepage = "https://github.com/bashfulrobot/iso-topology";
     license = licenses.asl20;
     mainProgram = "isotopo";
   };

--- a/modules/apps/cli/iso-topology/build/default.nix
+++ b/modules/apps/cli/iso-topology/build/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versions,
+}:
+
+let
+  v = versions.cli."iso-topology";
+in
+buildGoModule rec {
+  pname = "iso-topology";
+  inherit (v) version;
+
+  src = fetchFromGitHub {
+    owner = "MarkovWangRR";
+    repo = "iso-topology";
+    rev = "v${version}";
+    inherit (v) hash;
+  };
+
+  inherit (v) vendorHash;
+
+  env.CGO_ENABLED = "0";
+
+  subPackages = [
+    "cmd/isotopo"
+    "cmd/isotopo-mcp"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Isometric 2.5D architecture diagrams from a text DSL, with an MCP server for agent use";
+    homepage = "https://github.com/MarkovWangRR/iso-topology";
+    license = licenses.asl20;
+    maintainers = [ ];
+    mainProgram = "isotopo";
+  };
+}

--- a/modules/apps/cli/iso-topology/default.nix
+++ b/modules/apps/cli/iso-topology/default.nix
@@ -1,0 +1,25 @@
+{
+  pkgs,
+  config,
+  lib,
+  versions,
+  ...
+}:
+
+let
+  cfg = config.apps.cli.iso-topology;
+  isoTopology = pkgs.callPackage ./build { inherit versions; };
+in
+{
+  options = {
+    apps.cli.iso-topology.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable iso-topology: isometric 2.5D architecture diagrams from a text DSL.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ isoTopology ];
+  };
+}

--- a/settings/versions.nix
+++ b/settings/versions.nix
@@ -140,6 +140,15 @@
       hash = "sha256-ZFSUnZlp+BGIfJGs8V/K2YSmBtJrvmjplmRhxlC0o7g=";
     };
 
+    "iso-topology" = {
+      source = "github-release";
+      repo = "MarkovWangRR/iso-topology";
+      version = "0.15.0";
+      tagPrefix = "v";
+      hash = "sha256-nOn144kK6iFvuDOzTGhaX5p5YRHTO2NWFD6xRk1UDW0=";
+      vendorHash = "sha256-V/8PjfqwofxIXY89reSu3sY3UAMOxApzYCwqCwYMxh8=";
+    };
+
     graymatter = {
       source = "github-release";
       repo = "angelnicolasc/graymatter";

--- a/settings/versions.nix
+++ b/settings/versions.nix
@@ -142,7 +142,7 @@
 
     "iso-topology" = {
       source = "github-release";
-      repo = "MarkovWangRR/iso-topology";
+      repo = "bashfulrobot/iso-topology"; # fork of MarkovWangRR/iso-topology; audited at v0.15.0
       version = "0.15.0";
       tagPrefix = "v";
       hash = "sha256-nOn144kK6iFvuDOzTGhaX5p5YRHTO2NWFD6xRk1UDW0=";


### PR DESCRIPTION
## Summary

Closes #120: ISO topology maker

- Add `buildGoModule` derivation for iso-topology v0.15.0, producing both `isotopo` (CLI) and `isotopo-mcp` (MCP server) binaries
- Add `apps.cli.iso-topology` NixOS module (disabled by default); when enabled, adds `isotopo` to `environment.systemPackages`
- Wire `isotopo-mcp` into the claude-code MCP servers config, gated behind `serverProfile == "full"` (workstations only) so headless hosts don't start the server on every session
- `isoTopologyPkg` is built inside the claude-code module for the MCP server path but is **not** added to `environment.systemPackages` from there; the standalone `apps.cli.iso-topology` module is the sole delivery mechanism for putting `isotopo` on PATH

Pin: v0.15.0, vendorHash `sha256-V/8PjfqwofxIXY89reSu3sY3UAMOxApzYCwqCwYMxh8=`