### PR TITLE
fix(secrets): update tableau vault references to hyphenated names

### DIFF
--- a/extras/docs/secrets.md
+++ b/extras/docs/secrets.md
@@ -187,7 +187,7 @@ Names are pinned — they must match `secrets.json.tpl` exactly.
 | Item | Type | Fields | Consumed as |
 |------|------|--------|-------------|
 | `kong-konnect-pat` | API Credential | `credential` | `secrets.kong.kongKonnectPAT` |
-| `Tableau PAT` | API Credential | `hostname` (full `https://` origin, not a bare host), `Site Name`, `username`, `credential` | `secrets.tableau.{server,siteName,patName,patValue}` (self-hosted/local Tableau MCP against Kong's Tableau Cloud site; injected as `SERVER`/`SITE_NAME`/`PAT_NAME`/`PAT_VALUE` by the claude-code module; workstation-only, see `serverProfile` gate in `mcp-servers.nix`) |
+| `Tableau-PAT` | API Credential | `hostname` (full `https://` origin, not a bare host), `Site-Name`, `username`, `credential` | `secrets.tableau.{server,siteName,patName,patValue}` (self-hosted/local Tableau MCP against Kong's Tableau Cloud site; injected as `SERVER`/`SITE_NAME`/`PAT_NAME`/`PAT_VALUE` by the claude-code module; workstation-only, see `serverProfile` gate in `mcp-servers.nix`) |
 | `aha` | API Credential | `credential` | `secrets.aha.apiToken` (injected as `AHA_API_TOKEN` by the claude-code module for the `aha` skill) |
 | `wave` | API Credential | `credential` | `secrets.wave.fullAccessToken` (injected as `WAVE_FULL_ACCESS_TOKEN` by the claude-code module for the `wave-invoicing` skill; Wave Full Access Token — personal-use bearer, no OAuth) |
 | `context7` | API Credential | `credential` | `secrets.context7.apiKey` |

--- a/modules/apps/cli/claude-code/cfg/mcp-servers.nix
+++ b/modules/apps/cli/claude-code/cfg/mcp-servers.nix
@@ -150,7 +150,7 @@ let
     # Self-hosted/local (PAT-based) mode, not the hosted OAuth mcp.tableau.com
     # endpoint, matching the Claude Desktop setup already in use against
     # Kong's Tableau Cloud site. All four values (server, site, PAT name/value)
-    # live on the "Tableau PAT" 1Password item.
+    # live on the "Tableau-PAT" 1Password item.
     #
     # Workstation-only, same as chrome-devtools/playwright above: `npx -y
     # @tableau/mcp-server` fetches and executes npm code at run time, and

--- a/secrets.json.tpl
+++ b/secrets.json.tpl
@@ -73,9 +73,9 @@
     "dashboardsToken": "{{ op://automation/grafana-cloud-dashboards/token }}"
   },
   "tableau": {
-    "server": "{{ op://nixerator/Tableau PAT/hostname }}",
-    "siteName": "{{ op://nixerator/Tableau PAT/Site Name }}",
-    "patName": "{{ op://nixerator/Tableau PAT/username }}",
-    "patValue": "{{ op://nixerator/Tableau PAT/credential }}"
+    "server": "{{ op://nixerator/Tableau-PAT/hostname }}",
+    "siteName": "{{ op://nixerator/Tableau-PAT/Site-Name }}",
+    "patName": "{{ op://nixerator/Tableau-PAT/username }}",
+    "patValue": "{{ op://nixerator/Tableau-PAT/credential }}"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #113/#131. The "Tableau PAT" 1Password item was renamed to
`Tableau-PAT` and its `Site Name` field to `Site-Name` (space-free labels,
addressing the security review's low-severity finding about ambiguous
`op://` reference parsing on a spaced field name).

- Updated `secrets.json.tpl` to reference `Tableau-PAT`/`hostname`,
  `Tableau-PAT`/`Site-Name`, `Tableau-PAT`/`username`,
  `Tableau-PAT`/`credential`.
- Updated the `extras/docs/secrets.md` vault items table to match.

## Test plan

- [x] `just fmt`: 0 changed
- [x] `render-secrets --tpl ./secrets.json.tpl`: wrote cleanly, no errors
- [x] Verified `tableau` keys resolve non-empty via `jq` (existence-only,
      no secret values read)
- [x] `just build-host qbert`: clean build