### PR TITLE
fix(claude-code): fix broken tab delimiter in skills fzf browser

### DIFF
--- a/modules/apps/cli/claude-code/cfg/fish.nix
+++ b/modules/apps/cli/claude-code/cfg/fish.nix
@@ -378,9 +378,9 @@
           set -l meta (${pkgs.yq-go}/bin/yq --front-matter=extract -o=json '.' $f 2>/dev/null)
           test -z "$meta"; and continue
           set -l name (echo $meta | ${pkgs.jq}/bin/jq -r '.name // empty')
-          set -l desc (echo $meta | ${pkgs.jq}/bin/jq -r '.description // empty')
+          set -l desc (echo $meta | ${pkgs.jq}/bin/jq -r '.description // empty' | string join ' ')
           test -z "$name"; and continue
-          set -a rows "$name\t$desc"
+          set -a rows $name\t$desc
         end
         if test -z "$rows"
           echo "No skills found in $dir"


### PR DESCRIPTION
## Summary
- The `skills` fish function (from #140) quoted `"$name\t$desc"` when building fzf rows; fish only expands `\t` as an escape in unquoted text, so it stayed a literal backslash-t and `fzf --delimiter=<tab>` never matched, breaking the `glow` preview (`Error: unable to open file: open /home/dustin/.claude/skill...`).
- Multi-line skill descriptions (block-scalar YAML front matter, e.g. `agentos-init`) additionally broke the unquoted fix on its own: command substitution splits multi-line output into a fish list, so unquoted `$name\t$desc` cartesian-expanded across every line of the description. Joined the description into a single line first.

## Test plan
- [x] `fish -c "type skills"` shows the fixed function is active after rebuild
- [x] Standalone row-construction loop confirms a real tab (`^I` via `cat -A`) and exactly one row per skill, including `agentos-init`'s multi-line description
- [x] `fzf --delimiter=\t --with-nth=1,2 --filter=...` correctly splits fields on the real tab
- [x] `glow ~/.claude/skills/agentos-init/SKILL.md` opens without error