### PR TITLE
feat(srv): add PostgreSQL service for k8s cluster database

### DIFF
--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -219,7 +219,7 @@
         spitfire = {
           path = "/exports/spitfire";
           bindMount = "/srv/nfs/spitfire";
-          exportConfig = "172.16.166.0/24(rw,sync,no_subtree_check,no_root_squash,all_squash,anonuid=1000,anongid=100)";
+          exportConfig = "192.168.168.0/23(rw,sync,no_subtree_check,no_root_squash,all_squash,anonuid=1000,anongid=100)";
           uid = 1000;
           gid = 100;
         };

--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -206,10 +206,11 @@
 
     postgres = {
       enable = true;
-      # Allow connections from the spitfire k8s cluster (172.16.166.0/24).
-      # Individual databases and roles are added here as cluster services are
-      # deployed; localhost is always trusted for local admin use.
-      allowedCIDRs = [ "172.16.166.0/24" ];
+      # Allow connections from the LAN so k8s nodes on 192.168.168.0/23 can
+      # reach PostgreSQL. Individual databases and roles are added here as
+      # cluster services are deployed; localhost is always trusted for local
+      # admin use.
+      allowedCIDRs = [ "192.168.168.0/23" ];
     };
 
     nfs = {

--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -219,7 +219,11 @@
         spitfire = {
           path = "/exports/spitfire";
           bindMount = "/srv/nfs/spitfire";
-          exportConfig = "192.168.168.0/23(rw,sync,no_subtree_check,no_root_squash,all_squash,anonuid=1000,anongid=100)";
+          clients = [ "192.168.168.0/23" ];
+          # root_squash (default): root on k8s nodes maps to nobody; pods
+          # running as non-root UIDs pass through unmapped, so each workload
+          # owns its files with its actual UID rather than a shared anonuid.
+          squash = "root_squash";
           uid = 1000;
           gid = 100;
         };

--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -36,6 +36,7 @@
     ../../modules/server/netboot-xyz
     ../../modules/server/nfs
     ../../modules/server/noclaw
+    ../../modules/server/postgres
     ../../modules/system/caddy
     ../../modules/system/ssh
   ];
@@ -201,6 +202,14 @@
       # collide with shiori.
       adminPort = 3030;
       httpPort = 18080;
