### PR TITLE
feat(claude-code): add tableau skill for Kong CS reporting

### DIFF
--- a/modules/apps/cli/claude-code/config/skills/tableau/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/tableau/SKILL.md
@@ -7,10 +7,12 @@ description: >-
   tools, and more). Use this whenever the user asks about Tableau,
   dashboards, or reports on the Kong site -- especially customer health
   score, renewal risk, consumption/usage, churn risk, NPS/CSAT, bookings,
-  or pipeline data pulled from Tableau. Also trigger for "Kong 360",
-  "book of business", "pull up the churn risk dashboard", "what's this
-  account's health score in Tableau", "check the renewal pipeline",
-  "Kong Command Center", or any request to list/search/export a Tableau
+  or pipeline data pulled from Tableau. Also trigger for "Account 360",
+  "Kong 360", "book of business", "pull up the churn risk dashboard",
+  "what's this account's health score in Tableau", "check the renewal
+  pipeline", "Kong Command Center", "active contract", "Konnect
+  subscription usage", "Konnect capacity consumption", or any request to
+  list/search/export a Tableau
   workbook, view, or data source, even if the user doesn't say the word
   "Tableau" explicitly but clearly means the CS/RevOps reporting site
   (e.g. "what does the dashboard say about Acme's renewal risk"). Do NOT
@@ -92,14 +94,20 @@ same workbook. `references/content-map.md` already tells you which views
 are confirmed to return real data vs. confirmed dashboard shells for the
 Kong 360 and Book of Business workbooks.
 
-**4. A 400 on a specific sheet usually means it needs a filter.** Some
-sheets (e.g. `Firmographics` in Kong360 Summary) are driven by a
-dashboard action or parameter and won't render standalone. If
-`get-view-data` 400s on a view that's confirmed to be a real
-worksheet, try again with a `viewFilters` value -- most likely an account
-name/id field. You may need to open the dashboard in a browser once to
-learn the filter's exact display name; once you know it, note it in
-auto-memory so you don't have to rediscover it.
+**4. A 400 on a specific sheet usually means it needs a filter -- and
+`Account Name` is the confirmed field caption to try first.** Some sheets
+(e.g. `Firmographics` in Kong360 Summary) are driven by a dashboard
+action or parameter and won't render standalone. The `Account 360`
+workbook (see the content map) uses one global filter across all its
+tabs, and `Account Name` is confirmed live -- passing a nonexistent value
+via `viewFilters: {"Account Name": "..."}` returned zero rows instead of
+the default dataset, proving the field was recognized and applied, not
+ignored. Try `Account Name` on any unfamiliar parameter-driven view
+before guessing at other field names. If it doesn't resolve the account
+you need, the underlying doc for Account 360 (see content map) also
+mentions `SFDC Account ID`, `Domain`, and `Konnect Organization ID` as UI
+filter options, though those haven't been independently confirmed against
+the API's exact caption yet.
 
 **5. Row-level security scopes some content to the querying identity.**
 `Churn_Risk_Score` in Kong360 Churn Risk returned exactly one row with no
@@ -123,7 +131,7 @@ same session.
 
 `references/content-map.md` has the project/workbook/view/datasource
 inventory as of the last survey, with confirmed-working view ids for
-Kong 360 (Churn Risk) and known gaps for Book of Business
+Account 360, Kong 360 (Churn Risk), and known gaps for Book of Business
 (Pipeline & Renewals). Read it before falling back to
 `list-projects`/`list-workbooks` from scratch -- it'll usually get you
 straight to the right workbook id. It's a snapshot, not a live source of
@@ -131,16 +139,27 @@ truth: if something's missing or renamed, the tools are still
 authoritative, and it's worth updating the file once you've confirmed the
 change.
 
+Some dashboards have a companion Google Doc explaining what each tab
+means (the content map links the one for Account 360). These usually
+require Kong Workspace auth that a plain fetch won't have -- use the
+Google Drive MCP tools (`read_file_content` with the doc's file id,
+extracted from its URL) rather than a generic web fetch, which will 401.
+
 ## Workflow
 
 ### Step 1: Classify the request
 
