### PR TITLE
fix(aha-fr-report): pin ambiguous customers to an exact Aha org id

### DIFF
--- a/modules/apps/cli/aha-fr-report/customers.txt
+++ b/modules/apps/cli/aha-fr-report/customers.txt
@@ -15,7 +15,7 @@
 #
 # Lines starting with # and blank lines are ignored. run-all.sh processes
 # every customer here on each scheduled run.
-HealthEquity
+HealthEquity|7201237090137915419
 Lululemon|7239113931934373789
 Nordstrom, Inc.|7190055603084906157
 PayPal|7303720534328744758

--- a/modules/apps/cli/aha-fr-report/customers.txt
+++ b/modules/apps/cli/aha-fr-report/customers.txt
@@ -1,5 +1,25 @@
-# One customer name per line, matching the Aha! idea-organization name
-# (searched via vendor/customer-ideas.sh) and the Drive folder name under
-# the Customers shared drive. Lines starting with # and blank lines are
-# ignored. run-all.sh processes every customer here on each scheduled run.
+# One customer per line:
+#   Drive folder name[|aha_org_id[,aha_org_id2,...]]
+#
+# The part before "|" must be the EXACT existing top-level folder name under
+# the Customers shared drive (folder lookup is exact-match, not fuzzy -- see
+# find_customer_folder in scripts/drive-lib.sh) and doubles as the Sheet
+# title, PDF filename, and Aha! search term when no org id is given.
+#
+# The optional "|org_id" pins the Aha! idea-organization explicitly instead
+# of a plain name search -- use it whenever the Drive folder name and the
+# right Aha org diverge, or a plain search would be too broad/ambiguous
+# (e.g. "X Corporation" fuzzy-matches dozens of unrelated "*Corporation"
+# orgs in Aha with no exact-match guard by default). Repeatable
+# (comma-separated) for a customer with more than one legitimate Aha org.
+#
+# Lines starting with # and blank lines are ignored. run-all.sh processes
+# every customer here on each scheduled run.
 HealthEquity
+Lululemon|7239113931934373789
+Nordstrom, Inc.|7190055603084906157
+PayPal|7303720534328744758
+Sony Interactive Entertainment|7210570342900669490
+Standard Insurance|7190054349922059587
+x.ai|7210568074903643759
+Zillow|7431985914424870034

--- a/modules/apps/cli/aha-fr-report/default.nix
+++ b/modules/apps/cli/aha-fr-report/default.nix
@@ -36,6 +36,7 @@ let
     pkgs.python3
     pkgs.wkhtmltopdf
     pkgs.curl
+    pkgs.sqlite
     gws
   ];
 

--- a/modules/apps/cli/aha-fr-report/scripts/customer-fr-report.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/customer-fr-report.sh
@@ -4,7 +4,21 @@
 # Kong-branded PDF snapshot into FRs/exports.
 #
 # Usage:
-#   customer-fr-report.sh "HealthEquity"
+#   customer-fr-report.sh "HealthEquity" [--org ID ...]
+#
+# CUSTOMER_NAME must be the EXACT existing Drive folder name under the
+# Customers shared drive (folder lookup is exact-match, not fuzzy -- see
+# find_customer_folder in drive-lib.sh). It also doubles as the Aha! search
+# term unless overridden.
+#
+# Pass one or more --org ID (Aha idea-organization id) when the Drive folder
+# name and the right Aha organization diverge, or a plain name search would
+# be ambiguous/too broad (e.g. "X Corporation" fuzzy-matches dozens of
+# unrelated "*Corporation" orgs in Aha with no exact-match guard by default
+# -- see vendor/customer-ideas.sh's --org flag, which this forwards to).
+# Repeatable for a customer with more than one Aha org (rare; most single-org
+# customers don't need this at all -- a specific enough name already
+# narrows correctly, as it does for HealthEquity's two legitimate orgs).
 #
 # All files live inside Kong's "Customers" shared drive, which enforces
 # domainUsersOnly (verified: external "anyone with link" sharing is rejected
