### PR TITLE
fix(claude-code): correct tableau skill's Account 360 filter mechanism

### DIFF
--- a/modules/apps/cli/claude-code/config/skills/tableau/SKILL.md
+++ b/modules/apps/cli/claude-code/config/skills/tableau/SKILL.md
@@ -94,30 +94,46 @@ same workbook. `references/content-map.md` already tells you which views
 are confirmed to return real data vs. confirmed dashboard shells for the
 Kong 360 and Book of Business workbooks.
 
-**4. A 400 on a specific sheet usually means it needs a filter -- and
-`Account Name` is the confirmed field caption to try first.** Some sheets
-(e.g. `Firmographics` in Kong360 Summary) are driven by a dashboard
-action or parameter and won't render standalone. The `Account 360`
-workbook (see the content map) uses one global filter across all its
-tabs, and `Account Name` is confirmed live -- passing a nonexistent value
-via `viewFilters: {"Account Name": "..."}` returned zero rows instead of
-the default dataset, proving the field was recognized and applied, not
-ignored. Try `Account Name` on any unfamiliar parameter-driven view
-before guessing at other field names. If it doesn't resolve the account
-you need, the underlying doc for Account 360 (see content map) also
-mentions `SFDC Account ID`, `Domain`, and `Konnect Organization ID` as UI
-filter options, though those haven't been independently confirmed against
-the API's exact caption yet.
+**4. A 400 on a specific sheet usually means it needs an account
+identifier -- and for Account 360, that's the `Account ID Parameter`
+Tableau Parameter, not an `Account Name` data filter.** Some sheets (e.g.
+`Firmographics` in Kong360 Summary) are driven by a dashboard action or
+parameter and won't render standalone. The `Account 360` workbook (see
+the content map) uses one global control across all its tabs -- **a
+Tableau Parameter named `Account ID Parameter`, which takes the raw SFDC
+Account ID**, confirmed from a live dashboard URL
+(`?Account%20ID%20Parameter=<id>`) and verified end-to-end against a real
+account (returned data included the account name and a known contact
+verbatim). Pass it the same way as a regular filter --
+`viewFilters: {"Account ID Parameter": "<SFDC Account ID>"}` -- the
+MCP tool doesn't distinguish parameters from filters. **`Account Name`
+does NOT work here** -- every attempt with real name variants or the
+SFDC Account ID under that key returned zero rows; an earlier version of
+this doc claimed otherwise based on a false-positive test (a nonexistent
+value also returned zero, but because the account wasn't in scope under
+that key, not because the field caption was right). If `Account ID
+Parameter` doesn't resolve the account you need, get the live dashboard
+URL from the user or the Tableau UI and read the actual parameter/filter
+name off the query string rather than guessing at more field-name
+variants -- `SFDC Account ID`, `Domain`, and `Konnect Organization ID`
+mentioned in the companion doc as alternative UI filter options are
+unverified via the API and may have the same parameter-vs-filter trap.
 
-**5. Row-level security scopes some content to the querying identity.**
-`Churn_Risk_Score` in Kong360 Churn Risk returned exactly one row with no
-filters applied -- almost certainly the account(s) tied to whoever the
-PAT belongs to, not the full customer base. Assume "Book of Business" and
-similar my-portfolio dashboards behave the same way. Don't be surprised
-if a request to look up a customer *outside* the current user's book
-returns nothing from these particular views -- that's the security model
-working as intended, not a bug. If you need another CSM's book, that's a
-different credential, not a different query.
+**5. Row-level security scopes some content to the querying identity --
+and on Kong360 Churn Risk, it isn't overridable at all.** `Churn_Risk_Score`,
+`Churn_Risk_Attributes`, and `Churn_Risk_Comments` in Kong360 Churn Risk
+return exactly one row -- the account tied to whoever the PAT belongs to
+-- regardless of what you pass as `Account Name`: a real value, a made-up
+nonexistent value, and no filter at all all return byte-identical output.
+Verify this with a nonexistent-value test before trusting a non-empty
+result from these three views as being about the account you asked for.
+Assume "Book of Business" and similar my-portfolio dashboards behave
+similarly (RLS-scoped), though Account 360's `Account ID Parameter` (rule
+4) *does* successfully override the default for a different named
+account -- so RLS-scoping and "filter doesn't work" aren't the same
+failure mode, and it's worth testing which one you're hitting. If you
+need another CSM's book, that's a different credential, not a different
+query.
 
 **6. "No X found" from Pulse tools can mean genuine absence, not an
 error.** `list-all-pulse-metric-definitions` and
@@ -152,9 +168,10 @@ extracted from its URL) rather than a generic web fetch, which will 401.
 - **A specific customer's account health/renewal/consumption/churn/
   contracts/support/PS engagement** -> the **Account 360** workbook
   (`references/content-map.md`) is the primary, actively-maintained