-- **A specific customer's account health/renewal/consumption/churn** ->
-  Kong 360 project. Go to `references/content-map.md`, find the workbook
-  that covers the metric asked about (Churn Risk for health/renewal/NPS/
-  CSAT/escalations/consumption numbers, Bookings & Opportunities for deal
-  data, Customer Support for case data), then `get-view-data` on the
-  specific sheet-type view -- not the workbook's "Shell" dashboard.
+- **A specific customer's account health/renewal/consumption/churn/
+  contracts/support/PS engagement** -> the **Account 360** workbook
+  (`references/content-map.md`) is the primary, actively-maintained
+  source -- start there. It's one workbook, one global filter
+  (`viewFilters: {"Account Name": "<customer>"}`, confirmed working --
+  see rule 4), and one tab per topic (Active Contract, Bookings &
+  Opportunities, Konnect Subscription, Konnect Plus, Kong Enterprise
+  On-Prem, Konnect Capacity Consumption, Account Engagement, Support,
+  Customer Health & Risks, Professional Services). Only fall back to the
+  older "Kong 360" project if Account 360 doesn't cover what was asked
+  (it has no direct equivalent for Marketing Campaigns or Engagement).
 - **"My" pipeline/renewals/usage/prospecting across the whole book** ->
   Book of Business project. Be aware of the known gap noted in the
   content map (the Pipeline & Renewals views haven't yielded real tabular

--- a/modules/apps/cli/claude-code/config/skills/tableau/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/tableau/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: tableau
+description: >-
+  Query Kong's Tableau Cloud site via the local `@tableau/mcp-server` MCP
+  tools (list-projects, list-workbooks, list-datasources, search-content,
+  get-workbook, get-view, get-view-data, query-datasource, Pulse metric
+  tools, and more). Use this whenever the user asks about Tableau,
+  dashboards, or reports on the Kong site -- especially customer health
+  score, renewal risk, consumption/usage, churn risk, NPS/CSAT, bookings,
+  or pipeline data pulled from Tableau. Also trigger for "Kong 360",
+  "book of business", "pull up the churn risk dashboard", "what's this
+  account's health score in Tableau", "check the renewal pipeline",
+  "Kong Command Center", or any request to list/search/export a Tableau
+  workbook, view, or data source, even if the user doesn't say the word
+  "Tableau" explicitly but clearly means the CS/RevOps reporting site
+  (e.g. "what does the dashboard say about Acme's renewal risk"). Do NOT
+  trigger for Salesforce/SFDC queries that don't reference Tableau
+  reporting (the `sfdc` skill owns those) or for building new success-plan
+  documents (the `kong-success-plan` skill owns that, though it may call
+  into this skill for data).
+---
+
+# Tableau (Kong's Tableau Cloud)
+
+Pull data out of Kong's Tableau Cloud site for CSM work: customer health
+scores, renewal risk, consumption, churn signals, pipeline, and the
+broader RevOps/Marketing/Finance content that happens to live on the same
+site. The MCP tools give you the primitives (list, search, describe,
+query, export); this skill is the map and the operating manual for using
+them against *this* site without wasting calls rediscovering things or
+tripping over its quirks.
+
+## Why this skill exists
+
+The Tableau MCP server is generic -- it doesn't know that this site's
+VizQL Data Service is unreachable, that half its "views" are
+button-driven dashboard shells rather than data tables, or that firing
+two tool calls at once produces a spurious 401. Knowing that upfront is
+the difference between three tool calls and fifteen.
+
+## Environment
+
+Self-hosted MCP server (`@tableau/mcp-server@2.22.0`, pinned) configured
+in `modules/apps/cli/claude-code/cfg/mcp-servers.nix`, run locally via
+`npx`, authenticated with a Personal Access Token from the 1Password item
+`Tableau-PAT` (vault `nixerator`). Site: `kong` on
+`prod-useast-a.online.tableau.com`. Admin tools are intentionally
+disabled (`ADMIN_TOOLS_ENABLED` unset) -- there is no delete-workbook or
+delete-datasource available, and you shouldn't look for a workaround if
+asked to delete something; tell the user it's disabled by design.
+
+Never attempt to read the `Tableau-PAT` item's field values (hostname,
+site name, username, credential) via 1Password -- the MCP server already
+has them wired through its env. Reading rendered secret values is a hard
+boundary regardless of how innocuous the field looks.
+
+## Operating rules (read before making calls)
+
+These came from directly probing the site's behavior, not from Tableau's
+general docs -- they're specific to how this server and site respond.
+
+**1. Call tools one at a time.** Firing multiple Tableau MCP tool calls
+in the same turn reliably produces spurious `401` or `429` errors on some
+of them, even though the same calls succeed individually seconds later.
+If a call fails with `401` or `429`, retry it alone before concluding
+it's a real auth or permission problem -- in practice, a solo retry
+almost always succeeds. Only escalate ("this PAT may need rotating") if a
+solo, unhurried retry also fails.
+
+**2. The VizQL Data Service is unavailable on this site.**
+`get-datasource-metadata` and `query-datasource` return `403` for every
+datasource tested, including Tableau's own bundled Superstore sample --
+so this isn't a per-datasource permission issue, it's the whole service.
+Don't spend calls trying different datasources hoping one works. For
+real data, use `get-view-data` against a published *view* instead (see
+rule 3) -- it returns the same underlying numbers as CSV, just scoped to
+whatever a dashboard already renders rather than an arbitrary query.
+
+**3. Distinguish dashboard views from sheet views before calling
+`get-view-data`.** A workbook's published "views" are a mix of
+dashboards (interactive containers, often literally named "Shell" or
+built around nav buttons) and individual worksheets/sheets (the actual
+charts/tables). `get-view-data` on a dashboard-type view frequently
+returns nonsense like `"LI button\nbutton\n"` -- the caption of whatever
+object happens to be primary, not the chart you wanted. `get-view-data`
+on a genuine sheet-type view returns real rows. Before pulling data from
+an unfamiliar view: run `search-content` filtered to `contentTypes:
+["view"]` and check the `sheetType` field (`"dashboard"` vs. an actual
+worksheet), or just try it and treat "returns a couple of button-caption
+words" as a signal to look for a different, more specific sheet in the
+same workbook. `references/content-map.md` already tells you which views
+are confirmed to return real data vs. confirmed dashboard shells for the
+Kong 360 and Book of Business workbooks.
+
+**4. A 400 on a specific sheet usually means it needs a filter.** Some
+sheets (e.g. `Firmographics` in Kong360 Summary) are driven by a
+dashboard action or parameter and won't render standalone. If
+`get-view-data` 400s on a view that's confirmed to be a real
+worksheet, try again with a `viewFilters` value -- most likely an account
+name/id field. You may need to open the dashboard in a browser once to
+learn the filter's exact display name; once you know it, note it in
+auto-memory so you don't have to rediscover it.
+
+**5. Row-level security scopes some content to the querying identity.**
+`Churn_Risk_Score` in Kong360 Churn Risk returned exactly one row with no
+filters applied -- almost certainly the account(s) tied to whoever the
+PAT belongs to, not the full customer base. Assume "Book of Business" and
+similar my-portfolio dashboards behave the same way. Don't be surprised
+if a request to look up a customer *outside* the current user's book
+returns nothing from these particular views -- that's the security model
+working as intended, not a bug. If you need another CSM's book, that's a
+different credential, not a different query.
+
+**6. "No X found" from Pulse tools can mean genuine absence, not an
+error.** `list-all-pulse-metric-definitions` and
+`list-pulse-metric-subscriptions` return a friendly "none found" message
+rather than surfacing HTTP status codes -- so an empty Pulse result isn't
+necessarily masking an auth failure the way it might look. Confirmed by
+cross-checking against a working call (`list-projects`) succeeding in the
+same session.
+
+## Content map
+
+`references/content-map.md` has the project/workbook/view/datasource
+inventory as of the last survey, with confirmed-working view ids for
+Kong 360 (Churn Risk) and known gaps for Book of Business
+(Pipeline & Renewals). Read it before falling back to
+`list-projects`/`list-workbooks` from scratch -- it'll usually get you
+straight to the right workbook id. It's a snapshot, not a live source of
+truth: if something's missing or renamed, the tools are still
+authoritative, and it's worth updating the file once you've confirmed the
+change.
+
+## Workflow
+
+### Step 1: Classify the request
+
+- **A specific customer's account health/renewal/consumption/churn** ->
+  Kong 360 project. Go to `references/content-map.md`, find the workbook
+  that covers the metric asked about (Churn Risk for health/renewal/NPS/
+  CSAT/escalations/consumption numbers, Bookings & Opportunities for deal
+  data, Customer Support for case data), then `get-view-data` on the
+  specific sheet-type view -- not the workbook's "Shell" dashboard.
+- **"My" pipeline/renewals/usage/prospecting across the whole book** ->
+  Book of Business project. Be aware of the known gap noted in the
+  content map (the Pipeline & Renewals views haven't yielded real tabular
+  data yet) -- if `get-view-data` returns button captions, try
+  `get-view-image` for a visual read instead, or ask the user whether
+  they know of a specific underlying worksheet name.
+- **Anything else on the site** -- ad-hoc report, unfamiliar workbook,
+  cross-team dashboard -- treat it like the general path below.
+
+### Step 2 (unfamiliar content): discover, then pull
+
+If the content map doesn't already have what you need:
+
+1. `search-content` with relevant terms (fastest way to find a workbook/
+   view/datasource by name across the whole site, and it tells you
+   `sheetType` up front).
+2. `get-workbook` on the workbook id to see its full view list.
+3. `get-view` on a candidate view id for its metadata (owner, project,
+   usage stats) if you need to confirm you have the right one before
+   pulling data.
+4. `get-view-data` on the sheet-type view id to get the actual rows. Pass
+   `viewFilters` if the view is parameter-driven (rule 4).
+
+Don't reach for `get-datasource-metadata` or `query-datasource` first --
+they're dead ends on this site (rule 2). If a future session finds they
+do work (e.g. after a site admin enables the Metadata API), update rule 2
+and start using them; they'd be a cleaner path than reverse-engineering
+view filters.
+
+### Step 3: Present the data
+
+Default to a plain table or a short narrative summary of the pulled
+numbers -- whichever fits what was asked. If the user wants this rolled
+into a document (a success plan, a QBR deck, a renewal projection), that
+belongs to a different skill (`kong-success-plan`, `renewal-projection`)
+-- pull the data here, hand it off there.
+
+## Memory
+
+Same two-layer split as the `sfdc` skill.
+
+### skill-cache (stable identifiers)
+
+Before re-running `list-workbooks`/`list-views` to resolve a name to an
+id, check the cache:
+
+```bash
+skill-cache get tableau workbooks "<workbook name>"     # -> {"id":"..."}
+skill-cache get tableau views     "<workbook>/<view>"   # -> {"id":"..."}
+skill-cache get tableau datasources "<datasource name>" # -> {"id":"..."}
+```
+
+On a hit, use it. On a miss, resolve via the tools (or the content map),
+then write back -- no `--ttl`, these ids are effectively permanent:
+
+```bash
+skill-cache put tableau workbooks "Kong360 Churn Risk" '{"id":"54e0faed-38e1-4861-9d89-b78f59e6a780"}'
+skill-cache put tableau views "Kong360 Churn Risk/Churn_Risk_Score" '{"id":"22dcc980-a668-4b15-a6cd-f8faed79bb44"}'
+```
+
+Never cache query *results* or field values -- only stable ids. Full
+convention: `.claude/docs/skill-cache.md`.
+
+### auto-memory (soft facts)
+
+Save the things that took real digging to learn and would otherwise be
+rediscovered the hard way: a `viewFilters` field name that turned out to
+work, which workbook actually holds a given metric once verified live,
+row-level-security surprises, or any correction to something this skill
+currently gets wrong. Don't save one-off query results or task-specific
+numbers -- those belong to the conversation, not to memory.
+
+## What NOT to do
+
+- Don't fire Tableau MCP tool calls in parallel -- see rule 1. Sequential
+  and slightly slower beats fast and flaky.
+- Don't treat a single 401/429 as proof the PAT is broken -- retry alone
+  first (rule 1).
+- Don't call `get-datasource-metadata`/`query-datasource` expecting them
+  to work -- they don't, site-wide (rule 2).
+- Don't trust `get-view-data` output on a dashboard-type view at face
+  value -- if it looks like a caption fragment rather than a data table,
+  it probably is one (rule 3).
+- Don't invent a `viewFilters` field name -- confirm it (via the browser
+  or a 400's error detail if present) before assuming it worked.
+- Don't expect to see accounts outside the querying identity's own book
+  from row-level-secured views (rule 5) -- that's not a bug to work
+  around.
+- Don't try to route around the disabled admin tools (delete-*, Admin
+  Insights query group) -- they're off by design.
+
+## Files in this skill
+
+### references/
+
+- `content-map.md` -- project/workbook/view/datasource inventory with
+  ids, confirmed-working vs. confirmed-broken views, and open questions
+  from the last live survey.

