### PR TITLE
Configure tableau mcp

### DIFF
--- a/extras/docs/secrets.md
+++ b/extras/docs/secrets.md
@@ -187,6 +187,7 @@ Names are pinned — they must match `secrets.json.tpl` exactly.
 | Item | Type | Fields | Consumed as |
 |------|------|--------|-------------|
 | `kong-konnect-pat` | API Credential | `credential` | `secrets.kong.kongKonnectPAT` |
+| `Tableau PAT` | API Credential | `hostname`, `Site Name`, `username`, `credential` | `secrets.tableau.{server,siteName,patName,patValue}` (self-hosted/local Tableau MCP against Kong's Tableau Cloud site; injected as `SERVER`/`SITE_NAME`/`PAT_NAME`/`PAT_VALUE` by the claude-code module) |
 | `aha` | API Credential | `credential` | `secrets.aha.apiToken` (injected as `AHA_API_TOKEN` by the claude-code module for the `aha` skill) |
 | `wave` | API Credential | `credential` | `secrets.wave.fullAccessToken` (injected as `WAVE_FULL_ACCESS_TOKEN` by the claude-code module for the `wave-invoicing` skill; Wave Full Access Token — personal-use bearer, no OAuth) |
 | `context7` | API Credential | `credential` | `secrets.context7.apiKey` |

--- a/extras/docs/secrets.md
+++ b/extras/docs/secrets.md
@@ -187,7 +187,7 @@ Names are pinned — they must match `secrets.json.tpl` exactly.
 | Item | Type | Fields | Consumed as |
 |------|------|--------|-------------|
 | `kong-konnect-pat` | API Credential | `credential` | `secrets.kong.kongKonnectPAT` |
-| `Tableau PAT` | API Credential | `hostname`, `Site Name`, `username`, `credential` | `secrets.tableau.{server,siteName,patName,patValue}` (self-hosted/local Tableau MCP against Kong's Tableau Cloud site; injected as `SERVER`/`SITE_NAME`/`PAT_NAME`/`PAT_VALUE` by the claude-code module) |
+| `Tableau PAT` | API Credential | `hostname` (full `https://` origin, not a bare host), `Site Name`, `username`, `credential` | `secrets.tableau.{server,siteName,patName,patValue}` (self-hosted/local Tableau MCP against Kong's Tableau Cloud site; injected as `SERVER`/`SITE_NAME`/`PAT_NAME`/`PAT_VALUE` by the claude-code module; workstation-only, see `serverProfile` gate in `mcp-servers.nix`) |
 | `aha` | API Credential | `credential` | `secrets.aha.apiToken` (injected as `AHA_API_TOKEN` by the claude-code module for the `aha` skill) |
 | `wave` | API Credential | `credential` | `secrets.wave.fullAccessToken` (injected as `WAVE_FULL_ACCESS_TOKEN` by the claude-code module for the `wave-invoicing` skill; Wave Full Access Token — personal-use bearer, no OAuth) |
 | `context7` | API Credential | `credential` | `secrets.context7.apiKey` |

--- a/modules/apps/cli/claude-code/cfg/mcp-servers.nix
+++ b/modules/apps/cli/claude-code/cfg/mcp-servers.nix
@@ -143,6 +143,27 @@ let
         Authorization = "Bearer ${secrets.kong.kongKonnectPAT}";
       };
     };
+  }
+  // lib.optionalAttrs (secrets.tableau.patValue or null != null) {
+    # Tableau MCP -- query/explore Tableau Cloud content (workbooks, views,
+    # datasources) via natural language: https://github.com/tableau/tableau-mcp
+    # Self-hosted/local (PAT-based) mode, not the hosted OAuth mcp.tableau.com
+    # endpoint, matching the Claude Desktop setup already in use against
+    # Kong's Tableau Cloud site. All four values (server, site, PAT name/value)
+    # live on the "Tableau PAT" 1Password item.
+    tableau = {
+      command = "${pkgs.nodejs}/bin/npx";
+      args = [
+        "-y"
+        "@tableau/mcp-server@latest"
+      ];
+      env = {
+        SERVER = secrets.tableau.server;
+        SITE_NAME = secrets.tableau.siteName;
+        PAT_NAME = secrets.tableau.patName;
+        PAT_VALUE = secrets.tableau.patValue;
+      };
+    };
   };
 
   mkMcpServerJson =

