### PR TITLE
feat(srv): add jellyfin-media and jellyfin-config NFS exports

### DIFF
--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -240,6 +240,26 @@
           uid = 1000;
           gid = 100;
         };
+        jellyfin-media = {
+          path = "/exports/jellyfin-media";
+          bindMount = "/home/dustin/data-disk/media";
+          clients = [ "192.168.168.0/23" ];
+          # Jellyfin's pod runs as UID 1000 (fsGroup), matching the on-disk
+          # owner already -- this is a static PV pointed straight at
+          # existing files, not a CSI provisioner creating subdirs as root,
+          # so root_squash (not darkstar's no_root_squash) is correct.
+          squash = "root_squash";
+          uid = 1000;
+          gid = 100;
+        };
+        jellyfin-config = {
+          path = "/exports/jellyfin-config";
+          bindMount = "/home/dustin/docker/jellyfin-official";
+          clients = [ "192.168.168.0/23" ];
+          squash = "root_squash";
+          uid = 1000;
+          gid = 100;
+        };
       };
       additionalPaths = [
         {


### PR DESCRIPTION
## Summary
- Adds two new NFS exports on srv, backed by existing directories (no data copy): `/exports/jellyfin-media` (bind of `/home/dustin/data-disk/media`) and `/exports/jellyfin-config` (bind of `/home/dustin/docker/jellyfin-official`).
- Both use `root_squash` (not darkstar's `no_root_squash`) since these are statically-provisioned NFS PVs for a pod running as UID 1000, not a CSI provisioner needing root passthrough.
- Companion to the homelab repo's Jellyfin k8s migration (docs/superpowers/plans/2026-07-09-jellyfin-k8s-migration.md there).

## Test plan
- [x] `nixos-rebuild build --impure --flake ".#srv"` succeeds
- [x] Resolved `exports` derivation content verified correct
- [ ] After deploy: `showmount -e localhost` on srv shows both new exports
- [ ] Existing darkstar/spitfire exports unaffected