--- a/modules/apps/cli/claude-code/config/skills/tableau/references/content-map.md
+++ b/modules/apps/cli/claude-code/config/skills/tableau/references/content-map.md
@@ -11,11 +11,65 @@ workbooks at survey time. Only CSM-relevant projects are enumerated in
 detail below; everything else is listed by name only -- use
 `list-workbooks --filter projectName:eq:<name>` to explore those live.
 
-## Kong 360 -- per-account 360 profile
+## Account 360 -- CURRENT primary per-account dashboard (start here)
+
+Workbook id `1191812c-b476-49e6-be56-05238baab800`, project `3. Production`
+(`21dd15ca-49f5-4171-9203-7ceaa0ca0b3f`, under RevOps). This is the tool to
+reach for first for "what does Tableau say about customer X" -- it's a
+single workbook with one tab per topic, actively maintained (last updated
+2026-07-07 at survey time, tabs added as recently as 2024-09), and by far
+the most-used per-account content on the site: `Active Contract` alone has
+9,469 total views vs. 463 for the entire Kong 360 project's Churn Risk
+workbook. Treat the separate "Kong 360" project below as the prior
+generation -- check there only if Account 360 is missing something.
+
+Documented in a Google Doc ("Revenue Operations -- Account 360", last
+updated 2024-06-01, file id `1B4xrNs6YOg64KqslNvFbhrplmAbQyQFGZzYOBS01-E4`,
+readable via the Google Drive MCP tools) for every tab except
+`Professional Services`, which was added after the doc's last update.
+
+### Global filter (confirmed working)
+
+The whole workbook is driven by one account-level filter, applied via
+`viewFilters` on `get-view-data`. **Confirmed via live test**: passing
+`{"Account Name": "<nonexistent value>"}` to the `Active Contract` view
+returned zero rows instead of the default unfiltered dataset -- proof the
+`Account Name` field caption is exactly right, not a guess. The doc also
+describes `SFDC Account ID`, `Domain`, and `Konnect Organization ID` as
+alternative filter fields in the Tableau UI (use one at a time; the UI
+flow is "Clear Filters" on the others, then "Apply Filters" on the one
+you want) -- these three haven't been independently confirmed against the
+API's exact `viewFilters` caption yet, so try `Account Name` first and
+fall back to the others only if it doesn't resolve the account you need.
+
+**Without any filter**, every tab returns data already scoped to a single
+account (confirmed on `Active Contract` and `Konnect Subscription`) --
+consistent with the row-level security pattern seen elsewhere on this
+site (see the main SKILL.md). Don't assume an unfiltered call returns
+"nothing" or "everything"; it returns *something specific* by default.
+
+### Tabs
+
+| Tab | id | What it shows (per the doc) | Live-tested? |
+|---|---|---|---|
+| Active Contract | `62469a27-0042-44e3-930b-fb8ac1049423` | Current active contract value, segment value, product breakdown, and Konnect contract utilization (API requests/Gateway services used vs. contracted) | **Yes** -- returns real daily running-sum consumption vs. contracted volume |
+| Bookings & Opportunities | `3211c9ce-f5ba-4091-955b-156b05045f0e` | Lifetime contract value (TCV), active contract/segment value, visible open pipeline, closed-lost pipeline, closed bookings detail, open pipeline detail | Not yet |
+| Konnect Subscription | `d55db5a6-5274-4514-8b70-457e55de49e8` | 12-month usage trend by feature (API Requests, Gateway Services, Cloud Gateways), MoM breakdown, org details for multi-org accounts | **Yes** -- returns real monthly running-sum usage |
+| Konnect Plus | `ebb18efa-08a1-4504-85d5-617ef9c2bb6b` | Konnect Plus signups, invoices, credit consumption by feature and by month (credits measured in USD), per-org detail | Not yet |
+| Kong Enterprise (On-Prem) | `6e1343eb-9cc0-4188-af93-30cf04b0846e` | On-prem usage -- same data as Gainsight, uploaded by the field team, not live-collected. Includes a "usage last updated" timestamp -- check it before trusting the numbers | Not yet |
+| Konnect Capacity Consumption | `df384fab-9eee-4e54-a505-28af794ebc84` | Capacity purchased vs. used, overage/underage, consumption run rate, days-until-overage, breakdown by product and by month | Not yet |
+| Account Engagement | `8dbd7695-c617-4e4d-87c8-d6589fb94625` | Marketing campaign responses, MQLs, web visits, job-level breakdown of engaged contacts, PQL list of active product users | Not yet |
+| Support | `6fed0e82-3d5a-402e-99b7-ac44b28335f3` | Case volume by priority, case-creation timeline, full case detail (links to SFDC case record) | Not yet |
+| Customer Health & Risks | `5cfeda2f-e7a0-41e5-a159-c2d6ec4e2c7a` | Overall health score, CSM sentiment score, renewal likelihood, open renewal opportunities, health-score factor breakdown, CSM renewal sentiment/comments | Not yet -- likely the single richest tab for churn/renewal-risk conversations, check this alongside (or instead of) Kong360 Churn Risk |
+| Professional Services | `cb67dec3-1934-47f5-845b-8e6e08858b6a` | Not in the doc (added 2024-09-30, after the doc's last update) | **Tested, thin result**: unfiltered call returned only 2 columns (`Customer Stage`, `ORIGINAL_CONTRACT_DATE`) and 1 row for this identity's default-scoped account. Either PS content is genuinely sparse for that account, or the richer detail lives in a part of the dashboard this call didn't reach -- re-test against an account known to have active PS engagement before concluding this tab is data-poor. |
+
+## Kong 360 (legacy) -- per-account 360 profile, prior generation
 
 Project id `32bd0076-c9e8-4b1f-9220-737aa0f986fe`. One workbook per topic,
-all meant to be looked at for a single named account. This is the project
-to reach for when the ask is "what does Tableau say about customer X".
+all meant to be looked at for a single named account. Superseded in
+practice by Account 360 above (much lower usage across the board) but
+still live -- check here if Account 360 doesn't have what you need, e.g.
+it has no direct equivalent for Marketing Campaigns or Engagement.
 
 | Workbook | id | Key views |
 |---|---|---|
@@ -48,9 +102,10 @@ VizQL Data Service is unavailable here, see the main SKILL.md):
 
 `Firmographics` (`f4a50b98-...`) returned HTTP 400 when queried without
 filters -- it's likely a dashboard-action/parameter-driven sheet that
