### PR TITLE
fix(core): disable NetworkManager WiFi power-saving

### DIFF
--- a/modules/suites/core/default.nix
+++ b/modules/suites/core/default.nix
@@ -76,7 +76,15 @@ in
 
     # Networking defaults
     networking = {
-      networkmanager.enable = lib.mkDefault true;
+      networkmanager = {
+        enable = lib.mkDefault true;
+        # WiFi power-saving drops/delays inbound frames (including TCP SYNs)
+        # while the radio dozes between beacon intervals, breaking anything
+        # that expects this host to be reliably reachable from LAN peers
+        # (e.g. LocalSend discovery/transfer on 53317). No effect on wired
+        # NICs, so safe as a suite-wide default.
+        wifi.powersave = lib.mkDefault false;
+      };
       firewall = {
         enable = lib.mkDefault true;
         allowedTCPPorts = lib.mkDefault [ 22 ]; # SSH


### PR DESCRIPTION
## Summary
- `wlo1` on qbert had WiFi power management on (`iwconfig` showed `Power Management:on`; NetworkManager's `802-11-wireless.powersave` was unset/"default", so it deferred to the driver's own default).
- This causes the radio to silently drop or delay inbound frames — including TCP SYNs — while dozing between beacon intervals, so anything expecting this host to be reliably reachable from LAN peers breaks intermittently.
- Root-caused via LocalSend: the phone couldn't discover qbert over LAN, and a direct-IP HTTPS request from the phone to `https://<qbert-ip>:53317/api/localsend/v1/info` timed out at the TCP layer — not a discovery-protocol issue, an actual reachability issue. Toggling power management off live (`iwconfig wlo1 power off`) fixed it immediately.
- Sets `networking.networkmanager.wifi.powersave = false` in `suites/core` (shared by all workstation hosts via the `workstation` archetype). No effect on wired NICs, so safe as a shared default.

## Test plan
- [x] `just build-host qbert` — builds cleanly, diff shows the expected `NetworkManager.conf` rebuild
- [x] Verified live on qbert: `iwconfig wlo1 power off` immediately fixed phone → qbert reachability (pending user confirmation phone-side)
- [ ] After merge + rebuild: confirm `iwconfig wlo1` shows `Power Management:off` persists across reboot