### PR TITLE
feat(render-secrets): materialize FileBot license from 1Password

### DIFF
--- a/extras/docs/secrets.md
+++ b/extras/docs/secrets.md
@@ -123,12 +123,14 @@ Current MATERIALIZE entries:
 | `mixerator-`, `nixcfg-`, `nixerator-`, `talos-vms-git-crypt-key` | `~/.ssh/<name>` | 0600 | workstation hosts |
 | `incus-ui.crt` | `~/.config/incus/client.crt` | 0644 | all hosts |
 | `incus-ui.pfx` | `~/.config/incus/client.pfx` | 0600 | workstation hosts |
+| `filebot-license` | `~/.local/share/filebot/data/.license` | 0600 | all hosts (unused outside srv) |
 
 Current PUSH_ALONGSIDE entries (also pushed to remotes by `--push`):
 
 | Local path | Remote mode | Why |
 |------------|-------------|-----|
 | `~/.config/incus/client.crt` | 0644 | Needed at Nix eval time on every Incus host so `builtins.readFile` in the incus module can populate the preseed trust store |
+| `~/.local/share/filebot/data/.license` | 0600 | srv is headless (no 1Password CLI); the license only reaches it via `--push` from a workstation that materialized it locally |
 
 "Workstation hosts" are those with `archetypes.workstation.enable = true`
 (donkeykong, nixerator, qbert), matched by the `host:` guard. The pure server
@@ -232,6 +234,7 @@ Names are pinned — they must match `secrets.json.tpl` exactly.
 | `gmailctl` | Login | `Client ID` + `Client Secret` | `~/.gmailctl/credentials.json` (via `just fetch-gmailctl-creds`, which `op inject`s the two fields into a Desktop-app credentials.json template). Rendered straight to disk, **not** in `secrets.json` — keeps the client secret out of the Nix store. `gmailctl init` then writes `~/.gmailctl/token.json` locally. |
 | `incus-ui.crt` | Document | `file` | `~/.config/incus/client.crt` on all hosts (via `render-secrets` MATERIALIZE, 0644). Public certificate read by the Incus module via `builtins.readFile` at Nix eval time and injected into the preseed trust store. All Incus hosts; safe to be world-readable. |
 | `incus-ui.pfx` | Document | `file` | `~/.config/incus/client.pfx` on workstations (via `render-secrets` MATERIALIZE, 0600). PKCS12 bundle with private key; import into a browser to authenticate against any Incus web UI. Workstations only — srv is headless. |
+| `filebot-license` | Document | `file` | `~/.local/share/filebot/data/.license` on srv (via `render-secrets` MATERIALIZE + PUSH_ALONGSIDE, 0600). FileBot lifetime license (`.psm`) used by `dlm`/`dltv` (`modules/apps/cli/media-rename`) to rename/organize media. Materializes on any host running `render-secrets` but is only meaningful on srv, which gets it via `just push-secrets srv`. |
 
 Per-host network identity (Tailscale IPs, syncthing peer IDs) is NOT in 1P;
 those values live in `settings/globals.nix` under

--- a/modules/apps/cli/render-secrets/render-secrets.sh
+++ b/modules/apps/cli/render-secrets/render-secrets.sh
@@ -77,6 +77,13 @@ MATERIALIZE=(
   # Workstations only: needed for importing into a browser to authenticate
   # against the Incus web UI. srv is headless and has no browser.
   "incus-ui.pfx|${HOME}/.config/incus/client.pfx|600|700|${_WS}"
+
+  # FileBot lifetime license. Materializes here on any host that runs
+  # render-secrets (unused outside srv, same pattern as incus-ui.crt above)
+  # so PUSH_ALONGSIDE below has a local source file to scp to srv, the only
+  # host that runs filebot (modules/apps/cli/media-rename). Dest path matches
+  # nixpkgs' filebot package.nix substituteInPlace of APP_DATA/.license.
+  "filebot-license|${HOME}/.local/share/filebot/data/.license|600|700|"
 )
 
 # Files pushed alongside secrets.json when --push is used. Format per entry:
@@ -90,6 +97,11 @@ PUSH_ALONGSIDE=(
   # so builtins.readFile in the incus module can populate the preseed trust
   # store. MATERIALIZE places it locally; PUSH_ALONGSIDE carries it to peers.
   "${HOME}/.config/incus/client.crt|644"
+
+  # FileBot lifetime license: srv is headless (no 1Password CLI, never runs
+  # render-secrets directly), so it only gets the license via --push from a
+  # workstation that materialized it locally above.
+  "${HOME}/.local/share/filebot/data/.license|600"
 )
 
 usage() {


### PR DESCRIPTION
## Summary
- Adds `filebot-license` as a Document-backed `MATERIALIZE` + `PUSH_ALONGSIDE` entry in `render-secrets.sh`, mirroring the existing `incus-ui.crt` pattern
- Materializes locally on any host running `render-secrets`, then reaches srv (the only host running filebot) via `just push-secrets srv`
- Dest path (`~/.local/share/filebot/data/.license`) matches nixpkgs' `filebot` package.nix substitution of `APP_DATA/.license`
- Updates `extras/docs/secrets.md` MATERIALIZE/PUSH_ALONGSIDE/item tables to document the new entry

## Context
FileBot's valid license was identified on srv (`FileBot_Lifetime_License-filebot_noffin_com.psm`, valid until 2073) and is already active at the canonical path. This PR replaces the manually-copied `_staging/filebot-license` file with declarative 1Password-backed rendering, matching how SSH keys and the Incus client cert are already handled.

## Test plan
- [x] `bash -n render-secrets.sh` passes
- [x] `nix build .#nixosConfigurations.srv.config.system.build.toplevel --dry-run --impure` evaluates cleanly
- [ ] Upload `FileBot_Lifetime_License-filebot_noffin_com.psm` as a Document item titled `filebot-license` to the `nixerator` 1Password vault (manual step — requires write access I don't have)
- [ ] `just push-secrets srv` from a workstation and confirm the license lands at the right path/mode on srv