### PR TITLE
feat(aha-fr-report): apply Stack Rank sort to the PDF too

### DIFF
--- a/modules/apps/cli/aha-fr-report/scripts/fetch-ideas.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/fetch-ideas.sh
@@ -13,6 +13,11 @@
 # nullable -- an untracked idea, or a customer with no upsight-go data at
 # all, just gets all-null fields, not an error.
 #
+# Row order (shared by both the Sheet and the PDF, since both consume this
+# script's output directly): Open ideas first, Closed ideas last. Within
+# each of those, ranked ideas come first sorted by Stack Rank ascending (1
+# at the top), then unranked ideas after.
+#
 # Requires: the vendored customer-ideas.sh, AHA_API_TOKEN, jq, and (for the
 # tracking fields) idea-tracking-lookup.sh -- see that script for its own
 # graceful-miss behavior when upsight-go isn't installed, has no data for
@@ -64,4 +69,9 @@ echo "$ideas_json" | jq --argjson tracking "$tracking_json" '
       rank: null, production_blocker: null, target_release: null, use_case: null,
       source_url: null, notes: null, requester_name: null, requester_email: null
     }))
+  | sort_by([
+      (if .state == "open" then 0 else 1 end),
+      (if .rank == null then 1 else 0 end),
+      (.rank // 0)
+    ])
 '

--- a/modules/apps/cli/aha-fr-report/scripts/write-customer-sheet.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/write-customer-sheet.sh
@@ -24,12 +24,10 @@
 # Sheets evaluates them) rather than bare URLs. The header row is bolded,
 # shaded, and frozen, and columns are auto-width (recomputed from the
 # actual column count every run) -- reapplied on every run (idempotent),
-# not just on first creation.
-#
-# Row order: Open ideas first, Closed ideas last (needed for the
-# collapsed-closed-rows group below). Within each of those, ranked ideas
-# come first sorted by Stack Rank ascending (1 at the top), then unranked
-# ideas after.
+# not just on first creation. Row order (Open first, ranked-then-unranked
+# within each state) comes from fetch-ideas.sh -- see that script for
+# details; Closed rows land as one contiguous block at the bottom, which
+# the row-group collapse below relies on.
 #
 # Requires: gws (authenticated), fetch-ideas.sh (and in turn
 # customer-ideas.sh, AHA_API_TOKEN), jq.
@@ -76,19 +74,9 @@ n="$(echo "$ideas_json" | jq 'length')"
 echo "Got ${n} idea(s)." >&2
 
 # --- Step 3: build the 2D values array (header + rows) --------------------
-# Re-sort on top of customer-ideas.sh's open-first/closed-last order:
-# within each state, ranked ideas come first (Stack Rank 1 at the top,
-# ascending from there), unranked ideas follow. State still comes first
-# in the sort key so Closed rows stay one contiguous block at the bottom,
-# which Step 5 relies on to group/collapse them.
-ideas_json="$(echo "$ideas_json" | jq '
-  sort_by([
-    (if .state == "open" then 0 else 1 end),
-    (if .rank == null then 1 else 0 end),
-    (.rank // 0)
-  ])
-')"
-
+# fetch-ideas.sh already returns ideas sorted open-first/closed-last, ranked
+# ascending within each state -- Closed rows land as one contiguous block
+# at the bottom, which Step 5 relies on to group/collapse them.
 header='["State","Ref","Idea","Status","Stack Rank","Use Case","Requester","Production Blocker","Target Release","Notes","Aha Link","Proxy Vote Link","Source Link"]'
 open_count="$(echo "$ideas_json" | jq '[.[] | select(.state == "open")] | length')"
 closed_count="$(echo "$ideas_json" | jq '[.[] | select(.state != "open")] | length')"


### PR DESCRIPTION
## Summary

- Moved the rank-within-state sort from `write-customer-sheet.sh` into `fetch-ideas.sh`, the shared fetch step both the Sheet and the PDF pull from.
- `render_report.py` splits ideas into Open/Closed sections via a plain list comprehension, which preserves input order, so the PDF now shows the same ranked-first (1 at top), unranked-after ordering within each section with no changes needed there.

## Test plan

- [x] `bash -n` on both modified scripts
- [x] Merge+sort jq pipeline validated in isolation against ranked/unranked open/closed synthetic data
- [x] `render_report.py` HTML output confirmed to preserve the sorted row order
- [x] Full live run against HealthEquity (Sheet + PDF) completed with no errors