### PR TITLE
feat(render-secrets): materialize homelab-flux-deploy-key on workstations

### DIFF
--- a/modules/apps/cli/render-secrets/render-secrets.sh
+++ b/modules/apps/cli/render-secrets/render-secrets.sh
@@ -59,6 +59,14 @@ MATERIALIZE=(
   "nixerator-git-crypt-key|${HOME}/.ssh/nixerator-git-crypt-key|600|700|${_WS}"
   "talos-vms-git-crypt-key|${HOME}/.ssh/talos-vms-git-crypt-key|600|700|${_WS}"
 
+  # Read-only GitHub deploy key for homelab's Flux CD GitOps sync (any
+  # cluster's FluxInstance points at the same repo URL, so one key covers
+  # all of them). Workstations only: this is what `just bootstrap-flux-
+  # deploy-key` in homelab reads from disk to build each cluster's
+  # flux-system Secret. See homelab's docs/flux-darkstar-adoption.md.
+  "homelab-flux-deploy-key|${HOME}/.ssh/homelab-flux-deploy-key|600|700|${_WS}"
+  "homelab-flux-deploy-key.pub|${HOME}/.ssh/homelab-flux-deploy-key.pub|644|700|${_WS}"
+
   # Incus browser client certificate — public CRT, all Incus hosts.
   # Read by the Nix module via builtins.readFile at eval time to populate
   # the preseed trust store. 644 because it is a public key. Also listed


### PR DESCRIPTION
## Summary
- Adds two `MATERIALIZE` rows for the new `homelab-flux-deploy-key` (read-only GitHub deploy key for homelab's Flux CD GitOps sync) so it's restored to `~/.ssh/` on workstation rebuilds, same pattern as the existing per-repo git-crypt keys.
- Companion 1Password Document items (`homelab-flux-deploy-key` / `homelab-flux-deploy-key.pub`, nixerator vault) need to be created manually — `op document create` isn't runnable from this session (read-only service-account token).

## Test plan
- [ ] `op document create --vault nixerator --title homelab-flux-deploy-key ~/.ssh/homelab-flux-deploy-key`
- [ ] `op document create --vault nixerator --title homelab-flux-deploy-key.pub ~/.ssh/homelab-flux-deploy-key.pub`
- [ ] `just render-secrets` on a workstation with `~/.ssh/homelab-flux-deploy-key{,.pub}` removed — confirm both are restored with 600/644 perms