### PR TITLE
feat(claude-code): register bare-claude bg sessions for remote control

### DIFF
--- a/.claude/docs/cross-device-workflow.md
+++ b/.claude/docs/cross-device-workflow.md
@@ -11,6 +11,10 @@ The zellij module ships two wrappers, installed wherever `apps.cli.zellij.enable
 - `zj` — tight zellij wrapper. `zj s` list, `zj a [<name>]` attach, `zj n <name>` new (or `zj n <name> -- <cmd>`), `zj d` delete. Anything else passes through to `zellij`.
 - `czj` — `zj` layered for Claude. Starts a zellij session whose first pane is `claude` with a remote-control endpoint already attached, so the same session is usable locally **and** from claude.ai/code without a separate control-tower service.
 
+### bare `claude`
+
+The claude-code module's fish wrapper (`modules/apps/cli/claude-code/cfg/fish.nix`) intercepts a bare `claude` invocation (no args, interactive TTY): it prompts for a session name, then runs `claude --bg --name "$name" --remote-control "$name"`. `--bg` and `--remote-control` combine on one invocation — the session is a background agent (manageable via `claude agents`/`claude attach <id>`) that *also* registers a Remote Control endpoint under the same name, so it shows up in claude.ai/code and the iOS app without a separate zellij launch. This works outside zellij too (any host, not just `archetypes.claudeWorkHost` peers).
+
 ### `work` (cross-host picker)
 
 The `work` fish function is installed on every host (workstations + peers). Use it when you want to attach to a session that lives on another host without remembering which one.
@@ -25,7 +29,7 @@ Sessions are named per-repo by convention: zellij session name = repo basename (
 
 ## iPhone
 
-- **Spawn or resume from claude.ai/code:** czj sessions register their own remote-control endpoints, so claude.ai/code's session list picks them up directly. No separate control-tower service.
+- **Spawn or resume from claude.ai/code:** czj sessions and bare-`claude` background sessions both register their own remote-control endpoints, so claude.ai/code's session list picks them up directly. No separate control-tower service.
 - **SSH fallback (rarely needed):** Termius / Blink / Prompt over Tailscale → `ssh srv` (or `qbert` / `clanker`) → `zj a <name>` or `work`. SSH only — no mosh, no zellij-web.
 
 ## /github-issue

--- a/modules/apps/cli/claude-code/cfg/fish.nix
+++ b/modules/apps/cli/claude-code/cfg/fish.nix
@@ -11,6 +11,10 @@
     # (visible across all projects, git or not). Anything with args -- claude
     # agents / -r / -p / mcp / --bg ... -- passes straight through unchanged.
     # Escape hatch: `command claude` runs a plain foreground session.
+    #
+    # --remote-control "$name" rides along with --bg under the same name, so
+    # the session is also picked up by claude.ai/code and the iOS app without
+    # a separate czj/zellij launch.
     claude = {
       wraps = "claude";
       body = ''
@@ -22,7 +26,7 @@
             end
             test -z "$name"; and set name $default_name
 
-            set -l out (command claude --bg --name "$name")
+            set -l out (command claude --bg --name "$name" --remote-control "$name")
             printf '%s\n' $out
             set -l id (string match -rg 'claude attach (\S+)' -- $out)
             if test -n "$id"


### PR DESCRIPTION
## Summary
- Bare `claude` (no args, interactive TTY) starts a background agent via `claude --bg --name "$name"` but never registered a Remote Control endpoint, so those sessions didn't show up in claude.ai/code or the iOS app unless started through `czj`/zellij.
- `--bg` and `--remote-control` combine on a single invocation (verified against the installed `claude` binary), so the wrapper now passes `--remote-control "$name"` alongside `--bg` under the same name.
- Updated `.claude/docs/cross-device-workflow.md` to document the new path.

## Test plan
- [x] `just build-host qbert` builds cleanly with the change
- [x] Verified empirically that `claude --bg --name X --remote-control X` registers both a background agent (`claude agents --json`) and an active Remote Control endpoint under the same name
- [x] Confirmed the `claude attach <id>` regex parse in the fish wrapper still matches the combined-flag output