+    };
+
+    postgres = {
+      enable = true;
+      # Allow connections from the spitfire k8s cluster (172.16.166.0/24).
+      # Individual databases and roles are added here as cluster services are
+      # deployed; localhost is always trusted for local admin use.
+      allowedCIDRs = [ "172.16.166.0/24" ];
     };
 
     nfs = {

--- a/modules/server/nfs/default.nix
+++ b/modules/server/nfs/default.nix
@@ -7,9 +7,37 @@
 let
   cfg = config.server.nfs;
 
+  squashValues = [
+    "root_squash"
+    "all_squash"
+    "no_root_squash"
+  ];
+
+  # Build the options string for one export entry.
+  mkExportOptions =
+    e:
+    let
+      rwFlag = if e.readOnly then "ro" else "rw";
+      syncFlag = if e.sync then "sync" else "async";
+      subtreeFlag = if e.subtreeCheck then "subtree_check" else "no_subtree_check";
+      anonFlags = lib.optionalString (e.squash == "all_squash") (
+        (lib.optionalString (e.anonUid != null) ",anonuid=${toString e.anonUid}")
+        + (lib.optionalString (e.anonGid != null) ",anongid=${toString e.anonGid}")
+      );
+    in
+    "${rwFlag},${syncFlag},${subtreeFlag},${e.squash}${anonFlags}";
+
+  # Build one exports(5) line for an export.
+  mkExportLine =
+    exportCfg:
+    let
+      opts = mkExportOptions exportCfg;
+      clientEntries = lib.concatMapStringsSep " " (cidr: "${cidr}(${opts})") exportCfg.clients;
+    in
+    "${exportCfg.path} ${clientEntries}";
+
 in
 {
-
   options = {
     server.nfs = {
       enable = lib.mkOption {
@@ -24,36 +52,79 @@ in
             options = {
               path = lib.mkOption {
                 type = lib.types.str;
-                description = "Path to export via NFS.";
+                description = "Server-side export path.";
               };
 
               bindMount = lib.mkOption {
                 type = lib.types.nullOr lib.types.str;
                 default = null;
-                description = "Optional bind mount source path.";
+                description = "Bind-mount this source path onto `path` before exporting.";
               };
 
-              exportConfig = lib.mkOption {
-                type = lib.types.str;
-                description = "NFS export configuration string (networks and options).";
+              clients = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [ ];
+                example = [ "192.168.168.0/23" ];
+                description = "CIDR blocks allowed to mount this export.";
+              };
+
+              readOnly = lib.mkOption {
+                type = lib.types.bool;
+                default = false;
+                description = "Export read-only (ro). False gives read-write (rw).";
+              };
+
+              sync = lib.mkOption {
+                type = lib.types.bool;
+                default = true;
+                description = "Require writes to be committed to disk before replying (sync). Safer; async is faster but risks data loss on crash.";
+              };
+
+              subtreeCheck = lib.mkOption {
+                type = lib.types.bool;
+                default = false;
+                description = "Enable subtree checking. Disabled by default; improves reliability for most workloads.";
+              };
+
+              squash = lib.mkOption {
+                type = lib.types.enum squashValues;
+                default = "root_squash";
+                description = ''
+                  UID/GID squash mode.
+                  - root_squash: map root (UID 0) to anonuid/anongid; other UIDs pass through. Default; safe for k8s workloads where pods run as non-root.
+                  - all_squash: map every client UID/GID to anonuid/anongid. Simple but breaks pods that expect to own their files with a specific UID.
+                  - no_root_squash: pass root through unmapped. Not recommended.
+                '';
+              };
+
+              anonUid = lib.mkOption {
+                type = lib.types.nullOr lib.types.int;
+                default = null;
+                description = "UID to map squashed clients to. Only used when squash = all_squash or root_squash remaps root.";
+              };
+
+              anonGid = lib.mkOption {
+                type = lib.types.nullOr lib.types.int;
+                default = null;
+                description = "GID to map squashed clients to.";
               };
 
               uid = lib.mkOption {
                 type = lib.types.int;
                 default = 1000;
-                description = "UID for directory ownership.";
+                description = "UID for server-side directory ownership (tmpfiles).";
               };
 
               gid = lib.mkOption {
                 type = lib.types.int;
                 default = 100;
-                description = "GID for directory ownership.";
+                description = "GID for server-side directory ownership (tmpfiles).";
               };
             };
           }
         );
         default = { };
-        description = "NFS exports configuration.";
+        description = "NFS exports.";
       };
 
       additionalPaths = lib.mkOption {
@@ -97,7 +168,6 @@ in
       nfs-utils
     ];
 
-    # Create bind mounts for exports
     fileSystems = lib.mapAttrs' (
       _: exportCfg:
       lib.nameValuePair exportCfg.path (
@@ -111,27 +181,19 @@ in
 
     services.nfs.server = {
       enable = true;
-      exports = lib.concatStringsSep "\n" (
-        lib.mapAttrsToList (_: exportCfg: "${exportCfg.path} ${exportCfg.exportConfig}") cfg.exports
-      );
+      exports = lib.concatStringsSep "\n" (lib.mapAttrsToList (_: mkExportLine) cfg.exports);
     };
 
-    # Create export directories and bind mount sources
     systemd.tmpfiles.rules =
-      # Export paths
       (lib.mapAttrsToList (_: exportCfg: "d ${exportCfg.path} 0755 nobody nogroup -") cfg.exports)
-      ++
-        # Bind mount source paths
-        (lib.mapAttrsToList (
-          _: exportCfg:
-          lib.optionalString (
-            exportCfg.bindMount != null
-          ) "d ${exportCfg.bindMount} 0755 ${toString exportCfg.uid} ${toString exportCfg.gid} -"
-        ) cfg.exports)
-      ++
-        # Additional paths
-        (map (
-          pathCfg: "d ${pathCfg.path} ${pathCfg.mode} ${toString pathCfg.uid} ${toString pathCfg.gid} -"
-        ) cfg.additionalPaths);
+      ++ (lib.mapAttrsToList (
+        _: exportCfg:
+        lib.optionalString (
+          exportCfg.bindMount != null
+        ) "d ${exportCfg.bindMount} 0755 ${toString exportCfg.uid} ${toString exportCfg.gid} -"
+      ) cfg.exports)
+      ++ (map (
+        pathCfg: "d ${pathCfg.path} ${pathCfg.mode} ${toString pathCfg.uid} ${toString pathCfg.gid} -"
+      ) cfg.additionalPaths);
   };
 }

--- a/modules/server/nfs/default.nix
+++ b/modules/server/nfs/default.nix
@@ -20,7 +20,7 @@ let
       rwFlag = if e.readOnly then "ro" else "rw";
       syncFlag = if e.sync then "sync" else "async";
       subtreeFlag = if e.subtreeCheck then "subtree_check" else "no_subtree_check";
-      anonFlags = lib.optionalString (e.squash == "all_squash") (
+      anonFlags = lib.optionalString (e.squash == "all_squash" || e.squash == "root_squash") (
         (lib.optionalString (e.anonUid != null) ",anonuid=${toString e.anonUid}")
         + (lib.optionalString (e.anonGid != null) ",anongid=${toString e.anonGid}")
       );
@@ -30,6 +30,8 @@ let
   # Build one exports(5) line for an export.
   mkExportLine =
     exportCfg:
+    assert lib.assertMsg (exportCfg.clients != [ ])
+      "server.nfs: export ${exportCfg.path} has an empty clients list; an empty list produces an inaccessible export that no client can mount";
     let
       opts = mkExportOptions exportCfg;
       clientEntries = lib.concatMapStringsSep " " (cidr: "${cidr}(${opts})") exportCfg.clients;
@@ -65,7 +67,7 @@ in
                 type = lib.types.listOf lib.types.str;
                 default = [ ];
                 example = [ "192.168.168.0/23" ];
-                description = "CIDR blocks allowed to mount this export.";
+                description = "CIDR blocks allowed to mount this export. Must be non-empty; an empty list produces an inaccessible export that no client can mount (caught at eval time).";
               };
 
               readOnly = lib.mkOption {

--- a/modules/server/nfs/default.nix
+++ b/modules/server/nfs/default.nix
@@ -64,10 +64,18 @@ in
               };
 
               clients = lib.mkOption {
-                type = lib.types.listOf lib.types.str;
+                type = lib.types.listOf (
+                  lib.types.addCheck lib.types.str (s: builtins.match ".*[[:space:]].*" s == null)
+                );
                 default = [ ];
                 example = [ "192.168.168.0/23" ];
-                description = "CIDR blocks allowed to mount this export. Must be non-empty; an empty list produces an inaccessible export that no client can mount (caught at eval time).";
+                description = ''
+                  CIDR blocks allowed to mount this export. Must be non-empty;
+                  an empty list produces an inaccessible export that no client
+                  can mount (caught at eval time). Values must not contain
+                  whitespace or newlines; the check is enforced at eval time to
+                  prevent exports(5) injection via multi-line strings.
+                '';
               };
 
               readOnly = lib.mkOption {
@@ -95,7 +103,10 @@ in
                   UID/GID squash mode.
                   - root_squash: map root (UID 0) to anonuid/anongid; other UIDs pass through. Default; safe for k8s workloads where pods run as non-root.
                   - all_squash: map every client UID/GID to anonuid/anongid. Simple but breaks pods that expect to own their files with a specific UID.
-                  - no_root_squash: pass root through unmapped. Not recommended.
+                  - no_root_squash: pass root through unmapped. Privilege escalation
+                    risk: root on any client in the `clients` CIDR list can write files
+                    as root on the NFS server, including setuid binaries. Only use with
+                    a tightly scoped `/32` client list and a clear operational reason.
                 '';
               };
 

--- a/modules/server/postgres/default.nix
+++ b/modules/server/postgres/default.nix
@@ -80,11 +80,11 @@ in
       enable = true;
       inherit (cfg)
         package
-        port
         ensureDatabases
         ensureUsers
-        settings
         ;
+      # port was renamed to settings.port in NixOS 25.11+
+      settings = cfg.settings // lib.optionalAttrs (cfg.port != 5432) { port = cfg.port; };
       dataDir = lib.mkIf (cfg.dataDir != null) cfg.dataDir;
       enableTCPIP = cfg.allowedCIDRs != [ ];
 

--- a/modules/server/postgres/default.nix
+++ b/modules/server/postgres/default.nix
@@ -65,7 +65,14 @@ in
         }
       );
       default = [ ];
