### PR TITLE
docs(claude-code): clipboard-copy the merge command for background sessions

### DIFF
--- a/modules/apps/cli/claude-code/config/CLAUDE.md
+++ b/modules/apps/cli/claude-code/config/CLAUDE.md
@@ -60,7 +60,7 @@ When I say "git cleanup" (or an unambiguous equivalent, e.g. "clean up the git s
 
 - This phrase is scoped to whatever we were just working on, not a sweep of every stale worktree or open PR in the repo. If it's ambiguous which branch I mean, ask.
 - Outside of this phrase, the default still holds: push the branch and open a PR, but stop there, don't merge unprompted.
-- **Background sessions still cannot merge, this phrase doesn't lift that.** If you're running as a background job when I say this, do everything through step 1, then hand me the exact `gh pr merge` command instead of merging yourself or silently skipping it.
+- **Background sessions still cannot merge, this phrase doesn't lift that.** If you're running as a background job when I say this, do everything through step 1, then hand me the exact `gh pr merge` command instead of merging yourself or silently skipping it. Pipe that command through `wl-copy` (best-effort, ignore failures) so it's on my clipboard, and still print it as plain text in the reply — the clipboard is local to whatever machine you're running on, so if I'm remote (phone, another device) the printed text is the only copy I can actually use.
 
 ### Merge Conflicts (mergiraf)
 


### PR DESCRIPTION
## Summary
- Extends the git-cleanup phrase-trigger note (from #135): when a background session hands back a `gh pr merge` command it can't run itself, pipe it through `wl-copy` (best-effort) in addition to printing it, so it's ready to paste locally without retyping.
- Printed text stays the fallback since the clipboard is local to whichever machine the session runs on and won't help when connecting remotely.

## Test plan
- [x] Reviewed diff, single line, no secrets
- [ ] Confirm a future merge handoff actually lands on the clipboard