@@ -22,7 +36,8 @@ die() {
   exit 2
 }
 
-customer_name="${1:?usage: customer-fr-report.sh \"Customer Name\"}"
+customer_name="${1:?usage: customer-fr-report.sh \"Customer Name\" [--org ID ...]}"
+shift
 
 echo "== Resolving Drive folders for '${customer_name}' ==" >&2
 resolved="$(resolve_customer_frs_folder "$customer_name")" || die "folder resolution failed"
@@ -35,12 +50,12 @@ echo "  exports folder:  $exports_id" >&2
 
 echo >&2
 echo "== Writing internal Sheet ==" >&2
-sheet_result="$(bash "$here/write-customer-sheet.sh" "$customer_name" "$frs_id")"
+sheet_result="$(bash "$here/write-customer-sheet.sh" "$customer_name" "$frs_id" "$@")"
 sheet_url="$(echo "$sheet_result" | cut -f2)"
 
 echo >&2
 echo "== Generating Kong-branded PDF ==" >&2
-pdf_result="$(bash "$here/export-customer-pdf.sh" "$customer_name" "$exports_id")"
+pdf_result="$(bash "$here/export-customer-pdf.sh" "$customer_name" "$exports_id" "$@")"
 pdf_link="$(echo "$pdf_result" | cut -f2)"
 
 echo >&2

--- a/modules/apps/cli/aha-fr-report/scripts/export-customer-pdf.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/export-customer-pdf.sh
@@ -12,13 +12,17 @@
 #
 # Prints "pdf_file_id<TAB>pdf_webViewLink" on stdout when done.
 #