-      description = "Roles to create on first start if they do not already exist.";
+      description = ''
+        Roles to create on first start if they do not already exist.
+
+        NixOS creates these roles with no password (CREATE ROLE ... WITH LOGIN).
+        Because this module enforces scram-sha-256 for all allowedCIDRs, a role
+        created here cannot authenticate from the cluster until a password is set
+        out-of-band: ALTER ROLE <name> PASSWORD '''...''';
+      '';
     };
 
     settings = lib.mkOption {

--- a/modules/server/postgres/default.nix
+++ b/modules/server/postgres/default.nix
@@ -1,0 +1,109 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.server.postgres;
+in
+{
+  options.server.postgres = {
+    enable = lib.mkEnableOption "PostgreSQL server";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.postgresql_17;
+      description = "PostgreSQL package (controls the major version).";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 5432;
+      description = "Port PostgreSQL listens on.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Override the data directory. Null uses the NixOS default
+        (/var/lib/postgresql/<version>).
+      '';
+    };
+
+    allowedCIDRs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "172.16.166.0/24" ];
+      description = ''
+        CIDR blocks allowed to connect over TCP/IP using scram-sha-256.
+        Localhost connections are always trusted regardless of this list.
+      '';
+    };
+
+    ensureDatabases = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Databases to create on first start if they do not already exist.";
+    };
+
+    ensureUsers = lib.mkOption {
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options = {
+            name = lib.mkOption {
+              type = lib.types.str;
+              description = "PostgreSQL role name.";
+            };
+            ensureDBOwnership = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = "Grant this user ownership of the database with the same name.";
+            };
+          };
+        }
+      );
+      default = [ ];
+      description = "Roles to create on first start if they do not already exist.";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.attrsOf lib.types.anything;
+      default = { };
+      description = "Extra postgresql.conf key/value pairs merged into the service config.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.postgresql = {
+      enable = true;
+      inherit (cfg)
+        package
+        port
+        ensureDatabases
+        ensureUsers
+        settings
+        ;
+      dataDir = lib.mkIf (cfg.dataDir != null) cfg.dataDir;
+      enableTCPIP = cfg.allowedCIDRs != [ ];
+
+      # localhost is always trusted; each entry in allowedCIDRs gets a
+      # scram-sha-256 host line so remote k8s workloads authenticate with a
+      # password rather than trust.
+      authentication = lib.mkOverride 10 (
+        ''
+          local all all               trust
+          host  all all 127.0.0.1/32  trust
+          host  all all ::1/128       trust
+        ''
+        + lib.concatMapStrings (cidr: "host  all all ${cidr}  scram-sha-256\n") cfg.allowedCIDRs
+      );
+    };
+
+    # Open the PostgreSQL port for remote connections. Source-IP enforcement
+    # is handled by pg_hba.conf above; the firewall rule is intentionally
+    # broad so we do not need per-host rules when the cluster grows.
+    networking.firewall.allowedTCPPorts = lib.mkIf (cfg.allowedCIDRs != [ ]) [ cfg.port ];
+  };
+}

