### PR TITLE
feat(fish): add gwscfg for switching gws OAuth profiles

### DIFF
--- a/modules/apps/cli/fish/default.nix
+++ b/modules/apps/cli/fish/default.nix
@@ -103,6 +103,33 @@ in
             end
           '';
 
+          gwscfg = ''
+            # "work" (the default gws config dir, ~/.config/gws) is always offered.
+            # Any other profile is a subdirectory of gws-profiles, each holding its
+            # own client_secret.json + credentials.enc for a separate Google account.
+            set -l profiles_dir "$HOME/.config/gws-profiles"
+            set -l choices work
+
+            if test -d "$profiles_dir"
+              set -a choices (find "$profiles_dir" -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
+            end
+
+            set -l selected (printf '%s\n' $choices | fzf --prompt="Select gws profile: " --height=40% --border)
+
+            if test -z "$selected"
+              echo "No selection made"
+              return 1
+            end
+
+            if test "$selected" = work
+              set -e -U GOOGLE_WORKSPACE_CLI_CONFIG_DIR
+              echo "✓ Activated gws profile: work (default ~/.config/gws)"
+            else
+              set -Ux GOOGLE_WORKSPACE_CLI_CONFIG_DIR "$profiles_dir/$selected"
+              echo "✓ Activated gws profile: $selected"
+            end
+          '';
+
           copy = ''
             if test (count $argv) -gt 0
               if not test -f "$argv[1]"


### PR DESCRIPTION
## Summary
- Adds a `gwscfg` fish function alongside the existing `kcfg`/`tcfg` pickers, for switching between multiple `gws` (Google Workspace CLI) OAuth profiles.
- `work` (the default, no override) always appears as a choice and keeps the current Kong setup at `~/.config/gws` untouched.
- Any other profile is read from `~/.config/gws-profiles/<name>/` and activates by setting `GOOGLE_WORKSPACE_CLI_CONFIG_DIR` as a universal fish variable, so it persists across shells like `kcfg`/`tcfg` do via their copied files.

## Context
Follow-up from #105. A personal Google account profile (`~/.config/gws-profiles/personal`) still needs to be created manually via `gws auth setup` under that account; this PR only adds the switcher.

## Test plan
- [x] `just fmt` — clean
- [x] `just build-host qbert` — builds successfully, `gwscfg.fish.drv` compiles (validates fish syntax)
- [ ] Manually run `gwscfg` after a rebuild and confirm it picks between profiles correctly

Refs #105