--- a/modules/apps/cli/claude-code/cfg/mcp-servers.nix
+++ b/modules/apps/cli/claude-code/cfg/mcp-servers.nix
@@ -144,13 +144,19 @@ let
       };
     };
   }
-  // lib.optionalAttrs (secrets.tableau.patValue or null != null) {
+  // lib.optionalAttrs (serverProfile == "full" && (secrets.tableau.patValue or null) != null) {
     # Tableau MCP -- query/explore Tableau Cloud content (workbooks, views,
     # datasources) via natural language: https://github.com/tableau/tableau-mcp
     # Self-hosted/local (PAT-based) mode, not the hosted OAuth mcp.tableau.com
     # endpoint, matching the Claude Desktop setup already in use against
     # Kong's Tableau Cloud site. All four values (server, site, PAT name/value)
     # live on the "Tableau PAT" 1Password item.
+    #
+    # Workstation-only, same as chrome-devtools/playwright above: `npx -y
+    # @tableau/mcp-server@latest` fetches and executes arbitrary npm code at
+    # run time, and secrets.json is pushed identically to every host, so
+    # without this gate the entry would activate on headless hosts (srv,
+    # clanker) the moment the secret exists in the vault.
     tableau = {
       command = "${pkgs.nodejs}/bin/npx";
       args = [

--- a/modules/apps/cli/claude-code/cfg/mcp-servers.nix
+++ b/modules/apps/cli/claude-code/cfg/mcp-servers.nix
@@ -153,15 +153,26 @@ let
     # live on the "Tableau PAT" 1Password item.
     #
     # Workstation-only, same as chrome-devtools/playwright above: `npx -y
-    # @tableau/mcp-server@latest` fetches and executes arbitrary npm code at
-    # run time, and secrets.json is pushed identically to every host, so
-    # without this gate the entry would activate on headless hosts (srv,
-    # clanker) the moment the secret exists in the vault.
+    # @tableau/mcp-server` fetches and executes npm code at run time, and
+    # secrets.json is pushed identically to every host, so without this gate
+    # the entry would activate on headless hosts (srv, clanker) the moment
+    # the secret exists in the vault. Unlike those two, this server holds a
+    # live Tableau Cloud credential in its process environment, so the
+    # version is pinned rather than tracking @latest, to bound the blast
+    # radius of a compromised npm release. Bump deliberately after checking
+    # https://github.com/tableau/tableau-mcp/releases.
+    #
+    # ADMIN_TOOLS_ENABLED is intentionally left unset (defaults to false
+    # upstream): it gates both the destructive tools (delete-workbook,
+    # delete-datasource, etc.) and the whole Admin Insights read/query group
+    # at tool registration time (see e.g. `disabled: !config.adminToolsEnabled`
+    # in tableau-mcp's getStaleContentReport.ts), so none of that surface is
+    # even exposed to the MCP client with this config.
     tableau = {
       command = "${pkgs.nodejs}/bin/npx";
       args = [
         "-y"
-        "@tableau/mcp-server@latest"
+        "@tableau/mcp-server@2.22.0"
       ];
       env = {
         SERVER = secrets.tableau.server;

--- a/secrets.json.tpl
+++ b/secrets.json.tpl
@@ -71,5 +71,11 @@
   },
   "grafana": {
     "dashboardsToken": "{{ op://automation/grafana-cloud-dashboards/token }}"
+  },
+  "tableau": {
+    "server": "{{ op://nixerator/Tableau PAT/hostname }}",
+    "siteName": "{{ op://nixerator/Tableau PAT/Site Name }}",
+    "patName": "{{ op://nixerator/Tableau PAT/username }}",
+    "patValue": "{{ op://nixerator/Tableau PAT/credential }}"
   }
 }


### PR DESCRIPTION
## Summary
Closes #113: Configure tableau mcp

- feat(mcp): configure tableau MCP server
  Add the tableau MCP server (https://github.com/tableau/tableau-mcp) in
  self-hosted/local PAT mode against Kong's Tableau Cloud site, matching
  the setup already validated in Claude Desktop. Server, site name, and
  PAT name/value all come from the 'Tableau PAT' 1Password item, gated
  on the PAT value existing so hosts without the secret simply omit the
  entry.
  
  Closes #113