-needs an account identifier passed via `viewFilters` to render. The exact
-filter field name hasn't been confirmed; try the view in a browser once,
-note the filter's display name, and use that as the `viewFilters` key.
+needs an account identifier passed via `viewFilters` to render. Account
+360 (above) uses `Account Name` as its confirmed-working filter field
+caption -- try that here first before assuming this workbook uses a
+different field name.
 
 ## Book of Business -- the CSM's own portfolio
 
@@ -108,7 +163,7 @@ Project id `21dd15ca-49f5-4171-9203-7ceaa0ca0b3f` (under RevOps). Houses
 | Workbook | id | Notes |
 |---|---|---|
 | Kong Command Center | `856dcbbe-13c4-438e-b6a2-fe5098dfa0e0` | **Site-wide most-used workbook** (21,083 total views, 1,097 in the last month at survey time). Sales/pipeline command center -- Summary, Closed Bookings, Renewal Analysis, Pipeline Generation QTD/YTD Overview, Pipeline Generation Deep Dive, Pipeline Progression, Pipeline Conversions, Forecast Health, AE Forecast Health, AE Weekly Deep Dive, Productivity, Ramping Productivity Deep Dive, Account Penetration, MQL Overview. Skews sales-leadership/AE-productivity, but `Renewal Analysis` and `Account Penetration` are CS-relevant. Backed by `Funnel Metrics Cohort Detail` and `MQL Funnel Conversion Trend` datasources. |
