### PR TITLE
feat(claude-code): import 13 vetted cowork-skills

### DIFF
--- a/modules/apps/cli/claude-code/config/skills/animated-website/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/animated-website/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: animated-website
+description: Turn any MP4 video into a luxury scroll-animated website with parallax effects, glass morphism, and cinema-quality polish. Use this skill when the user says "animated website from this video", "scroll-animated site", "make a website from this video", "turn this video into a website", or provides an MP4 and wants a scroll-driven site built from it.
+---
+
+# Animated Website from Video
+
+Turn any MP4 video into a stunning, scroll-driven animated website with parallax effects, glass morphism cards, and cinema-quality polish. One command, one HTML file, zero dependencies.
+
+## Requirements
+
+- **FFmpeg** installed and available in PATH
+- **Python 3** (for local preview server)
+- An **MP4 video file** provided by the user
+
+## Workflow
+
+### Step 1: Analyze the Video
+
+Run `ffprobe` on the provided MP4 to extract:
+- Total duration (seconds)
+- Frame rate (fps)
+- Resolution (width x height)
+- Total frame count
+
+Report these stats to the user before proceeding.
+
+### Step 2: Extract Frames
+
+Extract frames from the video at 2 fps (or adjust based on duration to stay under 120 frames total).
+
+```bash
+# Desktop frames (1920x1080 WebP, quality 80)
+ffmpeg -i INPUT.mp4 -vf "fps=2,scale=1920:1080" -c:v libwebp -quality 80 frames/desktop_%04d.webp
+
+# Mobile frames (960x540 WebP, quality 70)
+ffmpeg -i INPUT.mp4 -vf "fps=2,scale=960:540" -c:v libwebp -quality 70 frames/mobile_%04d.webp
+```
+
+Store frames in a temporary `frames/` directory next to the output file.
+
+### Step 3: Generate Section Content
+
+Analyze the video context (filename, user description, or any provided brief) and generate content for **6 scroll sections**:
+
+| Section | Purpose | Content Needed |
+|---------|---------|---------------|
+| **Hero** | Full-screen opening | Headline, subheadline, CTA button text |
+| **Features** | Key capabilities | 3-4 feature cards with icon, title, description |
+| **Stats** | Social proof / numbers | 3-4 animated stat counters with labels |
+| **How It Works** | Process breakdown | 3-5 numbered steps with short descriptions |
+| **Gallery** | Visual showcase | Parallax image grid with captions |
+| **CTA** | Final conversion | Headline, body text, button text, button URL |
+
+Present the draft content to the user for approval before building.
+
+### Step 4: Build the HTML File
+
+Generate a single self-contained HTML file with all assets base64-encoded inline:
+
+**Scroll Animation Engine:**
+- Canvas element draws frames synced to scroll position
+- `requestAnimationFrame` loop for smooth playback
+- Frame preloading with progress indicator
+- Responsive breakpoint swaps desktop/mobile frame sets
+
+**Visual Effects:**
+- Ambient floating particles (subtle, slow-moving, low opacity)
+- Film grain overlay (CSS noise animation)
+- Glass morphism cards (`backdrop-filter: blur(16px)`, semi-transparent bg)
+- Letter-split text animations (each character staggers in on scroll)
+- Parallax gallery (layers move at different scroll speeds)
+- Navigation dots fixed on the right edge (highlight active section)
+
+**Design Tokens:**
+- Background: `#0a0a0b`
+- Text primary: `#ffffff`
+- Text secondary: `rgba(255,255,255,0.6)`
+- Accent: user-chosen or default `#D97757`
+- Card bg: `rgba(255,255,255,0.05)`
+- Card border: `rgba(255,255,255,0.1)`
+- Font: Inter (loaded from Google Fonts) or system sans-serif fallback
+- Border radius: `16px` on cards, `999px` on buttons
+
+**Structure:**
+```
+- Progress bar (top, fixed)
+- Navigation dots (right, fixed)
+- Section 1: Hero (full viewport, canvas background)
+- Section 2: Features (glass cards grid)
+- Section 3: Stats (animated counters)
+- Section 4: How It Works (numbered steps)
+- Section 5: Gallery (parallax grid)
+- Section 6: CTA (centered, large)
+- Footer (minimal)
+```
+
+Save the output as `animated-site-[topic].html` in the current working directory.
+
+### Step 5: Launch Preview
+
+Start a local Python server and open in the default browser:
+
+```bash
+python3 -m http.server 8888 &
+xdg-open http://localhost:8888/animated-site-[topic].html 2>/dev/null || echo "Preview: http://localhost:8888/animated-site-[topic].html"
+```
+
+## Customization Options
+
+After the initial build, offer these tweaks:
+
+| Option | What it changes |
+|--------|----------------|
+| **Scroll speed** | Frames per scroll pixel (default: 0.5) |
+| **Accent color** | Primary highlight color (default: #D97757) |
+| **Section text** | Any headline, description, or CTA copy |
+| **Logo** | Add a logo image to the hero and nav |
+| **Font** | Swap Inter for another Google Font |
+| **Frame density** | More or fewer frames extracted (affects file size) |
+| **Sections** | Add, remove, or reorder the 6 sections |
+
+## Rules
+
+- ALL assets must be inlined (base64 data URIs). The final HTML must work offline with zero external fetches (except optional Google Font).
+- Keep total file size under 50MB. If frames push it over, reduce frame count or quality.
+- Every section must be at least 100vh tall so scroll animations have room to breathe.
+- Test that navigation dots correctly highlight the active section.
+- Mobile responsive: stack cards vertically, use mobile frame set below 768px.
+- If FFmpeg is not installed, tell the user how to install it and stop.
+- Never hallucinate video content. If you cannot determine what the video is about, ask the user to describe it.

--- a/modules/apps/cli/claude-code/config/skills/brand-design/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/brand-design/SKILL.md
@@ -1,0 +1,527 @@
+---
+name: brand-design
+description: Generate on-brand HTML designs for LinkedIn carousels, article images, banners, and infographics. Use this skill when the user says "brand design", "LinkedIn carousel", "make a carousel about", "LinkedIn banner", "article image", "infographic for LinkedIn", or asks for a branded social graphic. Output is a self-contained HTML file with inline CSS, Google Fonts, SVG graphics, and a PNG/PDF export button.
+---
+
+# Brand Design
+
+Generate on-brand HTML designs for LinkedIn carousels, article images, banners, and infographics. Output is a self-contained HTML file with inline CSS, Google Fonts, SVG graphics, and an html2canvas download button for PNG export.
+
+The user's prompt describes what they want. Infer the format from context, or ask if unclear.
+
+Check CLAUDE.md for the user's name, role, and brand colors if defined. The palette and typography below are defaults — if the user has stated their own brand colors/fonts, use those instead.
+
+---
+
+## FORMATS
+
+| Format | Dimensions | Use |
+|---|---|---|
+| `carousel` | 1080 x 1080 px (per slide) | LinkedIn carousel posts (multiple slides in one HTML) |
+| `article-image` | 1080 x 607 px | LinkedIn article header images |
+| `banner` | 1584 x 396 px | LinkedIn profile/company banner |
+| `infographic` | 1080 x 1350 px | Tall-format data visuals |
+| `social-post` | 1080 x 1080 px (single) | Single-image LinkedIn posts |
+
+---
+
+## DEFAULT BRAND SYSTEM (Cool Slate + Signal Accents)
+
+Use this palette unless the user specifies their own brand colors.
+
+### Colors — Punch Backgrounds (dark bold slides)
+For single-image formats (banners, article images, social posts), pick ONE background. For **carousels with 5+ slides**, use up to 3 distinct punch backgrounds for visual variety:
+- **Bookend slides** (first & last): Cool Slate `#475569` (anchors the carousel identity)
+- **Interior punch slides**: Mix in Deep Forest and/or Midnight Blue (max one of each)
+- All breathe slides stay on Cloud `#f3f4f6` regardless
+
+| Name | Hex | RGB | Use |
+|---|---|---|---|
+| **Cool Slate** | `#475569` | 71, 85, 105 | Default. Blue-tinted neutral. Carousel bookends. |
+| **Slate Deep** | `#334155` | 51, 65, 85 | Cards/insets on slate |
+| **Slate Light** | `#64748b` | 100, 116, 139 | Hover states, subtle variations |
+| **Deep Forest** | `#064e3b` | 6, 78, 59 | Growth/compound topics |
+| **Midnight Blue** | `#1e3a5f` | 30, 58, 95 | Data/strategy/intel topics |
+
+### Colors — Breathe Backgrounds (light content slides)
+
+| Name | Hex | Use |
+|---|---|---|
+| **Cloud** | `#f3f4f6` | Breathe slide background |
+| **Card White** | `#ffffff` | Cards on cloud background |
+
+### Colors — Text
+
+| Token | On Dark | On Light |
+|---|---|---|
+| Primary | `#ffffff` | `#111827` |
+| Secondary | `#d1d5db` | `#6b7280` |
+| Muted | `#9ca3af` | `#9ca3af` |
+| Body | `#d1d5db` | `#64748b` |
+
+### Colors — Signal Accents
+
+| Name | Base | Bright | Use |
+|---|---|---|---|
+| **Emerald** | `#10b981` | `#34d399` | Primary accent, CTAs, positive. Use bright variant for text on dark bg. |
+| **Amber** | `#f59e0b` | `#fbbf24` | Highlights, reactive signals |
+| **Signal Blue** | `#3b82f6` | `#60a5fa` | Information, links, trust |
+| **Danger Red** | `#ef4444` | `#f87171` | Alerts, negative metrics |
+| **Purple** | `#8b5cf6` | `#a78bfa` | Process, scoring, tertiary |
+| **Cyan** | `#06b6d4` | — | Optional accent |
+
+### Typography
+
+```
+Font import: https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap
+
+--font-sans: 'Inter', system-ui, sans-serif
+--font-mono: 'JetBrains Mono', monospace
+```
+
+| Level | Font | Weight | Size | Tracking | Use |
+|---|---|---|---|---|---|
+| Display XL | Inter | 900 | 64px | -2px | Hero headline on punch slides |
+| Display Hollow | Inter | 900 | 64px | -2px | Outlined keyword. stroke 3px. |
+| Display | Inter | 900 | 48px | -1.5px | Secondary display |
+| Hollow Variant | Inter | 900 | 48px | -1.5px | Outlined keyword. stroke 2.5px. |
+| H1 | Inter | 800 | 36-40px | -0.5px | Section titles (use 40px on breathe slides) |
+| H2 | Inter | 700 | 28px | -0.3px | Card titles |
+| Body | Inter | 500 | 18-20px | 0 | Content (≥18px for mobile readability) |
+| Small | Inter | 500 | 16px | 0 | Descriptions (never below 16px) |
+| Caption | JetBrains Mono | 600 | 12px | 0.5px | Labels, metadata |
+| Mono Label | JetBrains Mono | 700 | 12-14px | 1-2px | Uppercase section labels |
+
+### Hollow Text Rules
+- Use ONLY for 1-3 keyword emphasis words, NEVER full sentences
+- Minimum font size: 48px
+- Stroke: 3px at 64px, 2.5px at 48px — never below 2px
+- Max 3 hollow words per slide
+- CSS: `color: transparent; -webkit-text-stroke: 3px <accent-bright>;`
+- In mixed fill+hollow, only hollow the final keyword
+
+### Spacing & Borders
+
+```
+Base unit: 8px
+Radii: 4px (sm), 8px (md), 12px (lg), 24px (pill)
+Shadows:
+  sm: 0 2px 8px rgba(0,0,0,0.06)
+  md: 0 4px 16px rgba(0,0,0,0.10)
+  dark: 0 4px 20px rgba(0,0,0,0.3)
+Border on dark: rgba(255,255,255,0.12)
+Border on light: #e5e7eb
+```
+
+---
+
+## CSS VISUAL ELEMENTS (Isometric & Decorative)
+
+Use pure CSS visuals to break up text-heavy slides. These replace stock imagery and are fully self-contained in the HTML file. ALL visuals MUST use **2D-only CSS** to ensure html2canvas compatibility for PDF/PNG export.
+
+### html2canvas Compatibility (CRITICAL)
+- **NEVER use:** `perspective()`, `rotateX()`, `rotateY()`, `rotateZ()` (3D), `translateZ()`, `transform-style: preserve-3d`, `backdrop-filter: blur()`
+- **SAFE to use:** `transform: rotate()` (2D), `translate()`, `scale()`, positional offsets (`top/left`), `box-shadow`, `border`, `opacity`, `linear-gradient()`
+- Test: if the visual looks correct as a flat screenshot, it will render correctly in html2canvas
+
+### Glass-Panel Style
+Semi-transparent branded cards with glowing borders. Use on dark punch slides.
+```css
+/* Template — substitute brand color values */
+background: rgba(16,185,129, 0.08-0.12);     /* brand color at 8-12% opacity */
+border: 1.5px solid rgba(52,211,153, 0.25-0.40); /* bright variant at 25-40% */
+border-radius: 14px;
+box-shadow: 0 0 24px rgba(16,185,129, 0.08), 0 6px 20px rgba(0,0,0,0.15);
+```
+Use emerald for positive/growth, amber for caution/reactive, blue for data/trust.
+
+### Isometric Layer Stack
+Diagonal arrangement of 3 equal-width panels, offset 18-22px per step. Creates a "stacked layers" visual without 3D transforms.
+```
+Layout: Layer 1 at left:0, Layer 2 at left:22px, Layer 3 at left:44px
+Container: 360px wide × 420px tall
+Each layer: position: absolute; top values spaced 120-130px apart
+Panel size: 300px wide, padding 24px 28px
+Layer label: 12px mono, uppercase
+Layer title: 19px sans, bold
+Time/metric values: 21px mono
+Cost/secondary: 13px mono
+Connectors: SVG arrows with departure dot + diagonal line + arrowhead polygon
+Optional: scale/direction indicator with subtle SVG arrows (opacity: 0.25)
+```
+Best for: validation layers, tech stack comparisons, progressive frameworks.
+
+### Channel-Routing Diagram
+Central node branching to 2-3 destination cards via SVG bezier curve connectors.
+```
+Layout:
+- Central node: 110×110px, left: 0, vertically centered
+- Node text: 11px label + 16px mono title
+- Connectors: SVG bezier curves (cubic C command) with departure dots + arrowhead polygons
+- Channel cards: positioned right of node (left: 140px), 190px wide, min-height 175px
+- Card label: 12px mono, uppercase
+- Card title: 19px sans, bold
+- Card subtitle: 15px sans
+- Audience label: 12px mono + 16px value
+- Top card: emerald accent, bottom card: amber accent
+```
+Best for: audience segmentation, message-channel matching, distribution strategies.
+
+### Floating Hypothesis Panels
+Scattered, slightly rotated cards with status indicators. Use on cover/intro slides.
+```
+Layout: 3 cards stacked vertically in 320px wide × 520px tall container
+- Each card 270px wide, rotated -3deg to +2deg
+- Each card offset slightly left/right (stagger: 0-30px)
+- Card padding: 22px 26px
+- Panel label: 12px mono, uppercase
+- Panel text: 19px sans, semibold
+- Status dot: 8px circle + 13px mono label ("Unvalidated", "Untested")
+- Glass-panel style on dark backgrounds
+- Vertical spacing: ~170px between card tops
+```
+Best for: opening slides that challenge assumptions, hypothesis framing.
+
+### Two-Column Punch Layout
+When adding visuals to punch slides, use a side-by-side layout:
+```css
+/* Wrapper: replaces the full-width flex-column */
+display: flex; align-items: center; gap: 24-32px; position: relative;
+
+/* Left column (text): */
+flex: 1;  /* takes ~65-70% */
+
+/* Right column (visual): */
+flex-shrink: 0; width: 280-340px;  /* takes ~30-35% */
+```
+- Constrain sub text `max-width` to 480-520px to avoid overlapping the visual
+- Reduce headline font-size by 2-4px (e.g., 58px instead of 62px) to fit the narrower column
+- Keep the stat-row at full width below the two-column layout
+
+---
+
+## POSITIONING RULES
+
+### Headlines
+- Own 30-40% of vertical space
+- Center-aligned on punch slides
+- Left-aligned body text on breathe slides
+- Display XL (64px) for covers, H1 (36px) for content slides
+
+### Content Zones
+- Maximum 3 zones per slide (headline, hero visual, footer/stats)
+- One idea per slide. No wall-of-text.
+
+### Margins
+- **40px** all sides on 1080x1080 carousel
+- **48px** on 1200x628 banner
+- **40px 50px** on 1080x607 article image
+
+### Floating Elements
+- Rotate 2-3 degrees for depth
+- Use `box-shadow: var(--shadow-md)` — never flat-stack
+
+### Accent Bars
+- Solid emerald bar (4px height) on top-left edge of punch slides
+- Vertical emerald stripe (4px width) on left edge for emphasis
+- NEVER use multi-color gradients (reads as AI-generated)
+
+---
+
+## SLIDE STRUCTURE (Carousels)
+
+Alternate between **punch** and **breathe** slides:
+
+### Punch Slide (dark background)
+```
+- Full-bleed background: var(--slate) or forest/midnight
+- Emerald accent bar: top-left, 4px height, ~30% width
+- Mono label: uppercase, 12px, letter-spacing 2px, emerald-bright
+- Display headline: 64px, white, -2px tracking
+- Optional hollow keyword in accent-bright
+- Supporting text: 1 line max, #d1d5db, 20px
+- Bottom stats bar: JetBrains Mono numbers in accent colors
+```
+
+**Two-column variant** (when adding CSS visuals):
+```
+- Same background, accent bar, mono label
+- Content area: display: flex; align-items: center; gap: 24-32px;
+- Left column (flex: 1): headline (54-58px) + sub (max-width: 480-520px)
+- Right column (flex-shrink: 0; width: 280-340px): glass-panel visual
+- Stat row stays full-width below the two-column area
+```
+
+### Breathe Slide (light background)
+```
+- Background: #f3f4f6
+- White cards with border-radius 12px, shadow-sm
+- H1 title: #111827, 36-40px (prefer 40px for readability)
+- Body: #64748b, 18-20px (never below 18px)
+- Card body: 20px minimum
+- Accent-colored left borders on cards (4px, emerald/amber/blue)
+- Data in JetBrains Mono
+```
+
+### Vertical Centering (eliminate bottom dead space)
+Wrap content areas in this flex container to distribute vertical space evenly:
+```css
+flex: 1; display: flex; flex-direction: column; justify-content: center;
+```
+Apply to: any slide section that has dead space below its content. This pushes content to the vertical center rather than stacking from the top.
+
+### Text Density Guidelines
+- **Card body copy**: 1 sentence max. Trim ruthlessly.
+- **Sub text**: 1-2 sentences. If it wraps past 3 lines, it's too long.
+- **Slide rule**: If a slide feels text-heavy, add a CSS visual element (see CSS VISUAL ELEMENTS section) rather than trying to make the text smaller.
+- **Step cards**: Title + 1-line description. Move detailed explanations to the next breathe slide.
+
+---
+
+## CAROUSEL READABILITY PRINCIPLES (CRITICAL)
+
+LinkedIn carousels are viewed primarily on mobile. A 1080×1080px canvas renders at ~350-400px on a phone screen — a **~3× compression ratio**. This means a 12px font on canvas renders at ~4px on screen, which is invisible. Every font size and spacing decision must account for this.
+
+### Minimum Font Size Thresholds (1080×1080 carousel)
+
+| Element | Minimum | Recommended | Never Below |
+|---|---|---|---|
+| Mono labels (uppercase) | 12px | 12-14px | 11px |
+| Body / descriptions | 18px | 19-20px | 16px |
+| Card titles | 22px | 22-24px | 20px |
+| Sub text / supporting copy | 20px | 20-22px | 18px |
+| Status text / cost labels | 13px | 13-15px | 12px |
+| Pipeline stage text | 18px | 18-20px | 16px |
+| Metric / stat values | 21px | 21-26px | 20px |
+| Display headlines | 48px | 54-64px | 48px |
+| Section H1 titles | 36px | 36-40px | 36px |
+| Caption / metadata | 12px | 12-13px | 11px |
+
+**Rule of thumb**: If you can't comfortably read it on a phone without zooming, it's too small. When in doubt, go 2-4px larger.
+
+### Space Utilisation — No Dead Zones
+
+```
+Slide padding: 40px (not 56px) — reclaims 32px of usable vertical + horizontal space
+Swipe CTA positioning: bottom: 44px; right: 40px;
+Swipe arrow positioning: bottom: 44px; right: 40px;
+Author block positioning: bottom: 44px; left/right: 40px;
+```
+
+- **Never leave >60px of empty space** at the top or bottom of a slide
+- Use `flex: 1; display: flex; flex-direction: column; justify-content: center;` to vertically center content and eliminate dead zones
+- If visual elements (layer stacks, channel diagrams, hypothesis panels) have blank space around them, **enlarge the element** to fill the available area rather than leaving dead zones
+
+### Hollow Border Technique for Panel Prominence
+
+When panels on dark backgrounds blend into the slide and become hard to distinguish, add hollow borders using the slide's accent colour at low opacity:
+
+```css
+/* Match border colour to the panel's thematic accent */
+border: 1.5px solid rgba(52,211,153, 0.35);   /* Emerald — for growth/positive */
+border: 1.5px solid rgba(251,191,36, 0.35);   /* Amber — for caution/reactive */
+border: 1.5px solid rgba(96,165,250, 0.35);   /* Blue — for data/trust */
+border: 1.5px solid rgba(255,255,255, 0.12);  /* Subtle white — for neutral panels */
+```
+
+- Use 1.5px stroke weight — thick enough to see on mobile, thin enough to stay elegant
+- Opacity range: 0.25-0.40 depending on contrast needs
+- Each panel on the same slide should use a **different accent colour** for visual distinction
+- This technique mirrors the hollow text pattern: outlining for prominence without filling
+
+### Pre-Publish Readability Checklist
+
+Before finalising any carousel, verify every slide against this checklist:
+
+1. ☐ **No font below 12px** on any element (including labels, status text, costs)
+2. ☐ **Body text ≥ 18px** on all slides (both punch and breathe)
+3. ☐ **Card titles ≥ 22px** — the entry point for scanning
+4. ☐ **No dead zones** — top/bottom spacing ≤ 60px, content vertically centred
+5. ☐ **Panels distinguishable** — hollow borders or clear visual separation on dark slides
+6. ☐ **Swipe CTA visible** but not eating content space (44px from bottom/right)
+7. ☐ **Glass panels readable** — text inside glass-panel cards ≥ 18px body, ≥ 12px labels
+8. ☐ **SVG connectors aligned** — if element sizes changed, verify arrows/curves still connect correctly
+9. ☐ **Slide padding = 40px** — not the old 56px default
+10. ☐ **Test at 350px width** — shrink browser to phone size and verify all text is legible
+
+---
+
+## HTML TEMPLATE STRUCTURE
+
+Every output file MUST follow this skeleton:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{TITLE}}</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    display: flex; flex-direction: column; justify-content: center;
+    align-items: center; min-height: 100vh;
+    background: #d0d0d0; padding: 40px; gap: 40px;
+  }
+  /* ... slide/banner styles ... */
+
+  .download-btn {
+    position: fixed; bottom: 30px; right: 30px;
+    padding: 14px 28px; background: #333; color: white;
+    border: none; border-radius: 8px;
+    font-family: 'Inter', sans-serif; font-size: 14px;
+    font-weight: 600; cursor: pointer; z-index: 100;
+  }
+  .download-btn:hover { background: #111; }
+  .size-label {
+    position: fixed; top: 15px; left: 50%; transform: translateX(-50%);
+    font-family: 'JetBrains Mono', monospace; font-size: 12px; color: #888;
+    background: #fff; padding: 6px 16px; border-radius: 6px;
+    border: 1px solid #ddd; z-index: 100;
+  }
+</style>
+</head>
+<body>
+
+<div class="size-label">{{FORMAT_LABEL}} — {{WIDTH}} x {{HEIGHT}}px</div>
+
+<!-- SLIDES/BANNER CONTENT HERE -->
+<div class="slide" id="slide-1">...</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+
+<div style="position: fixed; bottom: 30px; right: 30px; display: flex; gap: 10px; z-index: 100;">
+  <button class="download-btn" style="position: static; background: #10b981;" onclick="downloadPDF()">Download as PDF (LinkedIn)</button>
+  <button class="download-btn" style="position: static;" onclick="downloadPNG()">Download as PNG</button>
+</div>
+
+<script>
+async function downloadPDF() {
+  const btn = document.querySelector('[onclick="downloadPDF()"]');
+  btn.textContent = 'Generating PDF...';
+  btn.disabled = true;
+  try {
+    if (typeof html2canvas === 'undefined') throw new Error('html2canvas not loaded');
+    if (!window.jspdf) throw new Error('jsPDF not loaded');
+    const { jsPDF } = window.jspdf;
+    const pdf = new jsPDF({ orientation: 'portrait', unit: 'px', format: [{{WIDTH}}, {{HEIGHT}}] });
+    const slides = document.querySelectorAll('.slide');
+    for (let i = 0; i < slides.length; i++) {
+      btn.textContent = `Rendering slide ${i + 1} of ${slides.length}...`;
+      const canvas = await html2canvas(slides[i], {
+        scale: 2, useCORS: true, width: {{WIDTH}}, height: {{HEIGHT}}, logging: false
+      });
+      const imgData = canvas.toDataURL('image/jpeg', 0.95);
+      if (i > 0) pdf.addPage([{{WIDTH}}, {{HEIGHT}}]);
+      pdf.addImage(imgData, 'JPEG', 0, 0, {{WIDTH}}, {{HEIGHT}});
+    }
+    btn.textContent = 'Saving PDF...';
+    pdf.save('{{FILENAME_BASE}}.pdf');
+    btn.textContent = 'Download as PDF (LinkedIn)';
+  } catch (err) {
+    console.error('PDF generation failed:', err);
+    alert('PDF generation failed: ' + err.message + '\n\nTry opening via localhost instead of file://');
+    btn.textContent = 'Download as PDF (LinkedIn)';
+  }
+  btn.disabled = false;
+}
+
+async function downloadPNG() {
+  const slides = document.querySelectorAll('.slide');
+  for (let i = 0; i < slides.length; i++) {
+    const canvas = await html2canvas(slides[i], {
+      scale: 2, useCORS: true, width: {{WIDTH}}, height: {{HEIGHT}}
+    });
+    const link = document.createElement('a');
+    link.download = `{{FILENAME_BASE}}-${i + 1}.png`;
+    link.href = canvas.toDataURL('image/png');
+    link.click();
+    await new Promise(r => setTimeout(r, 500));
+  }
+}
+</script>
+
+</body>
+</html>
+```
+
+---
+
+## AUTHOR BLOCK (optional, for article images and banners)
+
+Only include this if the user asks for a name/photo credit on the graphic. Pull the name from CLAUDE.md if available; otherwise ask for it. Ask for a path to the headshot image — never invent or reuse a filename that isn't the user's own.
+
+```html
+<div style="position: absolute; bottom: 18px; right: 32px; display: flex; align-items: center; gap: 10px;">
+  <div style="text-align: right;">
+    <div style="font-family: 'Inter', sans-serif; font-size: 16px; font-weight: 600; color: #444;">{{USER_NAME}}</div>
+    <div style="font-family: 'JetBrains Mono', monospace; font-size: 12px; font-weight: 500; color: #999;">by {{USER_NAME}}</div>
+  </div>
+  <div style="width: 56px; height: 56px; border-radius: 50%; overflow: hidden; border: 2.5px solid #ddd; box-shadow: 0 2px 8px rgba(0,0,0,0.08);">
+    <img src="{{HEADSHOT_PATH}}" alt="{{USER_NAME}}" style="width:100%;height:100%;object-fit:cover;object-position:center top;" />
+  </div>
+</div>
+```
+
+---
+
+## SERVING & EXPORT NOTES
+
+### file:// vs localhost
+- **PDF download requires `localhost`** — browsers block CDN scripts (jsPDF, html2canvas) when opened via `file://` protocol due to CORS restrictions
+- Always serve via local HTTP server: `python3 -m http.server 8899` from the design directory
+- PNG download may work on `file://` but is unreliable — prefer localhost for both
+
+### LinkedIn Carousel Upload
+1. Download as PDF via the green button
+2. On LinkedIn: Create Post → Document → Upload the PDF
+3. LinkedIn automatically converts each page into a swipeable slide
+4. Recommended: 5-10 slides. More than 12 reduces engagement.
+
+---
+
+## CONTENT PRINCIPLES
+
+- **Tone**: match the user's stated tone, or ask if unclear. Default to authoritative but not boring.
+- **Audience**: ask the user who this is for (or check CLAUDE.md) — adapt content level and jargon accordingly.
+- **Data**: Include 2-3 stats in JetBrains Mono with colored accents when the content calls for it.
+- **One idea per slide** — never cram.
+- **Punch/breathe alternation** — bold dark slides for impact, light slides for detail.
+- This is a **general-purpose brand design skill** — use it for personal branding, side projects, thought leadership on any subject, client work, event graphics, or anything the user asks for.
+
+---
+
+## EXAMPLE PROMPT PATTERNS
+
+User says: "Create a 5-slide carousel about narrative drift"
+-> Generate 5 alternating punch/breathe slides at 1080x1080, using Cool Slate background
+
+User says: "Make an article image for my post about competitive readiness"
+-> Generate 1 article image at 1080x607, using breathe (light) background with data visualization
+
+User says: "LinkedIn banner showing the compound intelligence pipeline"
+-> Generate 1 banner at 1584x396
+
+User says: "Forest green carousel on growth compounding"
+-> Use Deep Forest (#064e3b) instead of default slate
+
+User says: "Midnight blue infographic on market signals"
+-> Use Midnight Blue (#1e3a5f) background, tall 1080x1350 format
+
+User says: "Carousel with a pipeline diagram on slide 3"
+-> Generate HTML carousel, but use an SVG-based diagram inline for that slide
+
+User says: "Carousel about messaging validation with visuals"
+-> Use two-column punch layout: text on left, isometric layer stack on right (glass-panel style, 2D-safe CSS)
+
+User says: "Make the carousel less text-heavy"
+-> Add CSS visual elements (layer stacks, channel-routing diagrams, floating panels) to punch slides. Trim card body copy to 1 sentence max.
+
+User says: "7-slide carousel with mixed backgrounds"
+-> Use 3 backgrounds: Cool Slate bookends (slides 1, 7), Deep Forest on one interior punch, Midnight Blue on another. All breathe slides stay Cloud.
+
+User says: "I need the carousel as a PDF for LinkedIn"
+-> Ensure jsPDF CDN is loaded alongside html2canvas. Add green "Download as PDF" button. Remind user to open via localhost, not file://.

--- a/modules/apps/cli/claude-code/config/skills/budget-dashboard/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/budget-dashboard/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: budget-dashboard
+description: Generate an interactive financial dashboard as a self-contained HTML file with Apple Swiss design. Includes sliders to adjust income and expenses in real-time, donut chart breakdown, 12-month savings projection with investment scenarios, milestone tracker, and benchmark comparisons. Use this skill when the user says "budget dashboard", "financial dashboard", "interactive budget", "budget app", "visualize my budget", "budget planner", "where's my money going", "savings dashboard", or any variation of wanting to see their finances visually.
+---
+
+# Budget Dashboard
+
+Build an interactive, self-contained HTML financial dashboard with an **Apple Swiss design aesthetic** — clean white backgrounds, SF-style typography (use Instrument Sans + Newsreader from Google Fonts), generous whitespace, soft shadows, pill-shaped buttons, and Apple system colors (#34c759 green, #007aff blue, #ff2d55 pink, #ff9500 orange, #af52de purple).
+
+## What It Delivers
+
+A single HTML file the user can open in any browser. Everything updates in real-time as they drag sliders. No backend, no dependencies beyond Chart.js from CDN.
+
+## Features Required
+
+1. **Top stat cards** (4 across) — Income, Expenses, Savings, Savings Rate — each with an icon, the value, and a subtitle
+2. **Slider panel** — Sliders for income and each expense category. Each slider shows current value and range. All sliders fire `update()` on input.
+3. **Donut chart** — Shows expense breakdown + savings as the largest slice. Center text shows savings rate %. Uses Chart.js doughnut.
+4. **Legend** — Color-coded list beside the donut with category names, dollar amounts, and percentages.
+5. **12-month projection chart** — Line chart (Chart.js) with 3 scenario toggle buttons: "Just Saving" (0% return), "High-Yield Savings" (4.5% APY), "Invested" (7% annual). Chart color changes per scenario.
+6. **Milestones** — Progress bars toward: Emergency Fund 3mo, Emergency Fund 6mo, $100K, $250K. Each shows ETA in months/years.
+7. **Benchmark comparisons** — Housing, Food, Savings, Wants vs. standard guidelines (50/30/20 rule). Visual bar with guideline marker.
+8. **Insight box** — Dynamic text that changes based on savings rate (different messages for <20%, 20-50%, 50%+, and negative).
+
+## Instructions
+
+### Step 1: Gather the Numbers
+
+Ask for (or help estimate):
+
+**For Personal:**
+- Total monthly income (after tax)
+- Fixed expenses (rent, utilities, insurance, subscriptions, loan payments)
+- Variable expenses (food, gas, entertainment, shopping)
+- Current savings rate
+- Any debt payments
+- Financial goals
+
+**For Business:**
+- Monthly revenue
+- Fixed costs (rent, software, salaries, insurance)
+- Variable costs (marketing, contractors, supplies, travel)
+- Growth investments
+- Tax set-aside percentage
+- Profit targets
+
+### Step 2: Build the Dashboard
+
+Generate a self-contained HTML file with all CSS inline (in a `<style>` tag) and all JS inline (in a `<script>` tag). Import Chart.js from CDN:
+
+```html
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
+```
+
+Import fonts from Google Fonts:
+```html
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600&display=swap" rel="stylesheet">
+```
+
+### Step 3: Design Rules (Apple Swiss)
+
+- **Background**: #f5f5f7 (Apple light gray)
+- **Cards**: #ffffff with border-radius: 20px, soft shadow (0 1px 3px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.04))
+- **Typography**: Instrument Sans for body/UI, Newsreader (serif) for large numbers and headings
+- **Colors**: Use Apple system colors — green #34c759, blue #007aff, pink #ff2d55, orange #ff9500, purple #af52de, teal #5ac8fa
+- **Sliders**: Clean white thumbs with blue border, thin 4px tracks
+- **Buttons**: Pill-shaped (border-radius: 100px), active state fills with blue
+- **Spacing**: Generous — 24-28px card padding, 16px grid gaps
+- **Animations**: Subtle fadeIn on load with staggered delays
+- **Hover states**: Cards lift slightly with enhanced shadow
+- **No dark mode** — keep it light and clean
+
+### Step 4: Populate with User's Numbers
+
+Set the slider default values and state object to match the user's actual income and expense numbers. All sliders should have sensible min/max ranges (e.g., income 2k-30k, rent 0-5k).
+
+### Step 5: Save and Deliver
+
+Save as: `financial-dashboard.html`
+
+The file should be completely self-contained — opening it in any browser should display the full interactive dashboard with no other dependencies.
+
+### Step 6: Verify
+
+Double-check:
+- All math adds up (income - expenses = savings)
+- Donut chart percentages total 100%
+- Projection chart uses correct compound interest formulas
+- Milestone ETAs are calculated correctly
+- All sliders update everything in real-time
+
+## Rules
+
+- Never give specific investment advice. Budget visualization is fine. "Put your money in X stock" is not.
+- Include a small footer disclaimer that this is a planning tool, not financial advice.
+- Always double-check the math. Budget totals must add up correctly.
+- If the user shares sensitive financial details, handle them with care and don't store them in memory.
+- Round to whole dollars.

--- a/modules/apps/cli/claude-code/config/skills/budget-dashboard/references/template.html
+++ b/modules/apps/cli/claude-code/config/skills/budget-dashboard/references/template.html
@@ -1,0 +1,865 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Financial Dashboard</title>
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400&display=swap" rel="stylesheet">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
+<style>
+  :root {
+    --bg: #f5f5f7;
+    --white: #ffffff;
+    --text: #1d1d1f;
+    --text-secondary: #6e6e73;
+    --text-tertiary: #aeaeb2;
+    --border: #d2d2d7;
+    --border-light: #e8e8ed;
+    --green: #34c759;
+    --green-bg: #f0faf2;
+    --blue: #007aff;
+    --blue-bg: #f0f5ff;
+    --orange: #ff9500;
+    --orange-bg: #fff8f0;
+    --pink: #ff2d55;
+    --pink-bg: #fff0f3;
+    --purple: #af52de;
+    --teal: #5ac8fa;
+    --radius: 20px;
+    --radius-sm: 14px;
+    --shadow: 0 1px 3px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.04);
+    --shadow-hover: 0 2px 8px rgba(0,0,0,0.06), 0 8px 24px rgba(0,0,0,0.06);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Instrument Sans', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    min-height: 100vh;
+  }
+
+  .app {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 48px 32px 80px;
+  }
+
+  /* ---- HEADER ---- */
+  .header {
+    margin-bottom: 40px;
+  }
+  .header-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+  }
+  .header h1 {
+    font-family: 'Newsreader', Georgia, serif;
+    font-size: 48px;
+    font-weight: 600;
+    letter-spacing: -1.5px;
+    line-height: 1.1;
+    color: var(--text);
+  }
+  .header p {
+    color: var(--text-secondary);
+    font-size: 17px;
+    font-weight: 400;
+    margin-top: 8px;
+    letter-spacing: -0.2px;
+  }
+  .date-pill {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    background: var(--white);
+    border: 1px solid var(--border-light);
+    border-radius: 100px;
+    padding: 8px 16px;
+    white-space: nowrap;
+  }
+
+  /* ---- STAT CARDS ---- */
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+  .stat {
+    background: var(--white);
+    border-radius: var(--radius);
+    padding: 24px 24px 20px;
+    box-shadow: var(--shadow);
+    transition: box-shadow 0.3s, transform 0.3s;
+    position: relative;
+    overflow: hidden;
+  }
+  .stat:hover {
+    box-shadow: var(--shadow-hover);
+    transform: translateY(-1px);
+  }
+  .stat-icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    margin-bottom: 14px;
+  }
+  .stat-icon.green { background: var(--green-bg); color: var(--green); }
+  .stat-icon.pink { background: var(--pink-bg); color: var(--pink); }
+  .stat-icon.blue { background: var(--blue-bg); color: var(--blue); }
+  .stat-icon.orange { background: var(--orange-bg); color: var(--orange); }
+  .stat-label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    margin-bottom: 6px;
+  }
+  .stat-value {
+    font-family: 'Newsreader', Georgia, serif;
+    font-size: 34px;
+    font-weight: 600;
+    letter-spacing: -1px;
+    line-height: 1.1;
+  }
+  .stat-value.green { color: var(--green); }
+  .stat-value.pink { color: var(--pink); }
+  .stat-value.blue { color: var(--blue); }
+  .stat-value.orange { color: var(--orange); }
+  .stat-sub {
+    font-size: 13px;
+    color: var(--text-tertiary);
+    margin-top: 4px;
+  }
+
+  /* ---- GRID ---- */
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 16px;
+  }
+  .grid-full { grid-column: 1 / -1; }
+
+  /* ---- CARD ---- */
+  .card {
+    background: var(--white);
+    border-radius: var(--radius);
+    padding: 28px;
+    box-shadow: var(--shadow);
+    transition: box-shadow 0.3s;
+  }
+  .card:hover { box-shadow: var(--shadow-hover); }
+  .card-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    margin-bottom: 24px;
+  }
+
+  /* ---- SLIDERS ---- */
+  .slider-group { margin-bottom: 22px; }
+  .slider-group:last-of-type { margin-bottom: 0; }
+  .slider-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 8px;
+  }
+  .slider-name {
+    font-size: 15px;
+    font-weight: 500;
+    color: var(--text);
+    letter-spacing: -0.1px;
+  }
+  .slider-val {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--blue);
+    font-variant-numeric: tabular-nums;
+    min-width: 72px;
+    text-align: right;
+  }
+
+  input[type="range"] {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--border-light);
+    outline: none;
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+  input[type="range"]:hover { background: var(--border); }
+  input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--white);
+    border: 2px solid var(--blue);
+    cursor: pointer;
+    box-shadow: 0 1px 4px rgba(0,122,255,0.3);
+    transition: transform 0.15s, box-shadow 0.15s;
+  }
+  input[type="range"]::-webkit-slider-thumb:hover {
+    transform: scale(1.12);
+    box-shadow: 0 2px 8px rgba(0,122,255,0.4);
+  }
+  input[type="range"]::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--white);
+    border: 2px solid var(--blue);
+    cursor: pointer;
+    box-shadow: 0 1px 4px rgba(0,122,255,0.3);
+  }
+  .slider-range {
+    display: flex;
+    justify-content: space-between;
+    font-size: 11px;
+    color: var(--text-tertiary);
+    margin-top: 4px;
+  }
+
+  /* ---- INSIGHT ---- */
+  .insight {
+    margin-top: 24px;
+    padding: 18px 20px;
+    background: var(--blue-bg);
+    border-radius: var(--radius-sm);
+    border-left: 3px solid var(--blue);
+  }
+  .insight-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--blue);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 6px;
+  }
+  .insight p {
+    font-size: 14px;
+    color: var(--text-secondary);
+    line-height: 1.55;
+  }
+  .insight strong { color: var(--text); }
+
+  /* ---- DONUT ---- */
+  .donut-layout {
+    display: flex;
+    align-items: center;
+    gap: 36px;
+  }
+  .donut-wrap {
+    width: 200px;
+    height: 200px;
+    flex-shrink: 0;
+    position: relative;
+  }
+  .donut-center {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    pointer-events: none;
+  }
+  .donut-center-value {
+    font-family: 'Newsreader', Georgia, serif;
+    font-size: 24px;
+    font-weight: 600;
+    color: var(--text);
+    letter-spacing: -0.5px;
+  }
+  .donut-center-label {
+    font-size: 11px;
+    color: var(--text-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .legend { flex: 1; }
+  .legend-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border-light);
+  }
+  .legend-row:last-child { border-bottom: none; }
+  .legend-left {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .legend-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .legend-name { font-size: 14px; color: var(--text); font-weight: 400; }
+  .legend-right {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .legend-amount { font-size: 14px; font-weight: 600; color: var(--text); font-variant-numeric: tabular-nums; }
+  .legend-pct { font-size: 12px; color: var(--text-tertiary); }
+
+  /* ---- PROJECTION ---- */
+  .scenarios {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 24px;
+  }
+  .scenario-btn {
+    padding: 7px 16px;
+    border-radius: 100px;
+    border: 1px solid var(--border);
+    background: var(--white);
+    color: var(--text-secondary);
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+    letter-spacing: -0.1px;
+  }
+  .scenario-btn:hover {
+    border-color: var(--blue);
+    color: var(--blue);
+  }
+  .scenario-btn.active {
+    background: var(--blue);
+    border-color: var(--blue);
+    color: white;
+  }
+  .chart-wrap { height: 280px; }
+
+  /* ---- MILESTONES ---- */
+  .milestones { display: flex; flex-direction: column; gap: 16px; }
+  .milestone {
+    padding: 16px 18px;
+    background: var(--bg);
+    border-radius: var(--radius-sm);
+  }
+  .ms-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+  }
+  .ms-name { font-size: 14px; font-weight: 600; color: var(--text); }
+  .ms-eta {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    background: var(--white);
+    padding: 3px 10px;
+    border-radius: 100px;
+    border: 1px solid var(--border-light);
+  }
+  .ms-bar-bg {
+    height: 5px;
+    background: var(--border-light);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+  .ms-bar {
+    height: 100%;
+    border-radius: 3px;
+    transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  .ms-bar.green { background: var(--green); }
+  .ms-bar.blue { background: var(--blue); }
+  .ms-bar.orange { background: var(--orange); }
+  .ms-bar.purple { background: var(--purple); }
+  .ms-amounts {
+    display: flex;
+    justify-content: space-between;
+    font-size: 12px;
+    color: var(--text-tertiary);
+    margin-top: 6px;
+  }
+
+  /* ---- BENCHMARKS ---- */
+  .benchmark { margin-bottom: 20px; }
+  .benchmark:last-child { margin-bottom: 0; }
+  .bm-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 8px;
+  }
+  .bm-name { font-size: 14px; font-weight: 500; color: var(--text); }
+  .bm-vals { font-size: 12px; color: var(--text-tertiary); font-variant-numeric: tabular-nums; }
+  .bm-track {
+    height: 6px;
+    background: var(--border-light);
+    border-radius: 3px;
+    position: relative;
+    overflow: visible;
+  }
+  .bm-fill {
+    height: 100%;
+    border-radius: 3px;
+    transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  .bm-guide {
+    position: absolute;
+    top: -5px;
+    width: 2px;
+    height: 16px;
+    background: var(--text-tertiary);
+    border-radius: 1px;
+    opacity: 0.5;
+  }
+  .bm-guide-label {
+    position: absolute;
+    top: 14px;
+    font-size: 10px;
+    color: var(--text-tertiary);
+    transform: translateX(-50%);
+    white-space: nowrap;
+  }
+  .bm-status {
+    display: inline-block;
+    margin-top: 6px;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 10px;
+    border-radius: 100px;
+  }
+  .bm-status.good { color: var(--green); background: var(--green-bg); }
+  .bm-status.warn { color: var(--orange); background: var(--orange-bg); }
+  .bm-status.over { color: var(--pink); background: var(--pink-bg); }
+
+  /* ---- RESPONSIVE ---- */
+  @media (max-width: 900px) {
+    .stats { grid-template-columns: repeat(2, 1fr); }
+    .grid { grid-template-columns: 1fr; }
+    .donut-layout { flex-direction: column; }
+  }
+  @media (max-width: 600px) {
+    .stats { grid-template-columns: 1fr; }
+    .header h1 { font-size: 36px; }
+    .app { padding: 24px 16px 60px; }
+  }
+
+  /* ---- ANIMATIONS ---- */
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(12px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  .anim { animation: fadeIn 0.45s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; opacity: 0; }
+  .d1 { animation-delay: 0.04s; }
+  .d2 { animation-delay: 0.08s; }
+  .d3 { animation-delay: 0.12s; }
+  .d4 { animation-delay: 0.16s; }
+  .d5 { animation-delay: 0.2s; }
+  .d6 { animation-delay: 0.24s; }
+  .d7 { animation-delay: 0.28s; }
+  .d8 { animation-delay: 0.32s; }
+
+  /* ---- FOOTER ---- */
+  .footer {
+    text-align: center;
+    margin-top: 32px;
+    font-size: 12px;
+    color: var(--text-tertiary);
+    letter-spacing: -0.1px;
+  }
+</style>
+</head>
+<body>
+
+<div class="app">
+
+  <div class="header anim d1">
+    <div class="header-row">
+      <div>
+        <h1>Finances</h1>
+        <p>Drag the sliders to explore what's possible.</p>
+      </div>
+      <span class="date-pill" id="date-pill">March 2026</span>
+    </div>
+  </div>
+
+  <!-- Stats -->
+  <div class="stats">
+    <div class="stat anim d1">
+      <div class="stat-icon green">↑</div>
+      <div class="stat-label">Income</div>
+      <div class="stat-value green" id="s-income">$10,000</div>
+      <div class="stat-sub">monthly, after tax</div>
+    </div>
+    <div class="stat anim d2">
+      <div class="stat-icon pink">↓</div>
+      <div class="stat-label">Expenses</div>
+      <div class="stat-value pink" id="s-expenses">$3,300</div>
+      <div class="stat-sub" id="s-expenses-sub">33% of income</div>
+    </div>
+    <div class="stat anim d3">
+      <div class="stat-icon blue">◎</div>
+      <div class="stat-label">Saved</div>
+      <div class="stat-value blue" id="s-savings">$6,700</div>
+      <div class="stat-sub" id="s-savings-sub">67% of income</div>
+    </div>
+    <div class="stat anim d4">
+      <div class="stat-icon orange">%</div>
+      <div class="stat-label">Savings Rate</div>
+      <div class="stat-value orange" id="s-rate">67%</div>
+      <div class="stat-sub">target: 20%+</div>
+    </div>
+  </div>
+
+  <div class="grid">
+
+    <!-- Sliders -->
+    <div class="card anim d5">
+      <div class="card-title">Adjust Your Budget</div>
+
+      <div class="slider-group">
+        <div class="slider-header">
+          <span class="slider-name">Monthly Income</span>
+          <span class="slider-val" id="v-income">$10,000</span>
+        </div>
+        <input type="range" id="r-income" min="2000" max="30000" step="250" value="10000">
+        <div class="slider-range"><span>$2,000</span><span>$30,000</span></div>
+      </div>
+      <div class="slider-group">
+        <div class="slider-header">
+          <span class="slider-name">Rent</span>
+          <span class="slider-val" id="v-rent">$2,500</span>
+        </div>
+        <input type="range" id="r-rent" min="0" max="5000" step="50" value="2500">
+        <div class="slider-range"><span>$0</span><span>$5,000</span></div>
+      </div>
+      <div class="slider-group">
+        <div class="slider-header">
+          <span class="slider-name">Groceries</span>
+          <span class="slider-val" id="v-groceries">$500</span>
+        </div>
+        <input type="range" id="r-groceries" min="100" max="1500" step="25" value="500">
+        <div class="slider-range"><span>$100</span><span>$1,500</span></div>
+      </div>
+      <div class="slider-group">
+        <div class="slider-header">
+          <span class="slider-name">Gas</span>
+          <span class="slider-val" id="v-gas">$150</span>
+        </div>
+        <input type="range" id="r-gas" min="0" max="500" step="10" value="150">
+        <div class="slider-range"><span>$0</span><span>$500</span></div>
+      </div>
+      <div class="slider-group">
+        <div class="slider-header">
+          <span class="slider-name">Extra / Misc</span>
+          <span class="slider-val" id="v-extra">$150</span>
+        </div>
+        <input type="range" id="r-extra" min="0" max="1000" step="25" value="150">
+        <div class="slider-range"><span>$0</span><span>$1,000</span></div>
+      </div>
+
+      <div class="insight" id="insight">
+        <div class="insight-label">Insight</div>
+        <p id="insight-text"></p>
+      </div>
+    </div>
+
+    <!-- Donut -->
+    <div class="card anim d6">
+      <div class="card-title">Where Your Money Goes</div>
+      <div class="donut-layout">
+        <div class="donut-wrap">
+          <canvas id="donutChart"></canvas>
+          <div class="donut-center">
+            <div class="donut-center-value" id="donut-center-val">67%</div>
+            <div class="donut-center-label">saved</div>
+          </div>
+        </div>
+        <div class="legend" id="legend"></div>
+      </div>
+    </div>
+
+    <!-- Projection -->
+    <div class="card grid-full anim d7">
+      <div class="card-title">12-Month Projection</div>
+      <div class="scenarios">
+        <button class="scenario-btn active" data-s="current" onclick="setScenario('current')">Just Saving</button>
+        <button class="scenario-btn" data-s="hys" onclick="setScenario('hys')">High-Yield Savings (4.5%)</button>
+        <button class="scenario-btn" data-s="invest" onclick="setScenario('invest')">Invested (7%)</button>
+      </div>
+      <div class="chart-wrap"><canvas id="projChart"></canvas></div>
+    </div>
+
+    <!-- Milestones -->
+    <div class="card anim d7">
+      <div class="card-title">Milestones</div>
+      <div class="milestones" id="milestones"></div>
+    </div>
+
+    <!-- Benchmarks -->
+    <div class="card anim d8">
+      <div class="card-title">How You Compare</div>
+      <div id="benchmarks"></div>
+    </div>
+  </div>
+
+  <div class="footer">This is a planning tool, not financial advice. Consult a professional for investment decisions.</div>
+</div>
+
+<script>
+const $ = id => document.getElementById(id);
+const fmt = n => '$' + n.toLocaleString('en-US');
+const pct = (n,d) => d > 0 ? Math.round(n/d*100) : 0;
+
+let S = { income:10000, rent:2500, groceries:500, gas:150, extra:150, scenario:'current' };
+
+// Colors — Apple-esque palette
+const colors = {
+  rent: '#ff2d55',
+  groceries: '#ff9500',
+  gas: '#5ac8fa',
+  extra: '#af52de',
+  savings: '#34c759'
+};
+
+let donut, proj;
+
+function initCharts() {
+  donut = new Chart($('donutChart').getContext('2d'), {
+    type: 'doughnut',
+    data: {
+      labels: ['Rent','Groceries','Gas','Extra','Savings'],
+      datasets: [{ data: [2500,500,150,150,6700], backgroundColor: Object.values(colors), borderWidth: 0, hoverOffset: 6 }]
+    },
+    options: {
+      cutout: '72%',
+      responsive: true,
+      maintainAspectRatio: true,
+      animation: { duration: 500, easing: 'easeOutQuart' },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: '#1d1d1f',
+          titleFont: { family: 'Instrument Sans', weight: 500 },
+          bodyFont: { family: 'Instrument Sans' },
+          cornerRadius: 10,
+          padding: 12,
+          callbacks: { label: c => ` ${fmt(c.raw)} (${pct(c.raw,S.income)}%)` }
+        }
+      }
+    }
+  });
+
+  proj = new Chart($('projChart').getContext('2d'), {
+    type: 'line',
+    data: {
+      labels: ['Now','Mo 1','Mo 2','Mo 3','Mo 4','Mo 5','Mo 6','Mo 7','Mo 8','Mo 9','Mo 10','Mo 11','Mo 12'],
+      datasets: [{
+        label: 'Total Saved',
+        data: [],
+        borderColor: '#007aff',
+        backgroundColor: 'rgba(0,122,255,0.06)',
+        borderWidth: 2.5,
+        fill: true,
+        tension: 0.35,
+        pointRadius: 3,
+        pointHoverRadius: 6,
+        pointBackgroundColor: '#007aff',
+        pointBorderColor: '#fff',
+        pointBorderWidth: 2
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: { duration: 500, easing: 'easeOutQuart' },
+      interaction: { mode: 'index', intersect: false },
+      scales: {
+        x: {
+          grid: { color: '#f0f0f5', drawBorder: false },
+          ticks: { color: '#aeaeb2', font: { family: 'Instrument Sans', size: 11 } }
+        },
+        y: {
+          grid: { color: '#f0f0f5', drawBorder: false },
+          ticks: {
+            color: '#aeaeb2',
+            font: { family: 'Instrument Sans', size: 11 },
+            callback: v => v >= 1000 ? '$' + (v/1000).toFixed(0) + 'k' : '$' + v
+          }
+        }
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: '#1d1d1f',
+          titleFont: { family: 'Instrument Sans', weight: 500 },
+          bodyFont: { family: 'Instrument Sans' },
+          cornerRadius: 10,
+          padding: 12,
+          callbacks: { label: c => ` ${fmt(Math.round(c.raw))}` }
+        }
+      }
+    }
+  });
+}
+
+function update() {
+  const { income, rent, groceries, gas, extra, scenario } = S;
+  const exp = rent + groceries + gas + extra;
+  const sav = Math.max(0, income - exp);
+  const rate = pct(sav, income);
+
+  // Stats
+  $('s-income').textContent = fmt(income);
+  $('s-expenses').textContent = fmt(exp);
+  $('s-expenses-sub').textContent = pct(exp,income) + '% of income';
+  $('s-savings').textContent = fmt(sav);
+  $('s-savings-sub').textContent = rate + '% of income';
+  $('s-rate').textContent = rate + '%';
+
+  // Slider displays
+  $('v-income').textContent = fmt(income);
+  $('v-rent').textContent = fmt(rent);
+  $('v-groceries').textContent = fmt(groceries);
+  $('v-gas').textContent = fmt(gas);
+  $('v-extra').textContent = fmt(extra);
+
+  // Donut
+  donut.data.datasets[0].data = [rent, groceries, gas, extra, sav];
+  donut.update('none');
+  $('donut-center-val').textContent = rate + '%';
+
+  // Legend
+  const items = [
+    { name:'Rent', val:rent, c:colors.rent },
+    { name:'Groceries', val:groceries, c:colors.groceries },
+    { name:'Gas', val:gas, c:colors.gas },
+    { name:'Extra', val:extra, c:colors.extra },
+    { name:'Savings', val:sav, c:colors.savings },
+  ];
+  $('legend').innerHTML = items.map(i => `
+    <div class="legend-row">
+      <div class="legend-left"><div class="legend-dot" style="background:${i.c}"></div><span class="legend-name">${i.name}</span></div>
+      <div class="legend-right"><span class="legend-amount">${fmt(i.val)}</span><span class="legend-pct">${pct(i.val,income)}%</span></div>
+    </div>
+  `).join('');
+
+  // Projection
+  const r = scenario === 'invest' ? 0.07/12 : scenario === 'hys' ? 0.045/12 : 0;
+  const d = [0];
+  for(let i=1;i<=12;i++) d.push(d[i-1]*(1+r)+sav);
+  proj.data.datasets[0].data = d;
+
+  const clr = scenario === 'invest' ? '#34c759' : scenario === 'hys' ? '#ff9500' : '#007aff';
+  const bg = scenario === 'invest' ? 'rgba(52,199,89,0.06)' : scenario === 'hys' ? 'rgba(255,149,0,0.06)' : 'rgba(0,122,255,0.06)';
+  proj.data.datasets[0].borderColor = clr;
+  proj.data.datasets[0].backgroundColor = bg;
+  proj.data.datasets[0].pointBackgroundColor = clr;
+  proj.update();
+
+  // Milestones
+  const ms = [
+    { name:'Emergency Fund (3 mo)', target: exp*3, c:'green' },
+    { name:'Emergency Fund (6 mo)', target: exp*6, c:'blue' },
+    { name:'$100K Saved', target: 100000, c:'orange' },
+    { name:'$250K Saved', target: 250000, c:'purple' },
+  ];
+  $('milestones').innerHTML = ms.map(m => {
+    const mo = sav > 0 ? Math.ceil(m.target / sav) : Infinity;
+    const eta = mo < Infinity ? (mo >= 12 ? Math.floor(mo/12)+'y '+(mo%12)+'m' : mo+'m') : '—';
+    const pctDone = sav > 0 ? Math.min(100, (sav/m.target)*100) : 0;
+    return `
+      <div class="milestone">
+        <div class="ms-top">
+          <span class="ms-name">${m.name}</span>
+          <span class="ms-eta">${mo < Infinity ? eta : 'Not reachable'}</span>
+        </div>
+        <div class="ms-bar-bg"><div class="ms-bar ${m.c}" style="width:${pctDone}%"></div></div>
+        <div class="ms-amounts"><span>${fmt(Math.min(sav, m.target))} / mo</span><span>${fmt(m.target)} goal</span></div>
+      </div>
+    `;
+  }).join('');
+
+  // Benchmarks
+  const bms = [
+    { name:'Housing', yours: pct(rent,income), guide:30, label:'30%' },
+    { name:'Food', yours: pct(groceries,income), guide:15, label:'15%' },
+    { name:'Savings', yours: rate, guide:20, label:'20%', invert:true },
+    { name:'Wants', yours: pct(extra,income), guide:30, label:'30%' },
+  ];
+  $('benchmarks').innerHTML = bms.map(b => {
+    const mx = Math.max(b.yours, b.guide, 40);
+    const bw = (b.yours/mx)*100;
+    const gp = (b.guide/mx)*100;
+    let cls, txt;
+    if(b.invert) {
+      cls = b.yours >= b.guide ? 'good' : b.yours >= b.guide*0.5 ? 'warn' : 'over';
+      txt = b.yours >= b.guide ? 'Excellent' : b.yours >= b.guide*0.5 ? 'Okay' : 'Low';
+    } else {
+      cls = b.yours <= b.guide ? 'good' : b.yours <= b.guide*1.2 ? 'warn' : 'over';
+      txt = b.yours <= b.guide ? 'On track' : b.yours <= b.guide*1.2 ? 'Slightly over' : 'Over';
+    }
+    const fc = cls==='good' ? 'var(--green)' : cls==='warn' ? 'var(--orange)' : 'var(--pink)';
+    return `
+      <div class="benchmark">
+        <div class="bm-header"><span class="bm-name">${b.name}</span><span class="bm-vals">${b.yours}% · guideline ${b.label}</span></div>
+        <div class="bm-track">
+          <div class="bm-fill" style="width:${bw}%;background:${fc}"></div>
+          <div class="bm-guide" style="left:${gp}%"><span class="bm-guide-label">${b.label}</span></div>
+        </div>
+        <span class="bm-status ${cls}">${txt}</span>
+      </div>
+    `;
+  }).join('');
+
+  // Insight
+  const yr = sav * 12;
+  let msg;
+  if(sav <= 0) {
+    msg = `You're spending <strong>${fmt(Math.abs(sav))}</strong> more than you earn each month. Reduce rent or extras to get back on track.`;
+  } else if(rate >= 50) {
+    msg = `You're putting away <strong>${fmt(sav)}/month</strong> — that's <strong>${fmt(yr)}</strong> in a year from saving alone. A ${rate}% savings rate is exceptional.`;
+  } else if(rate >= 20) {
+    msg = `<strong>${fmt(sav)}/month</strong> saved (${rate}%). That's <strong>${fmt(yr)}</strong> a year. You're above the 20% guideline — well done.`;
+  } else {
+    msg = `You're saving <strong>${fmt(sav)}/month</strong> (${rate}%). The 20% guideline would be <strong>${fmt(Math.round(income*0.2))}</strong>. Small cuts add up fast.`;
+  }
+  $('insight-text').innerHTML = msg;
+}
+
+function setScenario(s) {
+  S.scenario = s;
+  document.querySelectorAll('.scenario-btn').forEach(b => b.classList.toggle('active', b.dataset.s === s));
+  update();
+}
+
+function wire() {
+  const map = { 'r-income':'income', 'r-rent':'rent', 'r-groceries':'groceries', 'r-gas':'gas', 'r-extra':'extra' };
+  Object.entries(map).forEach(([id,key]) => {
+    $(id).addEventListener('input', () => { S[key] = parseInt($(id).value); update(); });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => { initCharts(); wire(); update(); });
+</script>
+
+</body>
+</html>

--- a/modules/apps/cli/claude-code/config/skills/contract-reviewer/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/contract-reviewer/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: contract-reviewer
+description: Review any contract and flag what matters before you sign. Use this skill when the user says "review this contract", "should I sign this", "check this agreement", "contract review", "what does this contract say", "flag anything bad", "review my lease", "NDA review", "freelance contract", or pastes a contract, agreement, terms, or legal document they need reviewed before signing.
+---
+
+# Contract Reviewer
+
+You review contracts, agreements, and legal documents. You explain what everything means in plain English, flag anything the user should worry about, and give a clear recommendation on whether to sign.
+
+## Input
+
+Accept any of these:
+- Pasted contract text
+- A PDF or document file in the folder
+- A screenshot of a contract
+- A URL to terms of service or agreement
+- The user describing a deal and asking what the contract should include
+
+## Process
+
+Read the entire document, then analyze it in this order:
+1. What is this agreement about?
+2. What are the key terms?
+3. What are the red flags?
+4. What's missing that should be there?
+5. Should they sign it?
+
+## Output Format
+
+```
+# Contract Review — [Document Title or Type]
+
+**Type:** [Employment agreement / Freelance contract / NDA / Lease / SaaS terms / etc.]
+**Between:** [Party A] and [Party B]
+**Date:** [If listed]
+
+---
+
+## The Short Version
+
+[3-4 sentences. What this contract does, who it favors, and the one thing the user absolutely needs to know before signing.]
+
+## Key Terms
+
+| Term | What It Says | What It Means |
+|------|-------------|---------------|
+| Duration | [Contract language] | [Plain English] |
+| Payment | [Contract language] | [Plain English] |
+| Termination | [Contract language] | [Plain English] |
+| Liability | [Contract language] | [Plain English] |
+| IP / Ownership | [Contract language] | [Plain English] |
+
+## Red Flags
+
+[For each red flag, use this format:]
+
+### 🔴 [Red Flag Title]
+
+**The clause:** "[Exact quote from the contract]"
+
+**Why this is a problem:** [Plain English explanation of why this hurts the user]
+
+**What to ask for instead:** [Specific alternative language or change to request]
+
+[Repeat for each red flag. If there are no red flags, say "No major red flags found." and explain why the contract looks fair.]
+
+## Yellow Flags
+
+[Things that aren't dealbreakers but worth being aware of:]
+
+- ⚠️ **[Issue]** — [Why it matters and what to watch for]
+- ⚠️ **[Issue]** — [Why it matters and what to watch for]
+
+## What's Missing
+
+[Important clauses or protections that SHOULD be in this type of contract but aren't:]
+
+- **[Missing item]** — [Why it matters. Example: "No termination clause means you could be locked in indefinitely."]
+- **[Missing item]** — [Why it matters]
+
+## The Bottom Line
+
+**Should you sign this?** [Yes / Yes with changes / No]
+
+[2-3 sentences explaining the recommendation. Be direct. If they should negotiate, tell them exactly what to push back on. If they should walk away, say so clearly.]
+
+## If You Negotiate, Say This
+
+[Give the user 1-3 specific scripts they can copy-paste or say to the other party:]
+
+1. **About [red flag]:** "I'd like to adjust [clause]. Can we change it to [specific alternative]? That way we're both protected."
+
+2. **About [red flag]:** "[Script]"
+```
+
+## Special Contract Types
+
+### Freelance / Contractor Agreements
+Always check for:
+- Payment terms and timeline (net 15, 30, 60?)
+- Kill fee (what happens if they cancel the project?)
+- IP ownership (do you keep your portfolio rights?)
+- Scope creep protection (how are additional requests handled?)
+- Non-compete clauses (are they reasonable in scope and duration?)
+
+### NDAs
+Always check for:
+- Duration (forever is a red flag)
+- Definition of "confidential information" (too broad?)
+- Mutual vs. one-way (is only one party protected?)
+- Carve-outs (can you still discuss publicly available info?)
+
+### Employment Contracts
+Always check for:
+- Non-compete (duration, geography, scope)
+- IP assignment (do they own everything you create, even on your own time?)
+- At-will vs. fixed term
+- Benefits and equity vesting schedule
+- Severance terms
+
+### Leases
+Always check for:
+- Early termination penalty
+- Rent increase caps
+- Maintenance responsibility
+- Subletting rights
+- Security deposit return terms
+
+### SaaS / Terms of Service
+Always check for:
+- Data ownership and portability
+- Price increase notice requirements
+- Auto-renewal and cancellation process
+- Service level guarantees
+- Limitation of liability
+
+## Rules
+
+- Always explain legal terms in plain English. If you use a legal term, immediately define it.
+- Be direct about red flags. Don't soften bad clauses to be polite. If something is one-sided, say so.
+- Always note which party the contract favors. Most contracts favor whoever drafted them.
+- Give specific, actionable negotiation scripts. Not "you should negotiate this" but "say this exact thing."
+- Include the disclaimer: "This is not legal advice. For high-stakes contracts (employment, large deals, partnerships), consult a lawyer. This review helps you understand what you're signing and know what questions to ask."
+- If a contract is genuinely fair and balanced, say so. Don't manufacture problems that aren't there.
+- Flag auto-renewal clauses every single time. They are the #1 thing people miss and regret.

--- a/modules/apps/cli/claude-code/config/skills/difficult-conversation-prep/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/difficult-conversation-prep/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: difficult-conversation-prep
+description: Prepare for tough conversations with a script, talking points, and responses to likely pushback. Use this skill when the user says "difficult conversation", "tough conversation", "hard talk", "how do I tell them", "I need to have a conversation about", "prep me for a confrontation", "how to bring up", "negotiate", or any variation of needing to have an uncomfortable or high-stakes conversation.
+---
+
+# Difficult Conversation Prep
+
+Prepare for any tough conversation with a clear game plan. Get opening lines, talking points, responses to likely pushback, and a framework so you walk in confident instead of anxious.
+
+## Instructions
+
+### Step 1: Understand the Situation
+
+From the user's request, identify:
+
+- **Who is the conversation with?** — Boss, client, partner, employee, friend, landlord, etc.
+- **What is it about?** — Raise, firing, boundary, complaint, breakup, disagreement, feedback, etc.
+- **What's the goal?** — What outcome does the user want?
+- **What's the relationship?** — Power dynamic, history, how the other person typically reacts
+- **What makes it hard?** — Why haven't they had this conversation yet?
+- **Any constraints?** — Timing, witnesses, HR involvement, legal considerations?
+
+### Step 2: Build the Prep Guide
+
+```markdown
+# Conversation Prep: [Brief Description]
+
+**With:** [Who]
+**About:** [What]
+**Your Goal:** [Desired outcome]
+**Their Likely Goal:** [What they probably want from this conversation]
+
+---
+
+## Before You Start
+
+**Mindset:** [1-2 sentences on the right mental frame. Not "be confident" but specific reframing: "This is not a confrontation. This is you advocating for something you've earned."]
+
+**Timing:** [When and where to have this conversation. Not over text. Not on a Friday at 5pm. Specific advice.]
+
+**What NOT to do:** [1-2 common mistakes people make in this type of conversation]
+
+---
+
+## The Opening
+
+[Write 2-3 opening line options. These are the hardest part. Give them exact words they can use.]
+
+**Option 1 (Direct):**
+"[Exact opening line — gets right to it]"
+
+**Option 2 (Softer):**
+"[Opening that sets context first, then gets to the point]"
+
+**Option 3 (Question-Led):**
+"[Opens with a question that leads naturally to the topic]"
+
+---
+
+## Key Points to Make
+
+[3-5 bullet points. Each one is a specific thing they need to communicate. Written as talking points, not a script — they need to sound like themselves.]
+
+1. **[Point]** — [How to say it naturally. Example phrasing.]
+2. **[Point]** — [Phrasing]
+3. **[Point]** — [Phrasing]
+
+---
+
+## Likely Pushback & How to Respond
+
+### If they say: "[Likely objection 1]"
+**Respond with:** "[Specific response — calm, firm, redirects to your point]"
+
+### If they say: "[Likely objection 2]"
+**Respond with:** "[Response]"
+
+### If they say: "[Likely objection 3]"
+**Respond with:** "[Response]"
+
+### If they get emotional or defensive:
+**Respond with:** "[De-escalation language — acknowledge their feelings without abandoning your position]"
+
+### If they shut down or refuse to engage:
+**Respond with:** "[How to keep the door open without forcing it]"
+
+---
+
+## Your Non-Negotiables
+
+Before going in, be clear with yourself:
+
+- **Must have:** [The minimum acceptable outcome]
+- **Ideal outcome:** [The best case]
+- **Walk-away point:** [When do you end the conversation or escalate?]
+
+---
+
+## How to Close
+
+[2-3 options for ending the conversation well, regardless of outcome]
+
+- **If it goes well:** "[Closing that locks in the agreement and next steps]"
+- **If it's unresolved:** "[Closing that keeps the door open: 'I'd like to revisit this on [day]. Can we both think about it?']"
+- **If it goes badly:** "[Closing that protects the relationship while maintaining your position]"
+```
+
+### Step 3: Writing Rules
+
+- **Give exact words, not advice.** "Be assertive" is useless. "Try saying: 'I need to talk about my compensation. Based on [X], I'm requesting [Y].'" is useful.
+- **Anticipate 3-5 responses.** The user will freeze if they hear something unexpected. Prep them for the most likely reactions.
+- **Match the relationship.** Talking to your boss is different from talking to your partner. Adjust formality, framing, and power dynamics.
+- **Never be manipulative.** The goal is honest, direct communication. No tricks, guilt trips, or ultimatums unless the situation genuinely calls for firm boundaries.
+- **Acknowledge emotions.** These conversations are hard because feelings are involved. Don't pretend otherwise.
+
+### Step 4: Save and Deliver
+
+Save as: `Conversation Prep - [Brief Topic].md`
+
+Offer: "Want me to role-play this conversation with you so you can practice? I'll play [the other person] and push back realistically."
+
+## Rules
+
+- This is about preparation, not manipulation. Frame everything as honest communication.
+- Always include the "Non-Negotiables" section. People lose track of their goals in the heat of the moment.
+- Never assume the worst about the other person. Prep for pushback, but don't frame them as the villain.
+- The role-play offer at the end is important. Encourage it. Practice makes these conversations dramatically easier.

--- a/modules/apps/cli/claude-code/config/skills/email-drafter/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/email-drafter/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: email-drafter
+description: Write a polished, ready-to-send professional email for any situation — outreach, follow-ups, negotiations, updates, apologies. Use this skill when the user says "draft an email", "write an email", "help me reply to", "email to", "compose an email", or asks for help wording a message to send.
+---
+
+# Email Drafter
+
+Write a professional, ready-to-send email for any situation. Give it the context — who you're writing to, what about, and what tone — and get a polished email you can copy-paste or tweak.
+
+## Instructions
+
+### Step 1: Understand the Situation
+
+From the user's request, identify:
+
+- **Recipient** — Who is this going to? (client, boss, prospect, vendor, team, stranger)
+- **Purpose** — What's the goal? (introduce yourself, follow up, negotiate, update, ask for something, say no)
+- **Tone** — Formal, professional-casual, friendly, firm, apologetic, enthusiastic?
+- **Key points** — What MUST be communicated?
+- **Relationship context** — First contact? Ongoing relationship? Responding to something?
+
+If the user's request is clear enough, write the email immediately. Only ask clarifying questions if critical information is missing (like who it's going to or what it's about).
+
+Check CLAUDE.md for the user's name, role, and communication style if available.
+
+### Step 2: Write the Email
+
+**Structure:**
+
+```
+Subject: [Clear, specific subject line — not generic]
+
+[Greeting — match the relationship: "Hi Sarah," / "Dear Mr. Chen," / "Hey team,"]
+
+[Opening line — context or connection. Never start with "I hope this email finds you well." Instead, reference something specific: their recent work, a shared connection, or get straight to the point.]
+
+[Body — 2-4 short paragraphs max. One idea per paragraph. Lead with the most important thing.]
+
+[Clear ask or next step — what do you want them to DO after reading this?]
+
+[Sign-off — match the tone: "Best," / "Thanks," / "Looking forward to hearing from you,"]
+[User's name]
+```
+
+### Step 3: Email Type Templates
+
+Use the right structure based on the email type:
+
+| Type | Key Elements |
+|------|-------------|
+| **Cold outreach** | Lead with value/relevance, not yourself. Why should they care? One clear CTA. |
+| **Follow-up** | Reference the previous interaction. Add new value, don't just "check in." |
+| **Negotiation** | State your position clearly. Use "I'd like to propose" not "I was wondering if maybe." |
+| **Update/status** | Lead with the headline. Details below. End with next steps. |
+| **Saying no** | Be direct and kind. Give a brief reason. Offer an alternative if possible. |
+| **Introduction** | Who you are (1 sentence), why you're reaching out (1 sentence), what you're asking (1 sentence). |
+| **Thank you** | Be specific about what you're thanking them for. Don't be generic. |
+| **Apology** | Acknowledge what happened, take responsibility, state what you're doing about it. No excuses. |
+| **Request** | State the ask upfront. Explain why briefly. Make it easy for them to say yes. |
+
+### Step 4: Quality Rules
+
+| Rule | Why |
+|------|-----|
+| Subject line must be specific | "Q1 Budget Proposal — Review by Friday" not "Following up" |
+| First sentence must earn the second | If the opening is boring, they stop reading |
+| Max 5 sentences per paragraph | Walls of text don't get read |
+| One clear call to action | Don't make them guess what you want |
+| No filler phrases | Cut "I just wanted to," "I was wondering if," "I hope this finds you well" |
+| Match their energy | If they wrote 3 sentences, don't write 3 paragraphs |
+| Proofread tone | Read it as the recipient. Does it sound pushy? Passive? Unclear? |
+
+### Step 5: Present Options
+
+Show the email and offer:
+- "Want me to make it shorter / longer / more formal / more casual?"
+- "Want a second version with a different angle?"
+- "Should I draft a follow-up to send if they don't respond in [X] days?"
+
+## Output
+
+A complete, ready-to-send email with subject line. Clean text the user can copy directly into their email client.

--- a/modules/apps/cli/claude-code/config/skills/explainer-graphic/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/explainer-graphic/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: explainer-graphic
+description: Create a visual infographic that explains a concept using a real-world analogy, then produce a detailed visual brief. Use this skill when the user says "explainer graphic", "make an infographic", "explain this visually", "create a graphic", or wants a complex topic turned into a shareable visual.
+---
+
+# Explainer Graphic
+
+Create stunning infographics that explain complex topics using real-world analogies anyone can understand. The secret sauce: find the killer analogy FIRST, then build the visual around it.
+
+## How It Works
+
+When you say "explain this visually" or "make an infographic about [topic]", this skill finds the perfect analogy, maps every piece, then writes a detailed visual brief you can build or hand to a designer.
+
+## Step 1: Find the Killer Analogy
+
+The analogy makes or breaks the graphic. Search these categories for the best fit:
+
+| Category | Example Analogies | Best For |
+|----------|-------------------|----------|
+| **Everyday Life** | Kitchen, closet, mailbox, filing cabinet, remote control | Organization, storage, interfaces |
+| **Jobs and Roles** | Receptionist, translator, librarian, bouncer, air traffic controller | Routing, filtering, managing |
+| **Construction** | Blueprint, foundation, scaffolding, plumbing, wiring | Architecture, infrastructure |
+| **Cooking** | Recipe, ingredients, oven, blender, mise en place | Processes, combining inputs |
+| **Sports** | Playbook, coach, referee, training camp, relay race | Strategy, teamwork, handoffs |
+| **Gaming** | Skill tree, inventory, quest log, respawn, power-ups | Progression, upgrades, systems |
+| **Nature** | Root system, beehive, food chain, ecosystem, seasons | Networks, hierarchies, cycles |
+| **Pop Culture** | Swiss army knife, Netflix queue, GPS navigation | Multi-tool, curated content, routing |
+
+### Analogy Selection Criteria
+
+- Does it click in under 3 seconds?
+- Would a 10-year-old get it?
+- Does it map to at least 3 parts of the concept?
+- Is it fresh? (Avoid "it's like a brain" for AI topics)
+
+## Step 2: Map the Analogy
+
+Fill out this framework for your chosen analogy:
+
+| Real Concept | Analogy Equivalent | Visual Element | Connection |
+|-------------|-------------------|----------------|------------|
+| [Part 1 of concept] | [Analogy part] | [What to draw] | [Why this mapping works] |
+| [Part 2 of concept] | [Analogy part] | [What to draw] | [Why this mapping works] |
+| [Part 3 of concept] | [Analogy part] | [What to draw] | [Why this mapping works] |
+| [Part 4 of concept] | [Analogy part] | [What to draw] | [Why this mapping works] |
+
+Every part of the concept MUST map to something in the analogy. If a piece does not map cleanly, the analogy is wrong. Go back and pick a better one.
+
+## Step 3: Choose a Layout
+
+Pick the layout that best matches your concept type:
+
+| Layout | Structure | Best For |
+|--------|-----------|----------|
+| **Split Panel** | Two halves side by side | Comparisons, before/after, real vs analogy |
+| **Circular Flow** | Elements in a circle with arrows | Cycles, feedback loops, recurring processes |
+| **Stacked Steps** | Vertical stack, top to bottom | Sequential processes, hierarchies, funnels |
+| **Comparison Grid** | 2x2 or 3x3 grid of cards | Feature comparisons, category breakdowns |
+| **Before/After** | Left side old way, right side new way | Transformations, upgrades, improvements |
+| **Pyramid** | Layers building up from base | Foundation concepts, priority levels |
+| **Hub and Spoke** | Central element with branches | One-to-many relationships, ecosystems |
+| **Timeline** | Left to right progression | Evolution, history, step-by-step |
+
+## Step 4: Write the Visual Brief
+
+Produce a complete brief with ALL of the following:
+
+### Graphic Title
+One punchy line (8 words max). Example: "API Keys Are Just VIP Wristbands"
+
+### Dimensions
+Specify target size: social post (1080x1080), infographic (1080x1920), slide (1920x1080), or blog (800x1200).
+
+### Color Palette
+Background, primary, accent, text, and secondary text -- all with hex codes.
+
+### Layout Description
+Exact placement of each element and size relative to canvas.
+
+### Sections
+For each section of the graphic:
+- **Label:** What the section is called
+- **Analogy visual:** What to draw (be specific -- "a kitchen counter with three bowls" not "cooking stuff")
+- **Real meaning:** What it represents in the actual concept
+- **Text overlay:** 1-2 lines max explaining the connection
+- **Icon or emoji:** A supporting visual element
+
+### Connection Lines
+Describe how sections connect:
+- Arrow style (solid, dashed, curved, dotted)
+- Arrow color
+- Label on arrow (if any)
+- Direction of flow
+
+### Key Insight Callout
+One highlighted box or banner with the main takeaway. This is the single most important sentence on the entire graphic. Style it differently from everything else (bigger, bolder, different color, bordered).
+
+## Rules
+
+- Every analogy must be universal -- no niche references only some people know
+- Max 50 words of text on the entire graphic (less is better)
+- Every section needs a visual element, not just text
+- The graphic should make sense even without reading the text (visuals carry the story)
+- One concept per graphic. If the topic is too big, split into multiple graphics
+
+## Example Usage
+
+- "Explain how APIs work visually"
+- "Create a graphic explaining how AI skills work"
+- "Explain this visually: how a neural network learns"
+
+## Tips for Best Results
+
+- If the first analogy feels forced, try a different category
+- Simpler analogies always beat clever ones

--- a/modules/apps/cli/claude-code/config/skills/invoice-generator/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/invoice-generator/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: invoice-generator
+description: Generate a professional PDF invoice from a few details. Use this skill when the user says "create an invoice", "invoice this client", "bill them", "send an invoice", "generate invoice", "make an invoice for", or any variation of wanting to bill someone for work done.
+---
+
+# Invoice Generator
+
+Create a clean, professional invoice as a PDF from a few simple inputs. No templates needed, no software to install. Just tell it who to bill, what for, and how much.
+
+## Instructions
+
+### Step 1: Gather Invoice Details
+
+From the user's request, identify:
+
+- **Client name** — Who is being billed?
+- **Client email or address** — Optional but include if provided
+- **Your business name** — Pull from CLAUDE.md if available
+- **Invoice number** — Auto-generate if not provided (format: INV-YYYY-001)
+- **Date** — Today's date unless specified
+- **Due date** — Default to Net 30 unless specified
+- **Line items** — What services or products are being billed?
+- **Amounts** — Price per item or flat rate
+- **Tax rate** — Only include if the user mentions tax
+- **Payment instructions** — Bank details, PayPal, Venmo, etc. Pull from CLAUDE.md or ask.
+
+If you have enough to build the invoice, build it. Only ask if you're missing the client name or the amounts.
+
+### Step 2: Calculate Totals
+
+For each line item:
+- Quantity x Rate = Line Total
+
+Then:
+- Subtotal = Sum of all line totals
+- Tax = Subtotal x Tax Rate (if applicable)
+- **Total Due** = Subtotal + Tax
+
+Double-check your math. Invoices with wrong totals destroy credibility.
+
+### Step 3: Build the Invoice
+
+Use clean, professional formatting:
+
+```
+[Your Business Name]
+[Your Address / Contact — if available]
+
+INVOICE
+
+Invoice #: [Number]
+Date: [Issue Date]
+Due: [Due Date]
+Bill To: [Client Name / Company]
+
+---
+
+| Description              | Qty | Rate     | Amount   |
+|--------------------------|-----|----------|----------|
+| [Service/Product]        | [X] | $[X.XX]  | $[X.XX]  |
+| [Service/Product]        | [X] | $[X.XX]  | $[X.XX]  |
+
+---
+
+                                    Subtotal: $[X.XX]
+                                    Tax (X%): $[X.XX]
+                                    TOTAL DUE: $[X.XX]
+
+Payment Terms: [Net 30 / Due on Receipt / etc.]
+Payment Method: [Bank transfer / PayPal / Venmo / etc.]
+
+[Payment details if provided]
+
+Thank you for your business.
+```
+
+### Step 4: Generate the PDF
+
+Use Python with reportlab or fpdf to generate a properly formatted PDF invoice. Save it to the user's workspace folder.
+
+Name the file: `Invoice-[ClientName]-[Number].pdf`
+
+### Step 5: Deliver
+
+Provide the file link and a one-line summary:
+- Invoice total
+- Due date
+- Client name
+
+Offer: "Want me to adjust anything, add notes, or create a recurring template for this client?"
+
+## Rules
+
+- Always double-check math. Subtotals and totals must be correct.
+- Keep it clean and professional. No decorative clutter.
+- Use the user's business name and details from CLAUDE.md when available.
+- Default to USD unless the user specifies another currency.
+- Never fabricate payment details. If you don't have them, leave a placeholder.

--- a/modules/apps/cli/claude-code/config/skills/learning-path-generator/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/learning-path-generator/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: learning-path-generator
+description: Create a structured learning plan for any skill or topic. Use this skill when the user says "learn", "how do I learn", "learning path", "study plan", "teach me", "roadmap for learning", "curriculum for", "I want to learn", or any variation of wanting a structured plan to learn something new.
+---
+
+# Learning Path Generator
+
+Create a structured, week-by-week learning plan for any skill or topic. No more "I'll figure it out as I go." Get a clear roadmap from beginner to competent with specific resources, milestones, and practice projects.
+
+## Instructions
+
+### Step 1: Understand the Goal
+
+From the user's request, identify:
+
+- **What they want to learn** — Be specific. "Python" is different from "Python for data analysis."
+- **Current level** — Complete beginner, some exposure, intermediate looking to level up?
+- **Available time** — Hours per week they can dedicate
+- **Learning style** — Videos, reading, hands-on projects, courses?
+- **Goal** — What does "learned" look like? Get a job? Build a project? Pass an exam? Just understand it?
+- **Timeline** — Any deadline?
+
+If the topic is clear, start building. Ask one question max if you need to narrow the scope.
+
+### Step 2: Research the Best Path
+
+Use WebSearch to find:
+
+- The most recommended learning resources for this topic (courses, books, tutorials)
+- Common beginner mistakes and plateaus
+- The skill tree (what to learn first, what depends on what)
+- Real practice projects at different levels
+
+### Step 3: Build the Learning Path
+
+Structure it in phases:
+
+```markdown
+# Learning Path: [Skill/Topic]
+
+**Goal:** [What they'll be able to do when finished]
+**Time Commitment:** [X hours/week]
+**Total Duration:** [X weeks]
+**Starting Level:** [Beginner / Intermediate / etc.]
+
+---
+
+## Phase 1: Foundation ([Weeks X-X])
+
+**Goal:** [What you'll know/be able to do after this phase]
+
+### Week [X]: [Topic]
+- **Learn:** [Specific concept or module]
+- **Resource:** [Specific course, chapter, tutorial, or video with link if possible]
+- **Practice:** [Hands-on exercise or mini-project]
+- **Milestone:** [How to know you've got it]
+
+### Week [X]: [Topic]
+- **Learn:** [Concept]
+- **Resource:** [Resource]
+- **Practice:** [Exercise]
+- **Milestone:** [Checkpoint]
+
+---
+
+## Phase 2: Building Skills ([Weeks X-X])
+
+**Goal:** [What this phase achieves]
+
+[Same weekly structure...]
+
+**Phase Project:** [A real project that uses everything from this phase]
+
+---
+
+## Phase 3: Applied Practice ([Weeks X-X])
+
+**Goal:** [What this phase achieves]
+
+[Same weekly structure...]
+
+**Phase Project:** [A more complex project]
+
+---
+
+## Phase 4: Advanced / Specialization ([Weeks X-X])
+
+[Only include if the user's goal requires it]
+
+---
+
+## Resources Summary
+
+| Resource | Type | Cost | Phase |
+|----------|------|------|-------|
+| [Resource 1] | [Course/Book/Tutorial] | [Free/$X] | Phase 1 |
+| [Resource 2] | [Type] | [Cost] | Phase 2 |
+
+## Common Pitfalls
+
+- [Mistake 1 — what it is and how to avoid it]
+- [Mistake 2]
+- [Mistake 3]
+
+## How to Know You're Ready
+
+[2-3 concrete indicators that the user has achieved their learning goal. Not vague "you'll feel confident" but specific: "You can build X without looking anything up" or "You can explain Y to someone else."]
+```
+
+### Step 4: Writing Rules
+
+- **Be specific with resources.** Not "watch YouTube videos." Instead: "[Course Name] by [Creator] on [Platform]." Verify these exist.
+- **Milestones must be testable.** The user should know definitively whether they've hit each checkpoint.
+- **Practice projects should be real.** Not "build a to-do app" unless that actually exercises the right skills. Projects should be things the user would actually want to build or use.
+- **Pace matters.** Don't cram 40 hours of content into a "1 week" block. Be honest about how long things take.
+- **Front-load wins.** The first week should produce a visible result so the user stays motivated.
+
+### Step 5: Save and Deliver
+
+Save as: `Learning Path - [Topic].md`
+
+Offer: "Want me to go deeper on any phase, find alternative resources, or create a daily schedule that fits your calendar?"
+
+## Rules
+
+- Always verify that recommended resources still exist and are current. Don't recommend a 2018 course for a field that changed completely in 2024.
+- Free resources first, paid only when they're significantly better.
+- Never overestimate pace. Most people overcommit and then quit. Build in buffer weeks.
+- Include at least one project per phase. Learning without building is forgetting.

--- a/modules/apps/cli/claude-code/config/skills/morning-briefing/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/morning-briefing/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: morning-briefing
+description: Run a daily scan of the user's niche/industry and surface the top content opportunities, scored and ranked with urgency levels. Use this skill when the user says "morning briefing", "daily briefing", "what should I film today", "start my day", or asks for a rundown of what's happening in their space today.
+---
+
+# Morning Briefing
+
+A daily industry scan that surfaces the top content opportunities in your niche, scored and ranked with urgency levels so you know exactly what to film today.
+
+## Instructions
+
+### Step 1: Identify the User's Niche
+
+Check CLAUDE.md for the user's niche, audience, and content focus. If CLAUDE.md exists and contains this information, use it and move on.
+
+If no niche is defined, ask exactly one question:
+> "What niche or industry should I scan? (e.g., AI tools, fitness, cooking, personal finance, SaaS)"
+
+Do not proceed until you have a clear niche.
+
+### Step 2: Research Current Landscape
+
+Use WebSearch to investigate the following areas within the user's niche. Run at least 4-5 searches across these categories:
+
+1. **Breaking news** — Product launches, major updates, company announcements from the last 24-48 hours
+2. **Trending discussions** — What people are talking about on social media, Reddit, forums, and YouTube right now
+3. **Competitor activity** — What are top creators in this niche posting about today? What is getting engagement?
+4. **Search trends** — What are people actively searching for? Any spikes in interest?
+5. **Upcoming events** — Launches, conferences, deadlines, or seasonal moments in the next 7 days
+
+Take notes on every finding. You need at least 8-10 raw findings before scoring.
+
+### Step 3: Score Each Finding
+
+Rate every finding across these 6 criteria:
+
+| Criteria | Scale | What It Measures |
+|---|---|---|
+| Buzz | 1-5 | How much attention is this getting right now? |
+| Audience Fit | 1-5 | How relevant is this to the user's specific audience? |
+| Timeliness | 1-3 | How time-sensitive is this? (3 = today only, 1 = evergreen) |
+| Content Gap | 1-3 | Are other creators already covering this well? (3 = nobody has, 1 = saturated) |
+| Visual Potential | 1-3 | Can this be shown on screen in a compelling way? |
+| Accessible | 1-3 | Can the user realistically make this video today? (3 = easy, 1 = needs equipment/access) |
+
+**Maximum score: 22 points**
+
+Discard any finding that scores below 12. Only surface findings that score 12 or higher.
+
+### Step 4: Build the Briefing
+
+Present the briefing in this exact format:
+
+```
+# Morning Briefing — [Date]
+**Niche:** [User's niche]
+**Sources scanned:** [Number] across news, social, search trends, competitors
+
+---
+
+## Top 3 Opportunities
+
+### 1. [Topic Title]
+**Score:** XX/22 | **Urgency:** [emoji]
+**What happened:** [2-3 sentence summary of the news/trend]
+**Why it matters for your audience:** [1 sentence connecting it to their viewers]
+**Hook idea:** "[A ready-to-use opening line]"
+**Content angle:** [How to frame the video — tutorial, reaction, explainer, etc.]
+
+### 2. [Topic Title]
+**Score:** XX/22 | **Urgency:** [emoji]
+**What happened:** [2-3 sentence summary]
+**Why it matters for your audience:** [1 sentence]
+**Hook idea:** "[Opening line]"
+**Content angle:** [How to frame it]
+
+### 3. [Topic Title]
+**Score:** XX/22 | **Urgency:** [emoji]
+**What happened:** [2-3 sentence summary]
+**Why it matters for your audience:** [1 sentence]
+**Hook idea:** "[Opening line]"
+**Content angle:** [How to frame it]
+```
+
+**Urgency levels:**
+- 🔴 **Film today** — This is time-sensitive. Waiting even 24 hours means you miss the wave.
+- 🟡 **Film this week** — Trending but has a longer window. 3-5 days before it cools off.
+- 🟢 **Evergreen opportunity** — Not time-sensitive but high potential. Queue it up.
+
+### Step 5: Quick Hits Section
+
+Below the top 3, include a "Quick Hits" section with 3-5 smaller findings that did not make the top 3 but are still worth knowing about. One line each.
+
+```
+## Quick Hits
+- [Brief finding 1 — what it is and why it is notable]
+- [Brief finding 2]
+- [Brief finding 3]
+- [Brief finding 4]
+```
+
+### Step 6: Recommendation
+
+End with a clear, opinionated recommendation:
+
+```
+## My Recommendation
+[1-2 sentences telling the user exactly what to film first and why. Be direct. Do not hedge.]
+```
+
+### Step 7: Offer Next Steps
+
+After delivering the briefing, ask:
+> "Want me to write a full script for any of these, generate hook variations, or dig deeper into a specific topic?"
+
+## Rules
+
+- Always include today's date in the briefing header.
+- Be opinionated. Do not present options neutrally. Tell the user what YOU think they should do.
+- Verify facts. Do not guess about product launches or features. If a search result is ambiguous, note the uncertainty.
+- Do not pad the briefing. If only 2 topics score above 12, present 2. Never include filler.
+- The hook ideas should be ready to use on camera. Written at a 5th grade reading level. Short and punchy.

--- a/modules/apps/cli/claude-code/config/skills/quick-research/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/quick-research/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: quick-research
+description: Research any topic across multiple sources and deliver a clean, sourced summary report. Use this skill when the user says "research this", "look into", "dig into", "what's the deal with", "find out about", "investigate", "give me a breakdown of", "what do you know about", or asks for a comparison or deep dive on a topic.
+---
+
+# Quick Research
+
+You are a research assistant. When the user asks you to research a topic, follow these steps exactly.
+
+## Step 1: Understand the Scope
+
+Figure out what the user actually needs:
+- **Quick answer** — "What's the deal with [thing]?" = 2-3 paragraph summary
+- **Comparison** — "Should I use X or Y?" = side-by-side analysis
+- **Deep dive** — "Dig into [topic]" = full report with sources
+
+Default to a medium-depth report unless they say otherwise.
+
+## Step 2: Research from Multiple Sources
+
+Use web search to find information from:
+- Official product/company websites
+- Recent news articles and announcements
+- User reviews and community discussion
+- Pricing pages
+- Competitor comparisons
+
+Get at least 3-5 different sources. Cross-reference claims.
+
+## Step 3: Build the Report
+
+```
+RESEARCH REPORT: [Topic]
+━━━━━━━━━━━━━━━━━━━━━━━
+
+SUMMARY
+[2-3 sentences — what this is and why it matters]
+
+KEY FINDINGS
+- [Finding 1 — backed by source]
+- [Finding 2 — backed by source]
+- [Finding 3 — backed by source]
+- [Finding 4 — backed by source]
+
+PRICING
+[Free tier? Paid plans? What do you get?]
+
+PROS
+- [Strength 1]
+- [Strength 2]
+
+CONS
+- [Weakness 1]
+- [Weakness 2]
+
+BOTTOM LINE
+[One paragraph — honest take. Is this worth using? Who is it for? Who should skip it?]
+
+SOURCES
+- [Source 1 title and URL]
+- [Source 2 title and URL]
+- [Source 3 title and URL]
+```
+
+## Rules
+
+- Always include sources. Never present unverified claims as fact.
+- If something is unclear or conflicting, say so. "Sources disagree on this" is better than guessing.
+- Be honest. If a product sucks, say it sucks. The user trusts you for real takes, not marketing fluff.
+- Keep it scannable. Headers, bullets, short paragraphs.
+- If the user asks about a competitor or tool, check if it's actually still active. Don't recommend dead products.

--- a/modules/apps/cli/claude-code/config/skills/receipt-scanner/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/receipt-scanner/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: receipt-scanner
+description: Read PDF receipts and invoices, extract vendor/date/amount/category, and build an expense report. Use this skill when the user says "scan my receipts", "build an expense report", "how much did I spend", "process these receipts", "expense report", "read my invoices", or points to a folder of receipts.
+---
+
+# Receipt Scanner
+
+You are an expense tracking assistant. When the user asks you to scan receipts or build an expense report, follow these steps exactly.
+
+## Step 1: Find the Receipts
+
+Look for PDF files in the user's project or the folder they point you to. Common locations:
+- A "receipts" folder in the project
+- Files the user drags into the conversation
+- Google Drive folder they reference
+
+## Step 2: Extract Data from Each Receipt
+
+For every receipt or invoice, pull:
+- **Date** of purchase/invoice
+- **Vendor** name
+- **Amount** (including currency)
+- **Category** — auto-categorize into: Software, Travel, Meals, Office Supplies, Equipment, Services, Other
+- **Payment method** if visible (credit card last 4, PayPal, etc.)
+
+## Step 3: Build the Report
+
+Create a clean expense report:
+
+```
+EXPENSE REPORT
+━━━━━━━━━━━━━━
+Period: [earliest date] to [latest date]
+Total: $X,XXX.XX
+
+BY CATEGORY
+Software:        $XXX.XX  (X receipts)
+Travel:          $XXX.XX  (X receipts)
+Meals:           $XXX.XX  (X receipts)
+Office Supplies: $XXX.XX  (X receipts)
+Services:        $XXX.XX  (X receipts)
+
+ITEMIZED LIST
+Date       | Vendor            | Category  | Amount
+-----------|-------------------|-----------|--------
+2026-03-01 | Adobe             | Software  | $54.99
+2026-03-02 | Delta Airlines    | Travel    | $342.00
+...
+
+NOTES
+- [flag any receipts that were hard to read]
+- [flag any unusually large charges]
+```
+
+## Step 4: Export Options
+
+Ask: "Want me to save this as a CSV spreadsheet, or keep it as a text report?"
+
+If CSV, create a proper .csv file with headers: Date, Vendor, Category, Amount, Payment Method, Notes.
+
+## Rules
+
+- If a receipt is blurry or hard to read, flag it and give your best guess with a note.
+- Always double-check math. The category totals must add up to the grand total.
+- If the user mentions tax categories or a specific format their accountant needs, adjust accordingly.
+- Sort the itemized list by date, oldest first.

--- a/modules/apps/cli/claude-code/config/skills/slide-deck-builder/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/slide-deck-builder/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: slide-deck-builder
+description: Generate a self-contained HTML slide deck with rich visual components — no PowerPoint or Google Slides needed. Use this skill when the user says "make a slide deck", "create slides", "build a presentation", "generate slides", or asks for a visual presentation on a topic.
+---
+
+# Slide Deck Builder
+
+Generate beautiful, self-contained HTML slide decks with rich visual components. No PowerPoint, no Google Slides, no dependencies. Just open the HTML file in a browser and present.
+
+## How It Works
+
+When you say "make a slide deck about [topic]" or "create slides for [presentation]", this skill builds a complete HTML file with fullscreen slides, keyboard navigation, and polished visual components.
+
+## Slide Structure
+
+Every deck follows this proven flow:
+
+| Slide | Purpose | Content |
+|-------|---------|---------|
+| **1. Title** | Set the stage | Big title, subtitle, your name or brand |
+| **2. Setup** | Frame the problem or context | Why this matters, what the audience will learn |
+| **3-8. Core Content** | Deliver the meat | One idea per slide, each with a visual component |
+| **9. Evidence** | Prove your point | Stats, quotes, case studies, examples |
+| **10. Takeaway** | Land the message | Summary, call to action, next steps |
+
+Adjust the number of core content slides based on topic complexity. Simple topics: 5-7 total slides. Complex topics: 10-15 slides. Never exceed 15 slides.
+
+## Visual Components
+
+Every single slide MUST have a visual component. Text-only slides are not allowed. Choose from:
+
+### Card Grid
+2-4 cards in a row, each with an icon/emoji, title, and one-line description. Use for: features, benefits, categories.
+
+### Comparison Panel
+Two columns side by side with a vs divider. Use for: old vs new, tool A vs tool B, before vs after.
+
+### Stat Callout
+One huge number or percentage with a short label below. Use for: impressive data points, growth numbers, costs.
+
+### Step Flow
+Horizontal or vertical numbered steps with arrows between them. Use for: processes, tutorials, how-it-works.
+
+### Quote Block
+Large quotation marks, italic text, attribution below. Use for: testimonials, expert quotes, key statements.
+
+### Icon + Label List
+Vertical list with emoji or icons on the left, labels on the right. Use for: feature lists, agendas, checklists.
+
+### Code Block
+Monospace text on a dark card with syntax-style coloring. Use for: code examples, command line, config files.
+
+### Timeline
+Horizontal line with dots and labels above and below. Use for: history, roadmap, project phases.
+
+### Image + Caption
+Centered image placeholder with a caption below. Use for: screenshots, diagrams, product photos.
+
+### Metric Dashboard
+3-4 stat boxes in a row, each with a label and value. Use for: KPIs, performance data, comparisons.
+
+## HTML Output
+
+Generate a single self-contained HTML file. No external fonts, CDN links, or images. Everything inline.
+
+**Layout:** Fullscreen slides (100vw x 100vh), content centered, max-width 900px, 60px padding.
+
+**Colors:** Background `#0a0a0a`, text `#ffffff`, secondary `#a0a0a0`, cards `#1a1a1a`, borders `#2a2a2a`, plus one accent color per deck.
+
+**Typography:** Headings bold sans-serif 48-64px, body 24-28px, stat numbers 72-96px in accent color, code monospace 18px.
+
+**Navigation:** Arrow keys to move slides, counter in bottom-right, smooth transitions, optional click-to-advance.
+
+## Content Rules
+
+1. **One idea per slide.** If you have two points, make two slides
+2. **Max 30 words per slide.** Slides are visual aids, not documents
+3. **Every slide has a visual component.** No exceptions. See the list above
+4. **Consistent accent color.** Pick one accent and use it for all highlights, buttons, and emphasis
+5. **No bullet point dumps.** If you need bullets, use an Icon + Label List component instead
+6. **Big text beats small text.** When in doubt, make it bigger
+7. **Whitespace is your friend.** Crowded slides lose the audience
+
+## Accent Color Selection
+
+Pick an accent color based on the topic:
+
+| Topic Area | Suggested Accent | Hex |
+|-----------|-----------------|-----|
+| AI / Tech | Electric blue | `#3B82F6` |
+| Business | Warm amber | `#F59E0B` |
+| Design | Coral pink | `#F43F5E` |
+| Finance | Emerald green | `#10B981` |
+| Health | Soft teal | `#14B8A6` |
+| Education | Royal purple | `#8B5CF6` |
+| Marketing | Vibrant orange | `#F97316` |
+| General | Clean white accent on dark | `#E5E5E5` |
+
+## Example Usage
+
+- "Make a slide deck about how AI agents work"
+- "Create slides for my team meeting on Q1 results"
+- "Build a presentation explaining our new product"
+- "Generate slides for a 5-minute talk on prompt engineering"
+
+## Tips for Best Results
+
+- Tell the skill how many slides you want and it will adjust density
+- Mention your audience so the content level is calibrated
+- Share your brand color and it becomes the accent
+- Ask for speaker notes if you want talking points alongside each slide
+- The HTML file works offline -- no internet needed to present

--- a/modules/apps/cli/claude-code/config/skills/visual-page-builder/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/visual-page-builder/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: visual-page-builder
+description: Generate a polished, self-contained HTML page that explains any concept visually using stat cards, flow diagrams, comparison grids, and other components. Use this skill when the user says "visual explanation", "explain this visually", "make a visual page", "build an HTML explainer", or wants a concept turned into a single shareable page.
+---
+
+# Visual Page Builder
+
+Generate a polished, self-contained HTML page that explains any concept using visual components. No frameworks, no dependencies, no build step. One file that looks like a real product page.
+
+## Page Types
+
+| Type | Best for | Key components |
+|------|----------|---------------|
+| **Architecture Overview** | Systems, tech stacks, infrastructure | Flow diagram, connection lines, component cards |
+| **Comparison Table** | Tool vs tool, plan vs plan, before vs after | Side-by-side grids, checkmarks, highlight winner |
+| **Process Flow** | Tutorials, onboarding, how-to guides | Numbered steps, arrows, status indicators |
+| **Timeline** | Roadmaps, project history, changelogs | Vertical timeline, date markers, milestone cards |
+| **Dashboard** | Metrics, KPIs, performance summaries | Stat cards, bar charts, progress rings |
+| **Concept Explainer** | Abstract ideas, frameworks, mental models | Analogy visuals, layered diagrams, callout boxes |
+| **Project Recap** | End-of-project summaries, case studies | Before/after, stats, testimonial cards, gallery |
+
+Ask the user which type fits their content, or auto-detect from their description.
+
+## Workflow
+
+### Step 1: Gather Content
+
+Ask the user for:
+- **Title** of the page
+- **3-6 sections** they want to cover (or let you suggest based on the topic)
+- **Key data points** (numbers, stats, comparisons)
+- **Relationships** between concepts (what connects to what)
+- **Hierarchy** (what is most important, what is supporting detail)
+
+If the user provides a document, transcript, or notes, extract these elements automatically and confirm.
+
+### Step 2: Plan the Layout
+
+Map each section to a visual component (see Visual Components below). Present the plan:
+
+```
+Section 1: "What is X" -> Concept card with icon + 3 key points
+Section 2: "How it works" -> 4-step process flow with arrows
+Section 3: "Performance" -> Stat cards (3 across) + comparison grid
+Section 4: "Get started" -> Callout box with CTA
+```
+
+Get user approval before building.
+
+### Step 3: Build the HTML
+
+Generate a single self-contained HTML file.
+
+**Design System:**
+
+| Token | Value |
+|-------|-------|
+| Background | `#0f0f10` |
+| Surface | `#1a1a1d` |
+| Surface border | `#2a2a2d` |
+| Text primary | `#ffffff` |
+| Text secondary | `#a0a0a0` |
+| Accent | `#D97757` (or user-chosen) |
+| Accent muted | `rgba(217, 119, 87, 0.15)` |
+| Font | Inter via Google Fonts, fallback `system-ui, sans-serif` |
+| Max width | `1000px` |
+| Card radius | `12px` |
+| Section spacing | `80px` vertical |
+
+**Visual Components Available:**
+
+| Component | When to use | Structure |
+|-----------|-------------|-----------|
+| **Stat cards** | Key numbers | Horizontal row, large number + label + optional trend arrow |
+| **Section cards** | Feature lists, grouped info | Grid of cards with icon/emoji, title, description |
+| **Comparison grid** | Side-by-side analysis | 2-3 columns, rows with checkmarks or values |
+| **Flow steps** | Sequential processes | Numbered circles connected by lines, title + description |
+| **Status badges** | Tags, categories, states | Colored pill badges (green/yellow/red/blue) |
+| **Code blocks** | Technical content, configs | Dark bg, monospace font, syntax-highlighted if applicable |
+| **Callout boxes** | Important notes, warnings, tips | Accent left border, icon, highlighted background |
+| **Progress bars** | Completion, capacity, scores | Horizontal bar with fill percentage and label |
+| **Tables** | Structured data, specs | Striped rows, sticky header, responsive scroll |
+| **Timelines** | Chronological events | Vertical line with dots, alternating left/right cards |
+| **Quote blocks** | Testimonials, key statements | Large quotation mark, italic text, attribution |
+| **Icon grids** | Feature overviews, tool lists | 2-3 column grid with emoji + title + one-line desc |
+
+### Step 4: Save and Preview
+
+Save the file as `[topic-slug]-visual.html` in the current working directory.
+
+Open in the default browser:
+```bash
+xdg-open [topic-slug]-visual.html 2>/dev/null || echo "Saved to $(pwd)/[topic-slug]-visual.html"
+```
+
+### Step 5: Iterate
+
+Ask: "How does it look? I can adjust colors, swap components, add sections, or change any text."
+
+Common tweaks:
+- Change accent color
+- Add or remove sections
+- Swap a component type (e.g., table to comparison grid)
+- Adjust text content
+- Add a logo or header image (base64 inline)
+
+## Rules
+
+- **Every section needs a visual component.** No section should be just a wall of text. If there is no obvious visual, use a callout box or icon grid.
+- **Max 50 words before a visual.** Introductory text for a section must be short. Let the visual do the heavy lifting.
+- **All CSS and JS inline.** Zero external dependencies. The file must work when double-clicked from the desktop with no server.
+- **Zero external fetches required.** Google Fonts is the one allowed exception (with system font fallback). Everything else is inline.
+- **Responsive.** Must look good on mobile (stack grids to single column, scale stat cards, scrollable tables).
+- **No JavaScript required for content.** JS is only for optional enhancements (smooth scroll, fade-in animations). The page must be fully readable with JS disabled.
+- **Consistent spacing.** Use the design system tokens. Do not eyeball padding or margins.
+- **Dark theme only.** Do not offer a light mode. The dark palette is part of the brand.
+- **Accessible.** Sufficient color contrast (WCAG AA minimum), semantic HTML, alt text on images.
+- Keep the total file under 500KB. If inlining images, compress them first.
+- The page title should appear in the browser tab (title tag).

--- a/modules/apps/cli/claude-code/config/skills/workflow-visualizer/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/workflow-visualizer/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: workflow-visualizer
+description: Map any system or workflow as an interactive HTML diagram with clickable nodes, hover details, and data-flow arrows. Use this skill when the user says "visualize this workflow", "map out this system", "diagram my workflow", "show how this works", or describes a multi-step process/pipeline they want diagrammed.
+---
+
+# Workflow Visualizer
+
+Turn any system description into a beautiful, interactive HTML diagram. Click nodes, hover for details, and see exactly how data flows through your workflow. One self-contained HTML file, no dependencies.
+
+## How It Works
+
+When you say "visualize this workflow" or "map out this system", this skill parses your description, identifies every component, and builds an interactive diagram you can open in any browser.
+
+## Step 1: Parse the System
+
+Extract these components from the user's description:
+
+| Component | What to Look For | Example |
+|-----------|-----------------|---------|
+| **Triggers** | What starts the workflow | "When a new email arrives", "Every morning at 9am" |
+| **Inputs** | Data that enters the system | "Email body", "CSV file", "API response" |
+| **Processing Steps** | Actions that transform data | "Extract key info", "Summarize text", "Filter results" |
+| **Tools / Services** | External tools or APIs used | "Claude", "Zapier", "Google Sheets", "Slack" |
+| **Decision Points** | Conditional branches | "If priority is high", "When amount > $100" |
+| **Outputs** | Final results or deliverables | "Send Slack message", "Update spreadsheet", "Generate report" |
+| **Loops** | Recurring or repeating steps | "Repeat for each item", "Run daily" |
+| **Data Stores** | Where data lives between steps | "Database", "JSON file", "Spreadsheet" |
+
+If the user's description is vague, ask clarifying questions before building.
+
+## Step 2: Choose a Layout
+
+Select the layout that best fits the workflow shape:
+
+| Layout | Structure | Best For |
+|--------|-----------|----------|
+| **Left-to-Right Flow** | Horizontal chain of nodes | Linear processes, pipelines, simple workflows |
+| **Top-Down Waterfall** | Vertical cascade | Sequential steps, decision trees, funnels |
+| **Hub and Spoke** | Central node with radiating connections | One tool that connects to many, API integrations |
+| **Swimlane** | Horizontal lanes per tool/person | Multi-team processes, handoffs between systems |
+| **Circular** | Loop back to start | Recurring workflows, feedback loops, monitoring |
+
+## Step 3: Build the Interactive HTML
+
+Generate a single self-contained HTML file with these features:
+
+### Node Types and Colors
+
+| Node Type | Background | Border | Icon Style |
+|-----------|-----------|--------|------------|
+| **Trigger** | `#1e3a5f` | `#3B82F6` (blue) | Lightning bolt, clock, webhook |
+| **Processing** | `#1a3d2e` | `#10B981` (green) | Gear, wand, filter |
+| **Tool / Service** | `#3d2e1a` | `#F59E0B` (amber) | Tool logo or wrench |
+| **Output** | `#3d1a1a` | `#EF4444` (red) | Check, send, export |
+| **Data Store** | `#1a1a2e` | `#6366F1` (indigo) | Database, folder, file |
+| **Decision** | `#2e1a3d` | `#A855F7` (purple) | Question mark, fork |
+
+### Node Content
+
+Each node displays:
+- **Icon** (emoji or SVG) at the top
+- **Label** (2-4 words, bold)
+- **Subtitle** (one short line describing what happens)
+
+### Connections and Interactivity
+
+**Lines:** Solid with arrowheads, color matches source node border, optional data label, animated dash on highlight.
+
+**Hover:** Node scales 1.05x, border glows, tooltip with step description.
+
+**Click:** Highlights node and direct connections, dims unconnected nodes, click background to reset.
+
+**Responsive:**
+- Diagram scales to fit the viewport
+- Works on desktop and tablet screens
+- Nodes wrap or scroll on very small screens
+
+### Style Defaults
+
+Page bg `#0f0f0f`, container `#161616`, header text `#ffffff`, subtitle `#888888`, node text `#ffffff`, connections `#444444` (colored when highlighted). System sans-serif font, 12px border radius, 20px node padding, 160px min node width.
+
+Include a header (workflow name + description), the diagram container, and a color-coded legend (Blue=Triggers, Green=Processing, Amber=Tools, Red=Outputs, Indigo=Data Stores, Purple=Decisions). All styles and JS inline, no external dependencies.
+
+## Rules
+
+1. **Every node must be a specific action, not a vague label.** "Process data" is bad. "Extract invoice total from PDF" is good
+2. **Connections must show what data flows between nodes.** Not just that they connect, but WHAT passes through
+3. **Decision points need labeled branches.** "Yes" and "No", or the specific conditions
+4. **No floating nodes.** Every node must connect to at least one other node
+5. **Dark background always.** Light mode diagrams wash out and look less professional
+6. **Max 20 nodes per diagram.** If the workflow is bigger, split into sub-diagrams
+7. **Self-contained HTML.** No external CSS, JS, or image dependencies. Must work offline
+
+## Example Usage
+
+- "Visualize this workflow: new lead from website form, added to CRM, sales gets Slack notification"
+- "Map out this system: Claude writes drafts, Grammarly checks, Google Docs for review"
+- "Diagram my workflow: check email, triage urgent vs non-urgent, route to Slack or Notion"
+
+## Tips for Best Results
+
+- Describe your workflow step by step in plain language
+- Mention every tool or service involved by name
+- Include any conditions or branches ("if X then Y, otherwise Z")
+- The more detail you give, the more accurate the diagram will be


### PR DESCRIPTION
## Summary
- Imported 13 of the 15 "Claude Cowork Skills" (from extras/eval/cowork-skills) into modules/apps/cli/claude-code/config/skills/, after a security review and a Claude Code compatibility pass
- Added a 14th skill, `brand-design`, adapted from a Claude Code slash command found via a linked GitHub repo (VicUgochukwu/brand-design-skill) -- converted to SKILL.md format and neutralized the original author's hardcoded name/headshot and unavailable Figma/Canva MCP references
- Security review (both sources): no exfiltration endpoints, no exec/eval patterns, no hidden/zero-width unicode, only CDN references (cdnjs, Google Fonts) baked into generated HTML output, not fetched by the skills themselves
- Compatibility fixes applied to the cowork-skills:
  - 9 skills had thin one-line descriptions with the real trigger phrasing stuffed into a Cowork-only `triggers:` frontmatter key that Claude Code ignores entirely (matching is description-text-only) -- folded that phrasing into `description`
  - Stripped the now-redundant `triggers:` blocks from all 13 files
  - `animated-website` and `visual-page-builder` called macOS-only `open` to launch a preview -- swapped for `xdg-open` with an echo fallback
- Excluded `customize` -- it's 100% Cowork-Desktop UI instructions ("Open Cowork -> Customize -> Skills... Click the three dots") with nothing applicable to the Claude Code CLI
- Left `extras/eval/` in place (untracked) as the source snapshot

## Test plan
- [ ] Rebuild (`just qr` or host rebuild) to deploy the new skills to ~/.claude/skills/
- [ ] Spot-check a couple of skills trigger correctly (e.g. "draft an email to...", "build an expense report", "make a LinkedIn carousel about...")