### PR TITLE
fix(render-secrets): repoint service-account item reference to new op-cli SA

### DIFF
--- a/secrets.json.tpl
+++ b/secrets.json.tpl
@@ -67,7 +67,7 @@
     "opToken": "{{ op://nixerator/noclaw-op-token/credential }}"
   },
   "onepassword": {
-    "serviceAccountToken": "{{ op://nixerator/6k3rotvuocczmaxrquy62yl7mi/credential }}"
+    "serviceAccountToken": "{{ op://nixerator/zm7ky22lk75tfi4absvvfewd3q/credential }}"
   },
   "grafana": {
     "dashboardsToken": "{{ op://automation/grafana-cloud-dashboards/token }}"


### PR DESCRIPTION
## Summary
- \`onepassword.serviceAccountToken\` in \`secrets.json.tpl\` pointed at \`op://nixerator/6k3rotvuocczmaxrquy62yl7mi/credential\`, set earlier today in #161. That item was superseded again — a fresh service account was generated directly in the 1Password web UI after repeated confusion/staleness during today's rotation.
- Repoints to the new item: \`op://nixerator/zm7ky22lk75tfi4absvvfewd3q/credential\`.

## Test plan
- [ ] \`op vault list\` with the new SA token shows both \`nixerator\` and \`automation\`
- [ ] \`just render-secrets\` succeeds end to end
- [ ] \`just push-secrets\` to affected hosts confirms auth restored