-| Account 360 | `1191812c-b476-49e6-be56-05238baab800` | Not yet probed -- name suggests it may overlap with or supersede the "Kong 360" project's per-account workbooks; worth comparing before assuming Kong 360 is the only per-account source. |
+| Account 360 | `1191812c-b476-49e6-be56-05238baab800` | **See the dedicated "Account 360" section above** -- this is the current primary per-account workbook, fully documented with tab ids and a confirmed-working filter. |
 | Win Wire | `aaf801e2-7eca-4981-90bb-3d59f2ac8fcf` | Not yet probed |
 | Income Revenue | `3e19b196-5b98-44a3-9d3e-252aa8c718e3` | Not yet probed |
 | AE 2x2 for QBRs | `837e839c-10f9-49bc-9ebb-d429152343c0` | QBR-prep dashboard, worth checking when prepping a QBR |

--- a/modules/apps/cli/claude-code/config/skills/tableau/references/content-map.md
+++ b/modules/apps/cli/claude-code/config/skills/tableau/references/content-map.md
@@ -1,0 +1,144 @@
+# Content map: Kong's Tableau Cloud site
+
+Surveyed 2026-07-07 via `list-projects` / `list-workbooks` / `list-datasources` /
+`search-content` / `get-workbook`. This is a snapshot to save you from
+re-discovering the same structure every session -- it drifts over time
+(dashboards get added, renamed, deprecated). If something here doesn't match
+what the tools return, trust the tools and update this file.
+
+Site: `kong` on `prod-useast-a.online.tableau.com`. 26 projects, 108+
+workbooks at survey time. Only CSM-relevant projects are enumerated in
+detail below; everything else is listed by name only -- use
+`list-workbooks --filter projectName:eq:<name>` to explore those live.
+
+## Kong 360 -- per-account 360 profile
+
+Project id `32bd0076-c9e8-4b1f-9220-737aa0f986fe`. One workbook per topic,
+all meant to be looked at for a single named account. This is the project
+to reach for when the ask is "what does Tableau say about customer X".
+
+| Workbook | id | Key views |
+|---|---|---|
+| Kong 360 (original/base) | `8f6c90ce-dc67-4d3e-9270-19eea9064d89` | low usage (14 total views), likely superseded by the others below |
+| Kong360 Summary | `b3035d7f-4a7c-451a-b36d-55b2de2bdef9` | Firmographics `f4a50b98-e43d-4eb2-b029-5a37d78c2f46`, Key Contacts `76b6ba40-2cbf-488a-b8f2-68b379cd54e9`, Active Contracts `decf6c23-a522-4588-a6ad-816c02574074` |
+| Kong360 Bookings & Opportunities | `cc4292e4-98cd-42b8-aa87-3c3b936098cb` | not yet probed for individual sheet ids |
+| Kong360 Consumption | `804d0711-fbc1-4082-ae06-f060021f26ae` | only the "Kong360 Shell" dashboard view was found (`5105f743-...`); no separate data sheet located yet -- check the workbook live with `get-workbook` for any tabs added since |
+| Kong360 Churn Risk | `54e0faed-38e1-4861-9d89-b78f59e6a780` | **confirmed working**: `Churn_Risk_Score` `22dcc980-a668-4b15-a6cd-f8faed79bb44` returns real per-account data (see fields below). Also `Churn_Risk_Attributes` `87b7b9e2-f8f8-4aba-80ca-77dad9eb9937`, `Churn_Risk_Comments` `ead788b2-1321-4e65-abf2-34c958b4e1d0` |
+| Kong360 Marketing Campaigns | `21ff5029-864e-4cb5-9a35-0ca7f4bb49c7` | not yet probed |
+| Kong360 Engagement | `88b0cea1-7a30-41d7-ae8e-aae8f291f077` | not yet probed |
+| Kong360 Customer Support | `790ca451-ce75-4434-9c0a-62502199863b` | not yet probed |
+
+**Confirmed fields from `Churn_Risk_Score`** (via `get-view-data`, no
+`viewFilters` supplied, returned exactly one row -- see "Row-level security"
+below): `CUSTOMER_STAGE__C`, `CXM_SENTIMENT_PICKLIST__C`, `Day of
+LAST_GAINSIGHT_TIMELINE_ACTIVITY`, `AVG_CSAT_LAST_6_MONTHS`, `AVG_NPS`,
+`ENGAGEMENT_CX_SCORE`, `GATEWAY_API_CALLS_CONSUMPTION`,
+`GATEWAY_API_SERVICES_CONSUMPTION`, `HEALTH_SCORE`,
+`KONG_ACADEMY_COURSES_COMPLETED`, `OPEN_ESCALATIONS`, `PERCENT_DELIVERED`,
+`RENEWAL_EXPANSION_SCORE`, `RENEWAL_RISK_LEVEL_SCORE`, `ROI_SCORE`,
+`TOTAL_CASES_LAST_180D`, `TOTAL_HIGH_URG_CASES_LAST_180D`,
+`TOTAL_NEW_ACV`, `TOTAL_OPEN_FTIS`.
+
+Backing datasources (both return 403 via `get-datasource-metadata` --
+VizQL Data Service is unavailable here, see the main SKILL.md):
+- `Kong360_Rollup` -- `088cb8fb-8106-44bc-8f35-ddd74e4c0210`
+- `Kong360_Account_ID_Domain_Map` -- `622ba944-fee5-4340-9d95-bd3a7b48b44d`
+  (maps an account's web domain to its internal account id -- useful if
+  you only have a customer's domain, not their Salesforce/Kong360 id)
+
+`Firmographics` (`f4a50b98-...`) returned HTTP 400 when queried without
+filters -- it's likely a dashboard-action/parameter-driven sheet that
+needs an account identifier passed via `viewFilters` to render. The exact
+filter field name hasn't been confirmed; try the view in a browser once,
+note the filter's display name, and use that as the `viewFilters` key.
+
+## Book of Business -- the CSM's own portfolio
+
+Project id `418647c6-e8cf-4578-822b-a2bb261b0d09` (nested under `3.
+Production` under `RevOps`). Reach for this when the ask is about "my
+accounts" collectively -- pipeline, renewals, usage, PS engagement across
+your whole book, not one named customer.
+
+| Workbook | id |
+|---|---|
+| 0. Book of Business - Homepage | `e819dff5-a3a9-43a9-8b9b-11aab732f70d` |
+| 1. Book of Business - Pipeline & Renewals | `15cb65c5-e3ea-4e0a-81a2-2a6d555002d3` |
+| 2. Book of Business - Prospecting & Actions | `e4682a8b-d4a0-4703-9de9-62a2652d8801` |
+| 3. Book of Business - Product Usage | `53e01fae-8f1c-4eb8-825c-133a37f65c92` |
+| 4. Book of Business - PS, Support, & Partner | `5e58effe-c282-496f-8b41-79bbb768c72a` |
+
+**Known gap:** every view checked in "1. Book of Business - Pipeline &
+Renewals" (`Closed Bookings` `af8625ff-...`, `Current Quarter Pipeline`
+`cb9d00fd-...`, `Renewal Deep Dive` `35f711a2-...`) is `sheetType:
+"dashboard"` (confirmed via `search-content`), and `get-view-data` on all
+three returned only `"LI button\nbutton\n"` -- nav-button captions, not
+the actual pipeline/renewal table. Unlike Kong 360's Churn Risk workbook,
+this workbook doesn't appear to publish the underlying worksheets as
+separate view tabs. This needs live investigation (e.g. via the
+`get-view-image` tool, or asking a site admin whether the underlying
+sheets can be exposed) before this project can reliably answer "show me
+my renewal pipeline as data".
+
+## Salesforce -- SFDC-sourced dashboards
+
+Project id `b4508a4a-c1f6-49fa-8d12-6938d2e0c59b`. Straightforward SFDC
+reporting, not row-level-secured to a single CSM as far as tested.
+
+| Workbook | id |
+|---|---|
+| Account Tracking | `415241ae-8099-41dc-ba52-63cab72de4d6` |
+| Marketing Leads | `85ec05b3-f60e-4fc4-a2fd-58f8c1b4835d` |
+| Open Pipeline | `55e67511-8fdd-4e8b-8785-c4416335e97c` |
+| Opportunity Overview | `5a8dc27b-2c8c-4698-904b-fa592efb88db` |
+| Opportunity Tracking | `97803af3-d709-4147-a941-91b98a603927` |
+| Quarterly Sales Result | `a402974e-9bd4-46d3-a4fc-3278aa66f98b` |
+| Top Accounts | `630b04fd-430b-4d1c-890b-0d6a67f81f81` |
+
+Datasources: Marketing, Opportunities Account Tracking, Opportunities
+Overview, Opportunities Pipeline, Opportunities Qtr Sales, Opportunities
+Top Accounts, Opportunities Tracking, Opportunities with Products -- all
+in this project, names are self-explanatory, ids not yet captured (use
+`list-datasources --filter projectName:eq:Salesforce`).
+
+## 3. Production -- flagship / cross-functional dashboards
+
+Project id `21dd15ca-49f5-4171-9203-7ceaa0ca0b3f` (under RevOps). Houses
+`Book of Business` (above) plus:
+
+| Workbook | id | Notes |
+|---|---|---|
+| Kong Command Center | `856dcbbe-13c4-438e-b6a2-fe5098dfa0e0` | **Site-wide most-used workbook** (21,083 total views, 1,097 in the last month at survey time). Sales/pipeline command center -- Summary, Closed Bookings, Renewal Analysis, Pipeline Generation QTD/YTD Overview, Pipeline Generation Deep Dive, Pipeline Progression, Pipeline Conversions, Forecast Health, AE Forecast Health, AE Weekly Deep Dive, Productivity, Ramping Productivity Deep Dive, Account Penetration, MQL Overview. Skews sales-leadership/AE-productivity, but `Renewal Analysis` and `Account Penetration` are CS-relevant. Backed by `Funnel Metrics Cohort Detail` and `MQL Funnel Conversion Trend` datasources. |
+| Account 360 | `1191812c-b476-49e6-be56-05238baab800` | Not yet probed -- name suggests it may overlap with or supersede the "Kong 360" project's per-account workbooks; worth comparing before assuming Kong 360 is the only per-account source. |
+| Win Wire | `aaf801e2-7eca-4981-90bb-3d59f2ac8fcf` | Not yet probed |
+| Income Revenue | `3e19b196-5b98-44a3-9d3e-252aa8c718e3` | Not yet probed |
+| AE 2x2 for QBRs | `837e839c-10f9-49bc-9ebb-d429152343c0` | QBR-prep dashboard, worth checking when prepping a QBR |
+
+## Other projects (not detailed -- use `list-workbooks`/`list-projects` filters live)
+
+- **RevOps** (`520c6ef4-...`) -- parent of "3. Production" and "2. Ad-hoc"
+- **Marketing** (`5c3539cb-...`) and subfolders (`1. Marketing KPIs
+  (Prod)`, `2. Development`, `2. Ad-hoc`, `3. Data Sources`, `4. Marketing
+  - Japan`) -- demand-gen, campaigns, funnel metrics. Not CSM-core but
+  useful for "what marketing activity touched this account" questions.
+- **Finance** (`27a9ddc1-...`) and subfolders (`0. Resources`, `1.
+  Sandbox`, `2. Ad-hoc`, `3. Production`)
+- **Professional Services** (`e120398f-...`) and subfolders
+  (`Sandbox`/`Production`/`Data Sources`) -- PS delivery/engagement data;
+  a `PS Engagement Overview` workbook also turns up oddly in `Samples`.
+- **Admin Insights** (`f1fd6796-...`) -- Tableau's own site-governance
+  datasources: `TS Events`, `TS Users`, `Site Content`, `Groups`, `Viz
+  Load Times`, `Job Performance`, `Permissions`, `Subscriptions`,
+  `Tokens`. This is meta-data about the Tableau site itself (who viewed
+  what, license usage), not customer data -- only relevant if asked about
+  Tableau usage/governance, not CSM work.
+- **Samples** -- Tableau's built-in Superstore/Regional sample content.
+- **Archive** / **Old / Deprecated Assets** -- deprecated, generally skip
+  unless specifically asked for historical content.
+
+## Pulse
+
+`list-all-pulse-metric-definitions` and `list-pulse-metric-subscriptions`
+both returned empty at survey time -- no Pulse metrics are currently
+published/subscribed for this identity. Don't read that as an error; it's
+a genuine "none exist yet" result. Worth re-checking periodically since
+Pulse adoption may grow.