-  source -- start there. It's one workbook, one global filter
-  (`viewFilters: {"Account Name": "<customer>"}`, confirmed working --
-  see rule 4), and one tab per topic (Active Contract, Bookings &
+  source -- start there. It's one workbook, one global control
+  (`viewFilters: {"Account ID Parameter": "<SFDC Account ID>"}`, a
+  Tableau Parameter, confirmed working -- see rule 4; `Account Name`
+  does NOT work), and one tab per topic (Active Contract, Bookings &
   Opportunities, Konnect Subscription, Konnect Plus, Kong Enterprise
   On-Prem, Konnect Capacity Consumption, Account Engagement, Support,
   Customer Health & Risks, Professional Services). Only fall back to the

--- a/modules/apps/cli/claude-code/config/skills/tableau/references/content-map.md
+++ b/modules/apps/cli/claude-code/config/skills/tableau/references/content-map.md
@@ -28,19 +28,34 @@ updated 2024-06-01, file id `1B4xrNs6YOg64KqslNvFbhrplmAbQyQFGZzYOBS01-E4`,
 readable via the Google Drive MCP tools) for every tab except
 `Professional Services`, which was added after the doc's last update.
 
-### Global filter (confirmed working)
+### Global filter (confirmed working -- corrected 2026-07-07)
 
