### PR TITLE
feat(srv): declare dlm/dltv as a Nix module

### DIFF
--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -20,6 +20,7 @@
     ../../modules/apps/cli/git
     ../../modules/apps/cli/graymatter
     ../../modules/apps/cli/helix
+    ../../modules/apps/cli/media-rename
     ../../modules/apps/cli/restic
     ../../modules/apps/cli/skillfish
     ../../modules/apps/cli/starship
@@ -54,6 +55,7 @@
     fish.enable = true;
     git.enable = true;
     helix.enable = true;
+    media-rename.enable = true;
     starship.enable = true;
     tailscale.enable = true;
     vscode-server.enable = false;

--- a/modules/apps/cli/media-rename/default.nix
+++ b/modules/apps/cli/media-rename/default.nix
@@ -1,0 +1,99 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.apps.cli.media-rename;
+
+  runtimeDeps = [
+    pkgs.filebot
+    pkgs.rsync
+    pkgs.openssh
+  ];
+
+  # Shared shape: rsync new files from the seedbox into a staging dir under
+  # the media root, rename/organize them with filebot, then clear staging.
+  # filebot runs as the invoking user directly against the local media tree
+  # (already on srv's own disk -- no Docker, no NFS round-trip, no chown
+  # step needed since files land already owned by whoever ran the command).
+  mkRenameScript =
+    {
+      name,
+      seedboxPath,
+      stagingDir,
+      db,
+      outputDir,
+    }:
+    pkgs.writeShellApplication {
+      inherit name;
+      runtimeInputs = runtimeDeps;
+      text = ''
+        MEDIA_ROOT="${cfg.mediaRoot}"
+        STAGING="$MEDIA_ROOT/_staging/${stagingDir}"
+
+        echo "Getting Files"
+        cd "$STAGING"
+        rsync --progress -avze ssh "${cfg.seedboxHost}:${seedboxPath}" ./
+
+        echo "Renaming Files"
+        filebot -r -rename "$STAGING" --format "{plex}" --db ${db} --lang en \
+          --action copy --conflict override --output "$MEDIA_ROOT/${outputDir}" -non-strict
+
+        echo "Cleaning up staging files"
+        find "$STAGING" -mindepth 1 -delete
+      '';
+    };
+
+  dlm = mkRenameScript {
+    name = "dlm";
+    seedboxPath = "/media/sdi1/msgedme/private/deluge/data/dlm/";
+    stagingDir = "process-m";
+    db = "themoviedb";
+    outputDir = "Movies";
+  };
+
+  dltv = mkRenameScript {
+    name = "dltv";
+    seedboxPath = "/media/sdi1/msgedme/private/deluge/data/dl/";
+    stagingDir = "process";
+    db = "thetvdb";
+    outputDir = "TV Shows";
+  };
+in
+{
+  options.apps.cli.media-rename = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Install dlm/dltv: pull new movies/TV from the seedbox and rename them
+        into the Jellyfin library with filebot. Replaces the old
+        Docker-based (rednoah/filebot) versions of these scripts.
+      '';
+    };
+
+    seedboxHost = lib.mkOption {
+      type = lib.types.str;
+      default = "msgedme@prometheus.feralhosting.com";
+      description = "SSH target for the seedbox rsync pull.";
+    };
+
+    mediaRoot = lib.mkOption {
+      type = lib.types.str;
+      default = "/home/dustin/data-disk/media";
+      description = ''
+        Root of the local media tree. Expects `$mediaRoot/_staging/process`
+        and `$mediaRoot/_staging/process-m` to already exist.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      dlm
+      dltv
+    ];
+  };
+}


### PR DESCRIPTION
## Summary
- New module: modules/apps/cli/media-rename, following the same writeShellApplication pattern as apps.cli.aha-fr-report.
- dlm and dltv become real, version-controlled, shellcheck-clean packages installed on PATH, replacing the loose hand-edited scripts previously living directly in $HOME with no history.
- Also simplifies the actual rename logic: filebot now runs natively (installed via #154) against the local media tree instead of through a Docker container or an ad-hoc k8s Job — the media is already local to srv, so there's no NFS round-trip, no Docker, and no chown step needed.

## Test plan
- [x] `nixos-rebuild build --impure --flake ".#srv"` succeeds (includes shellcheck via writeShellApplication)
- [x] Inspected the built `dlm` script content — correct PATH wiring, correct rsync/filebot invocation
- [ ] After deploy: `dlm`/`dltv` on PATH, filebot license imported, live test with real seedbox content