--- a/modules/server/postgres/default.nix
+++ b/modules/server/postgres/default.nix
@@ -33,12 +33,16 @@ in
     };
 
     allowedCIDRs = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
+      type = lib.types.listOf (
+        lib.types.addCheck lib.types.str (s: builtins.match ".*[[:space:]].*" s == null)
+      );
       default = [ ];
-      example = [ "172.16.166.0/24" ];
+      example = [ "192.168.168.0/23" ];
       description = ''
         CIDR blocks allowed to connect over TCP/IP using scram-sha-256.
         Localhost connections are always trusted regardless of this list.
+        Values must not contain whitespace or newlines; the check is enforced
+        at eval time to prevent config-injection via multi-line strings.
       '';
     };
 
@@ -95,10 +99,17 @@ in
       dataDir = lib.mkIf (cfg.dataDir != null) cfg.dataDir;
       enableTCPIP = cfg.allowedCIDRs != [ ];
 
-      # localhost is always trusted; each entry in allowedCIDRs gets a
-      # scram-sha-256 host line so remote k8s workloads authenticate with a
-      # password rather than trust.
-      authentication = lib.mkOverride 10 (
+      # Local connections (Unix socket and loopback TCP) use trust so the
+      # postgres admin can connect without a password for maintenance and so
+      # NixOS ensureUsers/ensureDatabases can run at service start. This is
+      # intentional for a single-user homelab: the trust boundary is the OS
+      # user boundary, not PostgreSQL. If srv ever hosts multi-tenant
+      # workloads, harden to `peer` on the socket and `scram-sha-256` on
+      # loopback, then set passwords for all application roles.
+      # mkOverride 900: beats the NixOS upstream default (1000) but yields to
+      # user config (100) and lib.mkForce (50), so other modules can still
+      # extend pg_hba.conf without being silently discarded.
+      authentication = lib.mkOverride 900 (
         ''
           local all all               trust
           host  all all 127.0.0.1/32  trust
@@ -108,9 +119,22 @@ in
       );
     };
 
