### PR TITLE
feat(srv): install filebot natively for dlm/dltv

### DIFF
--- a/hosts/srv/configuration.nix
+++ b/hosts/srv/configuration.nix
@@ -108,6 +108,7 @@
     dust
     eza
     fd
+    filebot
     gdu
     git
     git-crypt


### PR DESCRIPTION
## Summary
- Adds filebot (nixpkgs, v5.2.1, unfree-redistributable, srv already has allowUnfree) to srv's system packages.
- Replaces the Docker-based rednoah/filebot container dlm/dltv currently use.
- Media is already local to srv (/home/dustin/data-disk/media), so running filebot natively avoids Docker entirely for this workflow and sidesteps NFS-mount permission complications an ad-hoc k8s Job hit in testing.

## Test plan
- [x] `nixos-rebuild build --impure --flake ".#srv"` succeeds
- [ ] After deploy: `filebot -version` works
- [ ] License import works, dlm/dltv rewritten to call filebot directly