### PR DESCRIPTION
## Summary

- Adds a new `tableau` skill (`modules/apps/cli/claude-code/config/skills/tableau/`) covering Kong's Tableau Cloud site: customer health/renewal/consumption/churn data (Kong 360), the CSM's own book of business, Salesforce-sourced dashboards, and general ad-hoc access.
- Written from a live discovery pass against the actual MCP server and site — documents operational quirks that aren't obvious from the tool schemas alone: sequential-calls-only (parallel calls trigger spurious 401/429), the VizQL Data Service being unavailable site-wide (`get-datasource-metadata`/`query-datasource` return 403 even on Tableau's bundled sample data), dashboard-vs-sheet view distinctions (dashboard views return nav-button captions instead of data via `get-view-data`), and row-level security scoping some views to the querying identity's own book.
- `references/content-map.md` captures the project/workbook/view/datasource inventory as surveyed, including confirmed-working view ids for Kong 360 Churn Risk and a known gap in Book of Business (Pipeline & Renewals) where the underlying data tables aren't yet reachable via `get-view-data`.
- Follows the existing `sfdc` skill's structure and memory conventions (skill-cache for stable workbook/view/datasource ids, auto-memory for softer facts).

## Test plan

- [ ] Rebuild and confirm `~/.claude/skills/tableau/` is populated via the activation-script rsync mirror
- [ ] Trigger the skill in a live session (e.g. "what's Acme's health score in Tableau") and confirm it reaches for the right Kong 360 workbook
- [ ] Confirm `just capture`/`just qr` tracks the new skill in `.capture-state.json` without issue