-The whole workbook is driven by one account-level filter, applied via
-`viewFilters` on `get-view-data`. **Confirmed via live test**: passing
-`{"Account Name": "<nonexistent value>"}` to the `Active Contract` view
-returned zero rows instead of the default unfiltered dataset -- proof the
-`Account Name` field caption is exactly right, not a guess. The doc also
-describes `SFDC Account ID`, `Domain`, and `Konnect Organization ID` as
-alternative filter fields in the Tableau UI (use one at a time; the UI
-flow is "Clear Filters" on the others, then "Apply Filters" on the one
-you want) -- these three haven't been independently confirmed against the
-API's exact `viewFilters` caption yet, so try `Account Name` first and
-fall back to the others only if it doesn't resolve the account you need.
+**The real mechanism is a Tableau Parameter called `Account ID Parameter`,
+not a data filter on `Account Name`.** A user-shared dashboard URL exposed
+it directly: `.../ActiveContract?Account%20ID%20Parameter=<SFDC Account ID>`.
+Passed the same way through `viewFilters` on `get-view-data` (the tool
+doesn't distinguish parameters from filters -- both go in the same dict),
+it works correctly: `{"Account ID Parameter": "<SFDC Account ID>"}`
+returns real per-account data, and a nonexistent ID returns zero rows
+(confirmed discriminating, not silently ignored). Verified end-to-end on
+Sony Interactive Entertainment LLC (`0011K000029btLYQAY`) -- the returned
+data included the account name and a known contact (Nirvana Dogra)
+verbatim, proving it's real and not a default/RLS fallback.
+
+**`{"Account Name": "<value>"}` does NOT work on this workbook** despite
+earlier notes claiming it did -- every attempt (real name variants, exact
+SFDC Account ID under that key) returned zero rows. The original "confirmed
+via live test" claim below was a false positive: a nonexistent value also
+returns zero *because the account truly isn't in scope under that key*,
+not because the field caption is right. Use `Account ID Parameter` with
+the raw SFDC Account ID instead. `SFDC Account ID`, `Domain`, and `Konnect
+Organization ID` mentioned in the companion doc as alternative *filter*
+fields are unverified and likely also wrong for the same reason -- they
+may need the same "it's actually a Parameter" treatment. If `Account ID
+Parameter` doesn't resolve an account, get the exact URL from the
+Tableau UI (share/copy link) rather than guessing at more field-name
+variants -- it'll show the true parameter name and value format in the
+query string.
 
 **Without any filter**, every tab returns data already scoped to a single
 account (confirmed on `Active Contract` and `Konnect Subscription`) --
@@ -52,16 +67,16 @@ site (see the main SKILL.md). Don't assume an unfiltered call returns
 
 | Tab | id | What it shows (per the doc) | Live-tested? |
 |---|---|---|---|
-| Active Contract | `62469a27-0042-44e3-930b-fb8ac1049423` | Current active contract value, segment value, product breakdown, and Konnect contract utilization (API requests/Gateway services used vs. contracted) | **Yes** -- returns real daily running-sum consumption vs. contracted volume |
-| Bookings & Opportunities | `3211c9ce-f5ba-4091-955b-156b05045f0e` | Lifetime contract value (TCV), active contract/segment value, visible open pipeline, closed-lost pipeline, closed bookings detail, open pipeline detail | Not yet |
-| Konnect Subscription | `d55db5a6-5274-4514-8b70-457e55de49e8` | 12-month usage trend by feature (API Requests, Gateway Services, Cloud Gateways), MoM breakdown, org details for multi-org accounts | **Yes** -- returns real monthly running-sum usage |
-| Konnect Plus | `ebb18efa-08a1-4504-85d5-617ef9c2bb6b` | Konnect Plus signups, invoices, credit consumption by feature and by month (credits measured in USD), per-org detail | Not yet |
+| Active Contract | `62469a27-0042-44e3-930b-fb8ac1049423` | Current active contract value, segment value, product breakdown, and Konnect contract utilization (API requests/Gateway services used vs. contracted) | **Yes** -- with `Account ID Parameter` set, returns real daily running-sum consumption vs. contracted volume |
+| Bookings & Opportunities | `3211c9ce-f5ba-4091-955b-156b05045f0e` | Lifetime contract value (TCV), active contract/segment value, visible open pipeline, closed-lost pipeline, closed bookings detail, open pipeline detail | **Yes** -- with `Account ID Parameter` set, returns active product ACV, total product ACV, contract start/end dates |
+| Konnect Subscription | `d55db5a6-5274-4514-8b70-457e55de49e8` | 12-month usage trend by feature (API Requests, Gateway Services, Cloud Gateways), MoM breakdown, org details for multi-org accounts | **Yes** -- with `Account ID Parameter` set, returns real monthly running-sum usage |
+| Konnect Plus | `ebb18efa-08a1-4504-85d5-617ef9c2bb6b` | Konnect Plus signups, invoices, credit consumption by feature and by month (credits measured in USD), per-org detail | **Yes** -- with `Account ID Parameter` set, returns per-org rows including account name, org name/id, signup contact, invoice amounts -- good corroboration that the parameter is resolving the right account |
 | Kong Enterprise (On-Prem) | `6e1343eb-9cc0-4188-af93-30cf04b0846e` | On-prem usage -- same data as Gainsight, uploaded by the field team, not live-collected. Includes a "usage last updated" timestamp -- check it before trusting the numbers | Not yet |
-| Konnect Capacity Consumption | `df384fab-9eee-4e54-a505-28af794ebc84` | Capacity purchased vs. used, overage/underage, consumption run rate, days-until-overage, breakdown by product and by month | Not yet |
+| Konnect Capacity Consumption | `df384fab-9eee-4e54-a505-28af794ebc84` | Capacity purchased vs. used, overage/underage, consumption run rate, days-until-overage, breakdown by product and by month | **Tested, empty**: returns zero rows both with `Account ID Parameter` set and unfiltered -- unlike the other tabs, this one doesn't even show a default RLS-scoped row, so it may need a different parameter/filter name, or may just be a dashboard-shell view not exposed as data via the API |
 | Account Engagement | `8dbd7695-c617-4e4d-87c8-d6589fb94625` | Marketing campaign responses, MQLs, web visits, job-level breakdown of engaged contacts, PQL list of active product users | Not yet |
-| Support | `6fed0e82-3d5a-402e-99b7-ac44b28335f3` | Case volume by priority, case-creation timeline, full case detail (links to SFDC case record) | Not yet |
-| Customer Health & Risks | `5cfeda2f-e7a0-41e5-a159-c2d6ec4e2c7a` | Overall health score, CSM sentiment score, renewal likelihood, open renewal opportunities, health-score factor breakdown, CSM renewal sentiment/comments | Not yet -- likely the single richest tab for churn/renewal-risk conversations, check this alongside (or instead of) Kong360 Churn Risk |
-| Professional Services | `cb67dec3-1934-47f5-845b-8e6e08858b6a` | Not in the doc (added 2024-09-30, after the doc's last update) | **Tested, thin result**: unfiltered call returned only 2 columns (`Customer Stage`, `ORIGINAL_CONTRACT_DATE`) and 1 row for this identity's default-scoped account. Either PS content is genuinely sparse for that account, or the richer detail lives in a part of the dashboard this call didn't reach -- re-test against an account known to have active PS engagement before concluding this tab is data-poor. |
+| Support | `6fed0e82-3d5a-402e-99b7-ac44b28335f3` | Case volume by priority, case-creation timeline, full case detail (links to SFDC case record) | **Yes** -- with `Account ID Parameter` set, returns real per-case rows (owner, subject, priority, open/closed, dates) |
+| Customer Health & Risks | `5cfeda2f-e7a0-41e5-a159-c2d6ec4e2c7a` | Overall health score, CSM sentiment score, renewal likelihood, open renewal opportunities, health-score factor breakdown, CSM renewal sentiment/comments | **Tested, thin result**: only returns a `Last Updated Date` column even with `Account ID Parameter` set -- likely a dashboard-type view where `get-view-data` only reaches one sub-object (see rule 3 in the main SKILL.md); the real health-score detail probably needs `get-view-image` or a more specific underlying sheet id not yet found |
+| Professional Services | `cb67dec3-1934-47f5-845b-8e6e08858b6a` | Not in the doc (added 2024-09-30, after the doc's last update) | **Yes** -- with `Account ID Parameter` set, returns `Customer Stage` and `ORIGINAL_CONTRACT_DATE` (2 columns, 1 row) -- thin but real; matches the account's known contract start date, so this tab is just genuinely sparse, not broken |
 
 ## Kong 360 (legacy) -- per-account 360 profile, prior generation
 
@@ -77,7 +92,7 @@ it has no direct equivalent for Marketing Campaigns or Engagement.
 | Kong360 Summary | `b3035d7f-4a7c-451a-b36d-55b2de2bdef9` | Firmographics `f4a50b98-e43d-4eb2-b029-5a37d78c2f46`, Key Contacts `76b6ba40-2cbf-488a-b8f2-68b379cd54e9`, Active Contracts `decf6c23-a522-4588-a6ad-816c02574074` |
 | Kong360 Bookings & Opportunities | `cc4292e4-98cd-42b8-aa87-3c3b936098cb` | not yet probed for individual sheet ids |
 | Kong360 Consumption | `804d0711-fbc1-4082-ae06-f060021f26ae` | only the "Kong360 Shell" dashboard view was found (`5105f743-...`); no separate data sheet located yet -- check the workbook live with `get-workbook` for any tabs added since |
-| Kong360 Churn Risk | `54e0faed-38e1-4861-9d89-b78f59e6a780` | **confirmed working**: `Churn_Risk_Score` `22dcc980-a668-4b15-a6cd-f8faed79bb44` returns real per-account data (see fields below). Also `Churn_Risk_Attributes` `87b7b9e2-f8f8-4aba-80ca-77dad9eb9937`, `Churn_Risk_Comments` `ead788b2-1321-4e65-abf2-34c958b4e1d0` |
+| Kong360 Churn Risk | `54e0faed-38e1-4861-9d89-b78f59e6a780` | Returns real data, but **`Account Name` viewFilters is silently ignored on all three sheets** -- confirmed by passing a nonexistent account name and getting the exact same row back as unfiltered. These sheets only ever show whichever single account is RLS-locked to the querying identity; they cannot be used to look up a different named account. `Churn_Risk_Score` `22dcc980-a668-4b15-a6cd-f8faed79bb44`, `Churn_Risk_Attributes` `87b7b9e2-f8f8-4aba-80ca-77dad9eb9937`, `Churn_Risk_Comments` `ead788b2-1321-4e65-abf2-34c958b4e1d0` (this one's free-text comments name the RLS-locked account explicitly, e.g. contact names/company mentioned in the notes -- a good way to identify which account you're actually looking at) |
 | Kong360 Marketing Campaigns | `21ff5029-864e-4cb5-9a35-0ca7f4bb49c7` | not yet probed |
 | Kong360 Engagement | `88b0cea1-7a30-41d7-ae8e-aae8f291f077` | not yet probed |
 | Kong360 Customer Support | `790ca451-ce75-4434-9c0a-62502199863b` | not yet probed |
@@ -103,9 +118,9 @@ VizQL Data Service is unavailable here, see the main SKILL.md):
 `Firmographics` (`f4a50b98-...`) returned HTTP 400 when queried without
 filters -- it's likely a dashboard-action/parameter-driven sheet that
 needs an account identifier passed via `viewFilters` to render. Account
-360 (above) uses `Account Name` as its confirmed-working filter field
-caption -- try that here first before assuming this workbook uses a
-different field name.
+360's working key is the `Account ID Parameter` Tableau Parameter (see
+the corrected "Global filter" note above), not `Account Name` -- try that
+here first before assuming this workbook uses a different field name.
 
 ## Book of Business -- the CSM's own portfolio
 


### PR DESCRIPTION
## Summary
- Account 360's per-account control is the Tableau Parameter `Account ID Parameter` (raw SFDC Account ID), not an `Account Name` data filter as previously documented
- The prior "confirmed working" note for `Account Name` was a false positive: a nonexistent value also returned zero rows, but because the account wasn't in scope under that key, not because the filter was right
- Verified against a real account via a live dashboard URL and a nonexistent-parameter-value control test
- Documents that Kong360 Churn Risk's three views silently ignore any `Account Name` filter entirely (real value, nonexistent value, and no filter all return identical output)
- Marks several previously-untested Account 360 tabs (Bookings & Opportunities, Konnect Plus, Support, Professional Services) as confirmed working with the corrected parameter

## Test plan
- [ ] Re-run the skill against a known account and confirm `Account ID Parameter` returns correct, account-specific data
- [ ] Confirm Kong360 Churn Risk guidance is followed (don't trust non-empty results there without a nonexistent-value control test)