### PR TITLE
fix(render-secrets): correct incus cert vault item title to incus-ui.crt

### DIFF
--- a/extras/docs/secrets.md
+++ b/extras/docs/secrets.md
@@ -101,7 +101,7 @@ Current MATERIALIZE entries:
 | `id_ed25519`, `id_ed25519_np`, `id_rsa` | `~/.ssh/<name>` | 0600 | workstation hosts |
 | `id_ed25519.pub`, `id_rsa.pub`, `id_rsa_np.pub` | `~/.ssh/<name>` | 0644 | workstation hosts |
 | `mixerator-`, `nixcfg-`, `nixerator-`, `talos-vms-git-crypt-key` | `~/.ssh/<name>` | 0600 | workstation hosts |
-| `incus-client.crt` | `~/.config/incus/client.crt` | 0644 | all hosts |
+| `incus-ui.crt` | `~/.config/incus/client.crt` | 0644 | all hosts |
 | `incus-client.pfx` | `~/.config/incus/client.pfx` | 0600 | workstation hosts |
 
 Current PUSH_ALONGSIDE entries (also pushed to remotes by `--push`):
@@ -209,7 +209,7 @@ Names are pinned — they must match `secrets.json.tpl` exactly.
 | `id_ed25519{,_np,.pub}`, `id_rsa{,.pub}`, `id_rsa_np.pub` | Document | `file` | `~/.ssh/<name>` on workstation hosts (via `render-secrets`) |
 | `mixerator-`, `nixcfg-`, `nixerator-`, `talos-vms-git-crypt-key` | Document | `file` | `~/.ssh/<name>` on workstation hosts (via `render-secrets`) |
 | `gmailctl` | Login | `Client ID` + `Client Secret` | `~/.gmailctl/credentials.json` (via `just fetch-gmailctl-creds`, which `op inject`s the two fields into a Desktop-app credentials.json template). Rendered straight to disk, **not** in `secrets.json` — keeps the client secret out of the Nix store. `gmailctl init` then writes `~/.gmailctl/token.json` locally. |
-| `incus-client.crt` | Document | `file` | `~/.config/incus/client.crt` on all hosts (via `render-secrets` MATERIALIZE, 0644). Public certificate read by the Incus module via `builtins.readFile` at Nix eval time and injected into the preseed trust store. All Incus hosts; safe to be world-readable. **If this item is absent from the vault, `render-secrets` automatically extracts the cert from `client.pfx` on workstations — no manual upload required after the pfx is in place.** |
+| `incus-ui.crt` | Document | `file` | `~/.config/incus/client.crt` on all hosts (via `render-secrets` MATERIALIZE, 0644). Public certificate read by the Incus module via `builtins.readFile` at Nix eval time and injected into the preseed trust store. All Incus hosts; safe to be world-readable. If this item is absent from the vault, `render-secrets` automatically extracts the cert from `client.pfx` on workstations. |
 | `incus-client.pfx` | Document | `file` | `~/.config/incus/client.pfx` on workstations (via `render-secrets` MATERIALIZE, 0600). PKCS12 bundle with private key; import into a browser to authenticate against any Incus web UI. Workstations only — srv is headless. The pfx is the source of truth; the crt is derived from it automatically. |
 
 Per-host network identity (Tailscale IPs, syncthing peer IDs) is NOT in 1P;

--- a/modules/apps/cli/render-secrets/render-secrets.sh
+++ b/modules/apps/cli/render-secrets/render-secrets.sh
@@ -63,7 +63,7 @@ MATERIALIZE=(
   # Read by the Nix module via builtins.readFile at eval time to populate
   # the preseed trust store. 644 because it is a public key. Also listed
   # in PUSH_ALONGSIDE so --push propagates it alongside secrets.json.
-  "incus-client.crt|${HOME}/.config/incus/client.crt|644|700|"
+  "incus-ui.crt|${HOME}/.config/incus/client.crt|644|700|"
 
   # Incus browser client certificate (PKCS12 bundle — private key inside).
   # Workstations only: needed for importing into a browser to authenticate


### PR DESCRIPTION
The 1Password Document item holding the Incus browser client certificate is named `incus-ui.crt`, not `incus-client.crt`. The MATERIALIZE entry was looking for the wrong title, causing `render-secrets` to fail on every host with:

```
"incus-client.crt" isn't an item in the "nixerator" vault
render-secrets: FAILED to materialize: /home/dustin/.config/incus/client.crt
```

Updates the MATERIALIZE entry and docs to match the actual vault item name.

## Test plan
- [ ] `just render-secrets` on donkeykong succeeds and materializes `~/.config/incus/client.crt`