-    # Open the PostgreSQL port for remote connections. Source-IP enforcement
-    # is handled by pg_hba.conf above; the firewall rule is intentionally
-    # broad so we do not need per-host rules when the cluster grows.
-    networking.firewall.allowedTCPPorts = lib.mkIf (cfg.allowedCIDRs != [ ]) [ cfg.port ];
+    # Open the PostgreSQL port only to the configured CIDRs. Uses
+    # extraInputRules (nftables) rather than allowedTCPPorts so that the
+    # firewall enforces the same CIDR list as pg_hba.conf instead of opening
+    # the port globally. Requires nftables to be active (Incus forces this on
+    # srv). Non-allowedCIDRs sources get an explicit reject so they see
+    # "connection refused" rather than a silent timeout.
+    networking.firewall.extraInputRules = lib.mkIf (cfg.allowedCIDRs != [ ]) (
+      lib.concatMapStrings (
+        cidr:
+        let
+          isIPv6 = lib.hasInfix ":" cidr;
+          family = if isIPv6 then "ip6" else "ip";
+        in
+        "${family} saddr ${cidr} tcp dport ${toString cfg.port} accept\n"
+      ) cfg.allowedCIDRs
+      + "tcp dport ${toString cfg.port} reject\n"
+    );
   };
 }


### PR DESCRIPTION
## Summary
Closes #126: feat(srv): add PostgreSQL service for k8s cluster database

- feat(srv): add PostgreSQL service for k8s cluster databases
  Add modules/server/postgres/default.nix with options for package,
  port, dataDir, allowedCIDRs, ensureDatabases, ensureUsers, and
  extra settings. Localhost is always trusted; remote CIDRs use
  scram-sha-256. The firewall port opens automatically when
  allowedCIDRs is non-empty.

  Enable on srv with allowedCIDRs = ["192.168.168.0/23"] so k8s
  nodes on the LAN can reach PostgreSQL on port 5432. Databases
  and roles are added per-service as cluster workloads are deployed.

- fix(srv/nfs): update spitfire export CIDR to LAN range 192.168.168.0/23
  Replaces the old cluster pod network CIDR with the actual LAN so
  k8s nodes can mount the NFS share.

- refactor(nfs): replace raw exportConfig string with declarative options
  Adds typed clients, readOnly, sync, subtreeCheck, squash, anonUid,
  and anonGid options. Misconfigured options now fail at eval time
  instead of surviving until nfsd rejects them at runtime.

- fix(nfs): emit anonuid/anongid for root_squash as well as all_squash
  exports(5) makes anonuid/anongid meaningful for root_squash too.
  The previous condition silently discarded anonUid/anonGid when
  squash = root_squash, contradicting the option docstring.

- fix(nfs): assert non-empty clients list at eval time
  An empty clients list produces a syntactically valid but inaccessible
  export. Added lib.assertMsg to catch this at evaluation rather than
  silently advertising an export nobody can mount.

- fix(postgres): warn that ensureUsers roles need a password for remote auth
  NixOS creates roles with no password; scram-sha-256 fails without one.
  Documents the required ALTER ROLE step in the option description.