### PR TITLE
fix(render-secrets): repoint stale op service-account item reference

### DIFF
--- a/secrets.json.tpl
+++ b/secrets.json.tpl
@@ -67,7 +67,7 @@
     "opToken": "{{ op://nixerator/noclaw-op-token/credential }}"
   },
   "onepassword": {
-    "serviceAccountToken": "{{ op://nixerator/ijut33dfmteltpb4qe52votusq/credential }}"
+    "serviceAccountToken": "{{ op://nixerator/6k3rotvuocczmaxrquy62yl7mi/credential }}"
   },
   "grafana": {
     "dashboardsToken": "{{ op://automation/grafana-cloud-dashboards/token }}"


### PR DESCRIPTION
## Summary
- `secrets.json.tpl` pinned the day-to-day `OP_SERVICE_ACCOUNT_TOKEN` to `op://nixerator/ijut33dfmteltpb4qe52votusq/credential`, an item ("Desktop-Secrets-Automation-RO") that hasn't been touched in over a year — the underlying service account has since been deleted/rotated.
- Every `render-secrets` run kept re-baking that dead token into `secrets.json`, so every new shell's `op` CLI failed with `403 Forbidden (Service Account Deleted)` until `op-toggle` fell back to desktop biometric auth.
- Repoints the template to `op://nixerator/6k3rotvuocczmaxrquy62yl7mi/credential` ("Service Account Auth Token: op-cli"), the current live token.

## Test plan
- [x] Rendered secrets locally with the fixed template (`render-secrets --tpl ./secrets.json.tpl`)
- [x] Verified the newly rendered `onepassword.serviceAccountToken` authenticates successfully (`op whoami` → `SERVICE_ACCOUNT`, same Integration ID as the known-good bootstrap token)
- [ ] After merge: `just push-secrets qbert donkeykong srv` to propagate the corrected `secrets.json` to other hosts