### PR TITLE
feat(aha-fr-report): surface internal_discussion_url in the Sheet

### DIFF
--- a/modules/apps/cli/aha-fr-report/scripts/fetch-ideas.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/fetch-ideas.sh
@@ -9,9 +9,9 @@
 #
 # Prints the merged ideas JSON array on stdout -- each element gains: rank,
 # production_blocker, target_release, use_case, source_url, notes,
-# requester_name, requester_email. Every one of those is independently
-# nullable -- an untracked idea, or a customer with no upsight-go data at
-# all, just gets all-null fields, not an error.
+# internal_discussion_url, requester_name, requester_email. Every one of
+# those is independently nullable -- an untracked idea, or a customer with
+# no upsight-go data at all, just gets all-null fields, not an error.
 #
 # Row order (shared by both the Sheet and the PDF, since both consume this
 # script's output directly): Open ideas first, Closed ideas last. Within
@@ -63,11 +63,13 @@ echo "$ideas_json" | jq --argjson tracking "$tracking_json" '
      rank: (.rank // null), production_blocker: (.production_blocker // null),
      target_release: (.target_release // null), use_case: (.use_case // null),
      source_url: (.source_url // null), notes: (.notes // null),
+     internal_discussion_url: (.internal_discussion_url // null),
      requester_name: (.requester_name // null), requester_email: (.requester_email // null)
    })) as $tracking
   | map(. + ($tracking[.ref] // {
       rank: null, production_blocker: null, target_release: null, use_case: null,
-      source_url: null, notes: null, requester_name: null, requester_email: null
+      source_url: null, notes: null, internal_discussion_url: null,
+      requester_name: null, requester_email: null
     }))
   | sort_by([
       (if .state == "open" then 0 else 1 end),

--- a/modules/apps/cli/aha-fr-report/scripts/idea-tracking-lookup.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/idea-tracking-lookup.sh
@@ -11,6 +11,7 @@
 #   {"REF-123": {"rank": 1, "production_blocker": 1, "target_release": "3.16",
 #                "use_case": "Shared Gateway Migration",
 #                "source_url": "https://...", "notes": "...",
+#                "internal_discussion_url": "https://kong.slack.com/...",
 #                "requester_name": "Chris Fulara",
 #                "requester_email": "chris.fulara@example.com"}, ...}
 # Every field is independently nullable -- an idea with only a rank set (or
@@ -18,17 +19,19 @@
 # requester_name/requester_email are resolved from upsight-go's contacts
 # table via idea_ranks.requester_contact_id, not stored as free text.
 #
-# Schema dependency: this reads six columns added to idea_ranks by
+# Schema dependency: this reads seven columns added to idea_ranks by
 # bashfulrobot/upsight-go#60 (requester_contact_id, production_blocker,
-# target_release, use_case, source_url, notes). Until that migration has
-# run on a given upsight.db, those columns don't exist yet -- this script
+# target_release, use_case, source_url, notes) and #61
+# (internal_discussion_url, the Kong-internal Slack thread, kept distinct
+# from source_url's customer-facing link). Until those migrations have run
+# on a given upsight.db, those columns don't exist yet -- this script
 # degrades to "{}" on any SQLite error (including "no such column"), same
 # as every other graceful-miss path here, so running against an
 # un-migrated database just means blank cells, not a broken report.
 #
 # Degrades to "{}" (non-fatal) when sqlite3 isn't on PATH, the upsight
-# database doesn't exist, the schema predates upsight-go#60, or none of the
-# given orgs have any tracked ideas.
+# database doesn't exist, the schema predates upsight-go#60/#61, or none of
+# the given orgs have any tracked ideas.
 #
 # Config via environment:
 #   UPSIGHT_DB   Path to upsight.db (default: ~/.local/share/upsight/upsight.db,
@@ -70,6 +73,7 @@ sqlite3 -readonly -json "$UPSIGHT_DB" "
     ir.use_case                         AS use_case,
     ir.source_url                       AS source_url,
     ir.notes                            AS notes,
+    ir.internal_discussion_url          AS internal_discussion_url,
     c.first_name || ' ' || c.last_name  AS requester_name,
     c.email                             AS requester_email
   FROM idea_ranks ir
@@ -82,7 +86,8 @@ sqlite3 -readonly -json "$UPSIGHT_DB" "
          OR ir.target_release IS NOT NULL
          OR ir.use_case IS NOT NULL
          OR ir.source_url IS NOT NULL
-         OR ir.notes IS NOT NULL)
+         OR ir.notes IS NOT NULL
+         OR ir.internal_discussion_url IS NOT NULL)
   ORDER BY (ir.rank IS NULL), ir.rank ASC;
 " 2>/dev/null | jq -s '(add // []) | map({(.ref): del(.ref)}) | add // {}' 2>/dev/null || true
 # The || true above matters: with pipefail, a sqlite3 query failure (e.g.

--- a/modules/apps/cli/aha-fr-report/scripts/write-customer-sheet.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/write-customer-sheet.sh
@@ -18,10 +18,12 @@
 # upsight-go, blank if untracked -- see fetch-ideas.sh and
 # idea-tracking-lookup.sh), Aha Link (the idea's own public link, shown as
 # "View idea"), Proxy Vote Link (this customer's own org page in Aha, shown
-# as "View proxy"), and Source Link (where the request was first gathered,
-# e.g. a Slack thread, shown as "View source"). All three link columns are
-# HYPERLINK() formulas (values written with USER_ENTERED, not RAW, so
-# Sheets evaluates them) rather than bare URLs. The header row is bolded,
+# as "View proxy"), Source Link (where the request was first gathered, e.g.
+# a customer Slack thread, shown as "View source"), and Internal Discussion
+# Link (the separate Kong-internal Slack thread about the request, shown as
+# "View discussion"). All four link columns are HYPERLINK() formulas
+# (values written with USER_ENTERED, not RAW, so Sheets evaluates them)
+# rather than bare URLs. The header row is bolded,
 # shaded, and frozen, and columns are auto-width (recomputed from the
 # actual column count every run) -- reapplied on every run (idempotent),
 # not just on first creation. Row order (Open first, ranked-then-unranked
@@ -77,7 +79,7 @@ echo "Got ${n} idea(s)." >&2
 # fetch-ideas.sh already returns ideas sorted open-first/closed-last, ranked
 # ascending within each state -- Closed rows land as one contiguous block
 # at the bottom, which Step 5 relies on to group/collapse them.
-header='["State","Ref","Idea","Status","Stack Rank","Use Case","Requester","Production Blocker","Target Release","Notes","Aha Link","Proxy Vote Link","Source Link"]'
+header='["State","Ref","Idea","Status","Stack Rank","Use Case","Requester","Production Blocker","Target Release","Notes","Aha Link","Proxy Vote Link","Source Link","Internal Discussion Link"]'
 open_count="$(echo "$ideas_json" | jq '[.[] | select(.state == "open")] | length')"
 closed_count="$(echo "$ideas_json" | jq '[.[] | select(.state != "open")] | length')"
 rows="$(echo "$ideas_json" | jq --argjson header "$header" '
@@ -95,7 +97,8 @@ rows="$(echo "$ideas_json" | jq --argjson header "$header" '
       (.notes // ""),
       (if (.url // "") != "" then "=HYPERLINK(\"\(.url)\",\"View idea\")" else "" end),
       (if (.org_url // "") != "" then "=HYPERLINK(\"\(.org_url)\",\"View proxy\")" else "" end),
-      (if (.source_url // "") != "" then "=HYPERLINK(\"\(.source_url)\",\"View source\")" else "" end)
+      (if (.source_url // "") != "" then "=HYPERLINK(\"\(.source_url)\",\"View source\")" else "" end),
+      (if (.internal_discussion_url // "") != "" then "=HYPERLINK(\"\(.internal_discussion_url)\",\"View discussion\")" else "" end)
     ])
   )
 ')"


### PR DESCRIPTION
## Summary

- upsight-go#61's migration (00072) added `internal_discussion_url` to `idea_ranks`, a Kong-internal Slack thread link distinct from the existing customer-facing `source_url`.
- `idea-tracking-lookup.sh` now reads it, `fetch-ideas.sh` merges it, and `write-customer-sheet.sh` writes it as a new Internal Discussion Link column (HYPERLINK, "View discussion"), matching the existing Source Link pattern.
- `render_report.py` needs no change: it already excludes every link/URL field from the customer-facing PDF by omission.

Also applied migrations 71 and 72 to the real `upsight.db` via `just migrate` in upsight-go (it was still on version 70; the app auto-migrates on launch but hadn't been relaunched since that code merged), after taking a backup.

## Test plan

- [x] `bash -n` on all modified scripts
- [x] `idea-tracking-lookup.sh` schema assumptions confirmed against the live (now-migrated) `upsight.db`
- [x] Extended the synthetic test DB with the new column, verified the positive-path merge and Sheet row jq
- [x] Live end-to-end run for HealthEquity, confirmed 14-column header including "Internal Discussion Link"
- [x] Full 8-customer batch (`run-all.sh`) run live: 8 succeeded, 0 failed