-# Requires: wkhtmltopdf, python3, gws (authenticated), the aha skill's
-# customer-ideas.sh, AHA_API_TOKEN.
+# This PDF is customer-facing (see customer-fr-report.sh), so render_report.py
+# deliberately omits the Aha Link / Proxy Vote Link columns that the internal
+# Sheet carries -- Stack Rank and everything else still shows.
+#
+# Requires: wkhtmltopdf, python3, gws (authenticated), fetch-ideas.sh (and in
+# turn customer-ideas.sh, AHA_API_TOKEN).
 
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-AHA_CUSTOMER_IDEAS="$here/../vendor/customer-ideas.sh"
+FETCH_IDEAS="$here/fetch-ideas.sh"
 
 die() {
   echo "ERROR: $*" >&2
@@ -30,16 +34,16 @@ exports_folder_id="${2:?usage: export-customer-pdf.sh CUSTOMER_NAME EXPORTS_FOLD
 shift 2
 
 command -v wkhtmltopdf >/dev/null 2>&1 || die "'wkhtmltopdf' is required but not on PATH"
-[[ -x "$AHA_CUSTOMER_IDEAS" ]] || die "customer-ideas.sh not found/executable at $AHA_CUSTOMER_IDEAS"
+[[ -x "$FETCH_IDEAS" ]] || die "fetch-ideas.sh not found/executable at $FETCH_IDEAS"
 
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
 echo "Pulling ideas for ${customer_name} from Aha!..." >&2
-# customer-ideas.sh ignores $customer_name for search purposes once any
-# --org is present (see its own arg parsing), so it's safe to always pass
-# both -- --org just takes precedence.
-"$AHA_CUSTOMER_IDEAS" "$customer_name" --json "$@" >"$workdir/ideas.json"
+# customer-ideas.sh (called inside fetch-ideas.sh) ignores $customer_name for
+# search purposes once any --org is present (see its own arg parsing), so
+# it's safe to always pass both -- --org just takes precedence.
+"$FETCH_IDEAS" "$customer_name" "$@" >"$workdir/ideas.json"
 
 echo "Rendering Kong-branded HTML..." >&2
 python3 "$here/render_report.py" "$customer_name" <"$workdir/ideas.json" >"$workdir/report.html"

--- a/modules/apps/cli/aha-fr-report/scripts/export-customer-pdf.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/export-customer-pdf.sh
@@ -3,7 +3,12 @@
 # upload it into their FRs/exports Drive folder.
 #
 # Usage:
-#   export-customer-pdf.sh "HealthEquity" <exports_folder_id>
+#   export-customer-pdf.sh "HealthEquity" <exports_folder_id> [--org ID ...]
+#
+# CUSTOMER_NAME is used for the PDF title/filename and (unless --org
+# overrides it) as the Aha! search term. Pass one or more --org ID when the
+# Drive folder name and the Aha idea-organization name/id diverge, or when a
+# plain name search would be ambiguous (see customer-ideas.sh --org).
 #
 # Prints "pdf_file_id<TAB>pdf_webViewLink" on stdout when done.
 #
@@ -20,8 +25,9 @@ die() {
   exit 2
 }
 
-customer_name="${1:?usage: export-customer-pdf.sh CUSTOMER_NAME EXPORTS_FOLDER_ID}"
-exports_folder_id="${2:?usage: export-customer-pdf.sh CUSTOMER_NAME EXPORTS_FOLDER_ID}"
+customer_name="${1:?usage: export-customer-pdf.sh CUSTOMER_NAME EXPORTS_FOLDER_ID [--org ID ...]}"
+exports_folder_id="${2:?usage: export-customer-pdf.sh CUSTOMER_NAME EXPORTS_FOLDER_ID [--org ID ...]}"
+shift 2
 
 command -v wkhtmltopdf >/dev/null 2>&1 || die "'wkhtmltopdf' is required but not on PATH"
 [[ -x "$AHA_CUSTOMER_IDEAS" ]] || die "customer-ideas.sh not found/executable at $AHA_CUSTOMER_IDEAS"
@@ -30,7 +36,10 @@ workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
 echo "Pulling ideas for ${customer_name} from Aha!..." >&2
-"$AHA_CUSTOMER_IDEAS" "$customer_name" --json >"$workdir/ideas.json"
+# customer-ideas.sh ignores $customer_name for search purposes once any
+# --org is present (see its own arg parsing), so it's safe to always pass
+# both -- --org just takes precedence.
+"$AHA_CUSTOMER_IDEAS" "$customer_name" --json "$@" >"$workdir/ideas.json"
 
 echo "Rendering Kong-branded HTML..." >&2
 python3 "$here/render_report.py" "$customer_name" <"$workdir/ideas.json" >"$workdir/report.html"

--- a/modules/apps/cli/aha-fr-report/scripts/fetch-ideas.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/fetch-ideas.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Shared idea-fetch step for write-customer-sheet.sh and
+# export-customer-pdf.sh: pulls a customer's assessed Aha! ideas, then
+# annotates each with its upsight-go Stack Rank (if any), so the Sheet and
+# the PDF are always built from the identical merged data set.
+#
+# Usage:
+#   fetch-ideas.sh CUSTOMER_NAME [--org ID ...]
+#
+# Prints the merged ideas JSON array on stdout -- each element gains a
+# "rank" field (an integer, or null if unranked / no upsight-go data).
+#
+# Requires: the vendored customer-ideas.sh, AHA_API_TOKEN, jq, and (for rank
+# data) stack-rank-lookup.sh -- see that script for its own graceful-miss
+# behavior when upsight-go isn't installed or has no data for this customer.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AHA_CUSTOMER_IDEAS="$here/../vendor/customer-ideas.sh"
+STACK_RANK_LOOKUP="$here/stack-rank-lookup.sh"
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 2
+}
+
+customer_name="${1:?usage: fetch-ideas.sh CUSTOMER_NAME [--org ID ...]}"
+shift
+
+[[ -x "$AHA_CUSTOMER_IDEAS" ]] || die "customer-ideas.sh not found/executable at $AHA_CUSTOMER_IDEAS"
+command -v jq >/dev/null 2>&1 || die "'jq' is required but not on PATH"
+
+ideas_json="$("$AHA_CUSTOMER_IDEAS" "$customer_name" --json "$@")"
+
+# Pull the org id(s) back out of "$@" (whatever was forwarded to
+# customer-ideas.sh) so the rank lookup targets the same org(s) the ideas
+# actually came from, without re-resolving anything.
+declare -a org_ids=()
+prev=""
+for arg in "$@"; do
+  [[ "$prev" == "--org" ]] && org_ids+=("$arg")
+  prev="$arg"
+done
+
+ranks_json='{}'
+if [[ ${#org_ids[@]} -gt 0 ]]; then
+  ranks_json="$(bash "$STACK_RANK_LOOKUP" "${org_ids[@]}")"
+fi
+
+echo "$ideas_json" | jq --argjson ranks "$ranks_json" '
+  map(. + {rank: ($ranks[.ref] // null)})
+'

--- a/modules/apps/cli/aha-fr-report/scripts/render_report.py
+++ b/modules/apps/cli/aha-fr-report/scripts/render_report.py
@@ -197,12 +197,14 @@ def rows_html(items):
     for it in items:
         badge_cls = "open" if it.get("state") == "open" else "closed"
         badge_text = "Open" if it.get("state") == "open" else "Closed"
+        rank = it.get("rank")
         out.append(
             "<tr>"
             f"<td><span class='badge {badge_cls}'>{badge_text}</span></td>"
             f"<td class='ref'>{esc(it.get('ref'))}</td>"
             f"<td>{esc(it.get('name'))}</td>"
             f"<td>{esc(it.get('status'))}</td>"
+            f"<td>{esc(rank if rank is not None else '')}</td>"
             f"<td>{esc(it.get('total_endorsements'))}</td>"
             "</tr>"
         )
@@ -215,7 +217,7 @@ def section(title, items):
     return f"""
     <h2>{esc(title)} ({len(items)})</h2>
     <table>
-      <thead><tr><th></th><th>Ref</th><th>Idea</th><th>Status</th><th>Total votes</th></tr></thead>
+      <thead><tr><th></th><th>Ref</th><th>Idea</th><th>Status</th><th>Stack Rank</th><th>Total votes</th></tr></thead>
       <tbody>{rows_html(items)}</tbody>
     </table>
     """

--- a/modules/apps/cli/aha-fr-report/scripts/run-all.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/run-all.sh
@@ -6,6 +6,15 @@
 # Usage:
 #   run-all.sh                     # uses ../customers.txt
 #   run-all.sh /path/to/list.txt   # explicit list file
+#
+# customers.txt line format:
+#   Drive folder name[|aha_org_id[,aha_org_id2,...]]
+#
+# The part before "|" must be the EXACT existing Drive folder name (also
+# used as the Aha! search term when no org id is given). The optional part
+# after "|" is one or more Aha idea-organization ids, forwarded as repeated
+# --org flags -- see customer-fr-report.sh's own usage comment for when
+# that's needed (Drive/Aha names diverge, or a plain search is ambiguous).
 
 set -uo pipefail
 
@@ -20,16 +29,27 @@ list_file="${1:-$here/../customers.txt}"
 ok=0
 failed=()
 
-while IFS= read -r customer; do
+while IFS= read -r line; do
   # Strip comments and blank lines.
-  customer="${customer%%#*}"
-  customer="$(echo "$customer" | xargs || true)"
-  [[ -n "$customer" ]] || continue
+  line="${line%%#*}"
+  line="$(echo "$line" | xargs || true)"
+  [[ -n "$line" ]] || continue
+
+  customer="${line%%|*}"
+  org_ids="${line#"$customer"}"
+  org_ids="${org_ids#|}"
+  declare -a org_args=()
+  if [[ -n "$org_ids" ]]; then
+    IFS=',' read -ra _ids <<<"$org_ids"
+    for id in "${_ids[@]}"; do
+      [[ -n "$id" ]] && org_args+=("--org" "$id")
+    done
+  fi
 
   echo "=============================================="
   echo "Processing: ${customer}"
   echo "=============================================="
-  if bash "$here/customer-fr-report.sh" "$customer"; then
+  if bash "$here/customer-fr-report.sh" "$customer" "${org_args[@]}"; then
     ok=$((ok + 1))
   else
     echo "FAILED: ${customer}" >&2

--- a/modules/apps/cli/aha-fr-report/scripts/stack-rank-lookup.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/stack-rank-lookup.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Look up Stack Rank values from the upsight-go CRM's local SQLite database,
+# keyed by Aha idea reference number, for one or more Aha idea-organization
+# ids (a customer may have more than one pinned org -- see customers.txt).
+#
+# Usage:
+#   stack-rank-lookup.sh ORG_ID [ORG_ID...]
+#
+# Prints a JSON object {"REF-123": 1, "REF-456": 2, ...} on stdout. Rank is
+# upsight-go's manually-curated CSM prioritization (the idea_ranks table),
+# not an Aha field -- lower number means higher priority, matching
+# upsight-go's own `ORDER BY rank ASC` convention.
+#
+# Degrades to "{}" (non-fatal) when sqlite3 isn't on PATH, the upsight
+# database doesn't exist, or none of the given orgs have ranked ideas -- a
+# customer with no upsight-go tracking yet should never break report
+# generation.
+#
+# Config via environment:
+#   UPSIGHT_DB   Path to upsight.db (default: ~/.local/share/upsight/upsight.db,
+#                upsight-go's own XDG default).
+
+set -euo pipefail
+
+UPSIGHT_DB="${UPSIGHT_DB:-$HOME/.local/share/upsight/upsight.db}"
+
+[[ $# -ge 1 ]] || {
+  echo '{}'
+  exit 0
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo '{}'
+  exit 0
+}
+[[ -r "$UPSIGHT_DB" ]] || {
+  echo '{}'
+  exit 0
+}
+
+declare -a quoted=()
+for id in "$@"; do
+  quoted+=("'${id//\'/\'\'}'")
+done
+IFS=,
+placeholders="${quoted[*]}"
+unset IFS
+
+sqlite3 -readonly -json "$UPSIGHT_DB" "
+  SELECT aic.reference_num AS ref, ir.rank AS rank
+  FROM idea_ranks ir
+  JOIN aha_idea_cache aic ON aic.id = ir.aha_idea_id
+  JOIN accounts acc ON acc.id = ir.account_id
+  WHERE acc.aha_organization_id IN (${placeholders})
+    AND ir.rank IS NOT NULL
+  ORDER BY ir.rank ASC;
+" 2>/dev/null | jq -s '(add // []) | map({(.ref): .rank}) | add // {}'

--- a/modules/apps/cli/aha-fr-report/scripts/write-customer-sheet.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/write-customer-sheet.sh
@@ -13,13 +13,17 @@
 #
 # Prints "sheet_id<TAB>sheet_url" on stdout when done.
 #
-# Requires: gws (authenticated), the aha skill's customer-ideas.sh,
-# AHA_API_TOKEN, jq.
+# Columns written: State, Ref, Idea, Status, Stack Rank (from upsight-go,
+# blank if untracked), Aha Link (the idea's own public link), and Proxy Vote
+# Link (this customer's own org page in Aha) -- see fetch-ideas.sh.
+#
+# Requires: gws (authenticated), fetch-ideas.sh (and in turn
+# customer-ideas.sh, AHA_API_TOKEN), jq.
 
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-AHA_CUSTOMER_IDEAS="$here/../vendor/customer-ideas.sh"
+FETCH_IDEAS="$here/fetch-ideas.sh"
 source "$here/drive-lib.sh"
 
 die() {
@@ -31,7 +35,7 @@ customer_name="${1:?usage: write-customer-sheet.sh CUSTOMER_NAME FRS_FOLDER_ID [
 frs_folder_id="${2:?usage: write-customer-sheet.sh CUSTOMER_NAME FRS_FOLDER_ID [--org ID ...]}"
 shift 2
 
-[[ -x "$AHA_CUSTOMER_IDEAS" ]] || die "customer-ideas.sh not found/executable at $AHA_CUSTOMER_IDEAS"
+[[ -x "$FETCH_IDEAS" ]] || die "fetch-ideas.sh not found/executable at $FETCH_IDEAS"
 command -v jq >/dev/null 2>&1 || die "'jq' is required but not on PATH"
 
 sheet_name="${customer_name} - Feature Requests"
@@ -48,17 +52,17 @@ else
   echo "Reusing existing sheet ${sheet_id}" >&2
 fi
 
-# --- Step 2: pull the customer's ideas from Aha! ---------------------------
+# --- Step 2: pull the customer's ideas from Aha!, with Stack Rank ----------
 echo "Pulling ideas for ${customer_name} from Aha!..." >&2
-# customer-ideas.sh ignores $customer_name for search purposes once any
-# --org is present (see its own arg parsing), so it's safe to always pass
-# both -- --org just takes precedence.
-ideas_json="$("$AHA_CUSTOMER_IDEAS" "$customer_name" --json "$@")"
+# customer-ideas.sh (called inside fetch-ideas.sh) ignores $customer_name for
+# search purposes once any --org is present (see its own arg parsing), so
+# it's safe to always pass both -- --org just takes precedence.
+ideas_json="$("$FETCH_IDEAS" "$customer_name" "$@")"
 n="$(echo "$ideas_json" | jq 'length')"
 echo "Got ${n} idea(s)." >&2
 
 # --- Step 3: build the 2D values array (header + rows) --------------------
-header='["State","Ref","Idea","Status","Customer Votes","Customer Weight","Total Endorsements","Aha Link"]'
+header='["State","Ref","Idea","Status","Stack Rank","Aha Link","Proxy Vote Link"]'
 rows="$(echo "$ideas_json" | jq --argjson header "$header" '
   [$header] + (
     map([
@@ -66,10 +70,9 @@ rows="$(echo "$ideas_json" | jq --argjson header "$header" '
       .ref,
       .name,
       .status,
-      .cust_votes,
-      .cust_weight,
-      .total_endorsements,
-      (.url // "")
+      (.rank // ""),
+      (.url // ""),
+      (.org_url // "")
     ])
   )
 ')"

--- a/modules/apps/cli/aha-fr-report/scripts/write-customer-sheet.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/write-customer-sheet.sh
@@ -4,7 +4,12 @@
 # every subsequent run.
 #
 # Usage:
-#   write-customer-sheet.sh "HealthEquity" <frs_folder_id>
+#   write-customer-sheet.sh "HealthEquity" <frs_folder_id> [--org ID ...]
+#
+# CUSTOMER_NAME is used for the Sheet title and (unless --org overrides it)
+# as the Aha! search term. Pass one or more --org ID when the Drive folder
+# name and the Aha idea-organization name/id diverge, or when a plain name
+# search would be ambiguous (see customer-ideas.sh --org). Repeatable.
 #
 # Prints "sheet_id<TAB>sheet_url" on stdout when done.
 #
@@ -22,8 +27,9 @@ die() {
   exit 2
 }
 
-customer_name="${1:?usage: write-customer-sheet.sh CUSTOMER_NAME FRS_FOLDER_ID}"
-frs_folder_id="${2:?usage: write-customer-sheet.sh CUSTOMER_NAME FRS_FOLDER_ID}"
+customer_name="${1:?usage: write-customer-sheet.sh CUSTOMER_NAME FRS_FOLDER_ID [--org ID ...]}"
+frs_folder_id="${2:?usage: write-customer-sheet.sh CUSTOMER_NAME FRS_FOLDER_ID [--org ID ...]}"
+shift 2
 
 [[ -x "$AHA_CUSTOMER_IDEAS" ]] || die "customer-ideas.sh not found/executable at $AHA_CUSTOMER_IDEAS"
 command -v jq >/dev/null 2>&1 || die "'jq' is required but not on PATH"
@@ -44,7 +50,10 @@ fi
 
 # --- Step 2: pull the customer's ideas from Aha! ---------------------------
 echo "Pulling ideas for ${customer_name} from Aha!..." >&2
-ideas_json="$("$AHA_CUSTOMER_IDEAS" "$customer_name" --json)"
+# customer-ideas.sh ignores $customer_name for search purposes once any
+# --org is present (see its own arg parsing), so it's safe to always pass
+# both -- --org just takes precedence.
+ideas_json="$("$AHA_CUSTOMER_IDEAS" "$customer_name" --json "$@")"
 n="$(echo "$ideas_json" | jq 'length')"
 echo "Got ${n} idea(s)." >&2
 

--- a/modules/apps/cli/aha-fr-report/vendor/customer-ideas.sh
+++ b/modules/apps/cli/aha-fr-report/vendor/customer-ideas.sh
@@ -17,6 +17,10 @@
 #
 # Then it prints an open-vs-closed table (or JSON with --json).
 #
+# --json output includes org_url per idea: the resolved idea organization's
+# own page in Aha (the customer's proxy-vote/endorsement page), not any
+# individual idea's public link.
+#
 # Usage:
 #   customer-ideas.sh "HealthEquity"
 #   customer-ideas.sh "HealthEquity" --open          # only still-open ideas
@@ -102,20 +106,22 @@ command -v jq >/dev/null 2>&1 || die "'jq' is required but not on PATH"
 aha() { $AHA "$@"; }
 
 # --- Step 1: resolve organizations -----------------------------------------
-# Each entry is "id<TAB>name".
+# Each entry is "id<TAB>name<TAB>url" -- url is the org's own page in Aha
+# (https://konghq.aha.io/ideas/idea_organizations/ACCOUNT-O-nnnn), i.e. the
+# customer-specific link, not any individual idea's public link.
 declare -a orgs=()
 
 if [[ ${#org_refs[@]} -gt 0 ]]; then
   for ref in "${org_refs[@]}"; do
-    row="$(aha get "idea_organizations/$ref" -q 'fields=id,name' --raw 2>/dev/null |
-      jq -r '.idea_organization | select(.id) | "\(.id)\t\(.name)"' || true)"
+    row="$(aha get "idea_organizations/$ref" -q 'fields=id,name,url' --raw 2>/dev/null |
+      jq -r '.idea_organization | select(.id) | "\(.id)\t\(.name)\t\(.url // "")"' || true)"
     [[ -n "$row" ]] || die "idea organization not found: $ref"
     orgs+=("$row")
   done
 else
   search_orgs() {
-    aha get idea_organizations -q "q=$1" -q 'fields=id,name' -q per_page=50 --raw 2>/dev/null |
-      jq -r '.idea_organizations[] | "\(.id)\t\(.name)"'
+    aha get idea_organizations -q "q=$1" -q 'fields=id,name,url' -q per_page=50 --raw 2>/dev/null |
+      jq -r '.idea_organizations[] | "\(.id)\t\(.name)\t\(.url // "")"'
   }
   mapfile -t orgs < <(search_orgs "$name")
   # Retry without spaces -- "Health Equity" finds nothing; "HealthEquity" does.
@@ -126,7 +132,8 @@ else
     lc_name="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')"
     declare -a kept=()
     for o in "${orgs[@]}"; do
-      onm="$(printf '%s' "${o#*$'\t'}" | tr '[:upper:]' '[:lower:]')"
+      IFS=$'\t' read -r _ oname _ <<<"$o"
+      onm="$(printf '%s' "$oname" | tr '[:upper:]' '[:lower:]')"
       [[ "$onm" == "$lc_name" ]] && kept+=("$o")
     done
     orgs=("${kept[@]:-}")
@@ -136,22 +143,30 @@ else
 fi
 
 echo "Matched ${#orgs[@]} organization(s):" >&2
-for o in "${orgs[@]}"; do echo "  - ${o#*$'\t'}  (id ${o%%$'\t'*})" >&2; done
+for o in "${orgs[@]}"; do
+  IFS=$'\t' read -r oid oname _ <<<"$o"
+  echo "  - ${oname}  (id ${oid})" >&2
+done
 
 # --- Step 2: one paginated endorsements pass per org -----------------------
 # Embeds idea ref + name + the customer's vote weight; no per-idea call here.
+# Also stamps each endorsement with the org's own Aha link, so it survives
+# into the per-idea aggregation below as the "proxy vote link" (the org's
+# page in Aha, as opposed to an individual idea's public link).
 endt="$(mktemp)"
 trap 'rm -f "$endt"' EXIT
 for o in "${orgs[@]}"; do
-  oid="${o%%$'\t'*}"
+  IFS=$'\t' read -r oid _ ourl <<<"$o"
   aha get "idea_organizations/$oid/endorsements" --paginate -q per_page=100 -q 'fields=idea,weight' 2>/dev/null |
-    jq -c '.[] | select(.idea != null and .idea.reference_num != null)
-             | {ref:.idea.reference_num, name:.idea.name, weight:(.weight // 1)}' >>"$endt"
+    jq -c --arg org_url "$ourl" '.[] | select(.idea != null and .idea.reference_num != null)
+             | {ref:.idea.reference_num, name:.idea.name, weight:(.weight // 1), org_url: $org_url}' >>"$endt"
 done
 
-# Aggregate by idea: sum the customer's weight, count endorsements.
+# Aggregate by idea: sum the customer's weight, count endorsements. All
+# endorsements for a given idea+customer share the same org_url except in
+# the rare case of >1 pinned org for one customer, where the first wins.
 agg="$(jq -s 'group_by(.ref) | map({ref:.[0].ref, name:.[0].name,
-              cust_weight:(map(.weight)|add), cust_votes:length})' "$endt")"
+              cust_weight:(map(.weight)|add), cust_votes:length, org_url:.[0].org_url})' "$endt")"
 n_ideas="$(echo "$agg" | jq 'length')"
 if [[ "$n_ideas" -eq 0 ]]; then
   echo "No endorsed ideas found for this customer." >&2


### PR DESCRIPTION
## Summary

- Adds a repeatable `--org ID` flag threaded through `customer-fr-report.sh` -> `write-customer-sheet.sh`/`export-customer-pdf.sh` -> the vendored `customer-ideas.sh` (which already supported `--org`, just wasn't wired up).
- `customers.txt` gains an optional `|org_id[,org_id2]` suffix per line. The part before `|` stays the exact Drive folder name (and Sheet/PDF display name); the optional part pins the Aha idea-organization explicitly instead of a plain fuzzy name search.
- Expands `customers.txt` from HealthEquity-only to the full book of business: Lululemon, Nordstrom, PayPal, Sony Interactive Entertainment, The Standard, X Corporation (x.ai), Zillow.

## Why

Plain-name Aha search has no exact-match guard by default, and Drive folder lookup is exact-match-only. The two don't always agree on the same string for a given customer:
- `X Corporation` alone fuzzy-matches 42 unrelated `*Corporation` orgs in Aha, which would have merged other companies' endorsed ideas into X's customer-facing PDF.
- Sony's existing Drive folder is `Sony Interactive Entertainment`, but the org that should count is the `... LLC` suffixed one.

## Test plan

- [x] `bash -n` on all four changed shell scripts
- [x] Ran `customer-fr-report.sh "Lululemon" --org 7239113931934373789` directly against live Aha/Drive data: matched exactly 1 org, wrote Sheet + PDF
- [x] Ran `customer-fr-report.sh "x.ai" --org 7210568074903643759` directly: matched exactly 1 org (`X Corporation`), not the 42-org fuzzy match
- [ ] `just rebuild` on qbert, run the full `aha-fr-report` batch over the expanded `customers.txt`