### PR TITLE
chore(claude-code): drop libreoffice dep after removing marp-slides skill

### DIFF
--- a/modules/apps/cli/claude-code/default.nix
+++ b/modules/apps/cli/claude-code/default.nix
@@ -304,7 +304,6 @@ in
             with pkgs;
             [
               libnotify # for notify-send in Stop hook (workstation-only)
-              libreoffice # soffice on PATH -- required for marp-slides skill's --pptx-editable export (workstation-only)
               sox # rec on PATH -- required for Claude Code /voice audio recording (workstation-only)
             ]
           )


### PR DESCRIPTION
## Summary
- Deprecated and removed the `marp-slides` skill (`~/.claude/skills/marp-slides`, not git-tracked) in favor of `revealjs` for slide decks going forward
- Dropped the `libreoffice` package from the claude-code home-manager module — it was only there to provide `soffice` for marp-slides' `--pptx-editable` PPTX export, which no longer exists

## Test plan
- [x] `nix fmt` — no changes
- [x] `statix check` — clean
- [x] `deadnix` — clean
- [x] Confirmed `libreoffice` had no other references in the repo