### PR TITLE
feat(fish): cluster-aware just wrapper with fzf cluster prompt

### DIFF
--- a/modules/apps/cli/fish/default.nix
+++ b/modules/apps/cli/fish/default.nix
@@ -123,6 +123,32 @@ in
             end
           '';
 
+          just = {
+            description = "Cluster-aware wrapper around `just`. In a repo with a just/_shared.just (the homelab fleet), if the requested recipe depends on _require-cluster and $CLUSTER isn't already set, fzf-prompts for a cluster and re-execs with it. Every other repo, and every already-CLUSTER-set or non-gated invocation, passes straight through to the real `just` untouched -- recipe output is never buffered, so interactive recipes (e.g. a `tofu apply` approval prompt) still stream live.";
+            body = ''
+              set -l repo_root (git rev-parse --show-toplevel 2>/dev/null)
+              if test -n "$CLUSTER"; or test -z "$repo_root"; or not test -f "$repo_root/just/_shared.just"
+                command just $argv
+                return $status
+              end
+
+              set -l recipe $argv[1]
+              if test -n "$recipe" && not string match -q -- "-*" "$recipe" && command just --show $recipe 2>/dev/null | string match -q "*_require-cluster*"
+                set -l picked (find "$repo_root/clusters" -maxdepth 1 -mindepth 1 -type d -exec basename {} \; | fzf --prompt="Select cluster: " --height=40% --border)
+                if test -z "$picked"
+                  echo "just: no cluster selected, aborting" >&2
+                  return 1
+                end
+                echo "→ CLUSTER=$picked just $argv"
+                set -lx CLUSTER $picked
+                command just $argv
+                return $status
+              end
+
+              command just $argv
+            '';
+          };
+
           gwscfg = ''
             # "work" (the default gws config dir, ~/.config/gws) is always offered.
             # Any other profile is a subdirectory of gws-profiles, each holding its


### PR DESCRIPTION
## Summary
- Fast-follow to homelab's justfile module split (bashfulrobot/homelab#23): adds a fish function named `just` that shadows the real binary.
- In a repo carrying `just/_shared.just` (the homelab fleet's marker), if the requested recipe depends on `_require-cluster` and `$CLUSTER` isn't already set, it fzf-prompts for a cluster (from that repo's `clusters/` dir) and re-execs with `CLUSTER` set — instead of making you retype the command by hand after the gate's fail-loud error.
- Every other repo, and every already-`CLUSTER`-set or non-gated invocation (read-only recipes still silently default to spitfire, matching the justfile's own documented UX), passes straight through to the real `just` via `command just $argv` — untouched, unbuffered, so interactive recipes like a `tofu apply` approval prompt still stream live.
- Gating detection uses `just --show <recipe>` (fast, read-only metadata) rather than running the recipe and inspecting its output, specifically to avoid buffering a live/interactive command.

## Test plan
- [x] `nix-instantiate --parse` and `fish -n` both pass
- [x] Passthrough verified when `CLUSTER` is already set, for non-gated recipes, and in a non-homelab repo
- [x] `CLUSTER` propagation and argument passthrough verified on a gated recipe, using a fully faked `just`/`fzf` pair in an isolated sandbox (not the real homelab repo, to avoid any risk of touching live infra during testing)