### PR TITLE
feat(secrets): add just rotate-op-token to guide SA rotation end to end

### DIFF
--- a/extras/docs/helpers.md
+++ b/extras/docs/helpers.md
@@ -103,9 +103,11 @@ on a host, `render-secrets`, `render-secrets-bootstrap.sh`, and the justfile
 recipes all run with no biometric prompts.
 
 **Prerequisites**: Nix with flakes. The default path (preferred) needs
-1Password CLI signed in (`op signin`) and Personal vault read access. The
-helper does `op read op://Personal/<item>/credential` to fetch the SA token
-once, triggering one desktop-biometric prompt.
+1Password CLI signed in (`op signin`) and read access to the item
+`secrets.json.tpl`'s `onepassword.serviceAccountToken` points at. The helper
+extracts that `op://` reference from the template itself (rather than
+hardcoding its own copy) and does one `op read`, triggering one
+desktop-biometric prompt.
 
 ```bash
 # Recommended -- fetch the SA token from your Personal vault:
@@ -125,8 +127,12 @@ Idempotent: if the existing token matches the input, the helper just repairs
 perms and exits success. Refuses to replace a different existing token unless
 `--force`. Refuses any input that doesn't start with `ops_`.
 
-**Token rotation**: regenerate the SA in 1Password, update the Personal
-vault item, then re-run with `--force` on each host.
+**Token rotation**: don't run this script by hand for a rotation — use
+`just rotate-op-token` (below). Rotating just the token value is
+straightforward with this script alone (regenerate in 1Password, update the
+item, `--force` on each host), but a full SA regeneration also needs the
+render-secrets/op-toggle sequence the rotate script automates; doing it by
+hand is exactly what caused a multi-hour outage the first time.
 
 **Live-USB use** (writes from root into the target user's home, before
 `nixos-install`):
@@ -138,6 +144,51 @@ sudo ./extras/helpers/setup-op-service-account.sh \
 
 The `bootstrap-install-secrets.sh stage` subcommand wraps this for you
 along with the corresponding secrets render.
+
+## rotate-op-service-account.sh
+
+Walks through rotating (or fully regenerating) the nixerator 1Password
+service account, end to end, on the host you run it from. This exists
+because rotating by hand is failure-prone in a specific, non-obvious way:
+
+- The token has to agree in three places: the SA's own vault grants
+  (`nixerator` + `automation`), the 1Password item `secrets.json.tpl` /
+  `setup-op-service-account.sh` read from, and the local file at
+  `~/.config/op/service-account-token` on this host.
+- `op-toggle`'s "back to service-account" path reads its token from the
+  *rendered* `secrets.json`, not that local file. Until you've rendered at
+  least once with an **explicit** token override, a successful rotation
+  still looks broken — every command keeps re-loading the stale, dead
+  token baked into the old render, and the error ("Service Account
+  Deleted") gives no hint that the fix already worked.
+
+```bash
+just rotate-op-token             # op read (default, preferred)
+just rotate-op-token --manual    # interactive paste
+# or directly:
+./extras/helpers/rotate-op-service-account.sh
+```
+
+What it does:
+
+1. Prints the manual 1Password steps (rotate/regenerate the SA, confirm
+   both vault grants, update the credential item) and waits for Enter.
+2. Installs the token locally via `setup-op-service-account.sh --force`.
+3. Renders `secrets.json` with `OP_SERVICE_ACCOUNT_TOKEN` set explicitly
+   from the just-installed file — bypassing `op-toggle` entirely, so the
+   fresh token is what actually lands in the render.
+4. Verifies with `op whoami` / `op vault list` (metadata only, never prints
+   the token) and warns if any secrets.json field known to need the
+   `automation` vault came back empty.
+5. Prints — but does not run — the `just push-secrets <hosts>` command to
+   propagate to the rest of the fleet. Fleet propagation is left as a
+   deliberate manual step.
+
+If a full SA regeneration produced a *new* 1Password item (not just a new
+token value in the existing item), update `secrets.json.tpl`'s
+`onepassword.serviceAccountToken` reference first — the script re-reads the
+template on each run, so both it and `setup-op-service-account.sh` pick up
+the new item automatically once the template is updated.
 
 ## render-secrets-bootstrap.sh
 

--- a/extras/docs/secrets.md
+++ b/extras/docs/secrets.md
@@ -69,6 +69,26 @@ This mirrors the identical global rule in `~/.claude/CLAUDE.md`.
 
 All three are idempotent — safe to re-run any time.
 
+## Rotating the service account
+
+Don't rotate the SA token by hand — use `just rotate-op-token` (alias
+`rot`). Rotating it manually is failure-prone: the token has to agree
+across the SA's own vault grants, the 1Password item the template reads
+from, and the local file on each host, and `op-toggle` reads its
+service-account fallback from the *rendered* `secrets.json` rather than
+that local file — so a stale render makes a successful rotation look like
+it silently didn't take (you'll see `(403) Forbidden (Service Account
+Deleted)` even though the new token is fine).
+
+```bash
+just rotate-op-token             # walks the full sequence, one host
+```
+
+See `extras/docs/helpers.md`'s `rotate-op-service-account.sh` section for
+what it does step by step. It prints — but does not run — the
+`push-secrets` command for the rest of the fleet; run that yourself once
+you're happy with the verification output.
+
 ## Materialized host files
 
 Besides the rendered `secrets.json`, `render-secrets` restores a small set of

--- a/extras/helpers/rotate-op-service-account.sh
+++ b/extras/helpers/rotate-op-service-account.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Walks through rotating the nixerator 1Password service-account token,
+# end to end, on THIS host. Rotating this token by hand is failure-prone:
+# the token has to agree in three places --
+#   1. The 1Password service account's own vault grants (nixerator +
+#      automation).
+#   2. The 1Password item secrets.json.tpl / setup-op-service-account.sh
+#      read from (onepassword.serviceAccountToken).
+#   3. The local file at ~/.config/op/service-account-token on this host.
+# -- and `op-toggle`'s "back to service-account" path reads its token from
+# the RENDERED secrets.json, not that local file. Until you've rendered at
+# least once with an EXPLICIT token override, a successful rotation still
+# looks broken (every command keeps re-loading the stale, dead token from
+# the old render).
+#
+# This script:
+#   1. Prints the manual 1Password steps and waits for you to do them.
+#   2. Installs the token locally (setup-op-service-account.sh --force).
+#   3. Renders secrets.json with an EXPLICIT token override -- bypassing
+#      op-toggle entirely, so step 2's fresh token is what actually lands.
+#   4. Verifies auth and reports which vaults are visible (metadata only --
+#      never prints token/secret values).
+#   5. Prints (does not run) the push-secrets command for the fleet.
+#
+# Usage:
+#   ./extras/helpers/rotate-op-service-account.sh            # op read (biometric)
+#   ./extras/helpers/rotate-op-service-account.sh --manual   # paste instead
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TPL="${REPO_ROOT}/secrets.json.tpl"
+CANONICAL="${HOME}/.config/op/service-account-token"
+SECRETS_FILE="${HOME}/.config/nixos-secrets/secrets.json"
+
+PASSTHROUGH_ARGS=()
+for a in "$@"; do
+  case "$a" in
+    --manual)
+      PASSTHROUGH_ARGS+=(--manual)
+      ;;
+    -h | --help)
+      sed -n '4,29p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "rotate-op-service-account: unknown arg: $a" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f "${TPL}" ]]; then
+  echo "rotate-op-service-account: ${TPL} not found -- run from a nixerator checkout." >&2
+  exit 1
+fi
+
+item_ref="$(sed -n 's#.*"serviceAccountToken": *"{{ *\(op://[^ ]*\) *}}".*#\1#p' "${TPL}")"
+if [[ -z "${item_ref}" ]]; then
+  echo "rotate-op-service-account: couldn't find onepassword.serviceAccountToken in ${TPL}" >&2
+  exit 1
+fi
+
+cat <<EOF
+
+=== Step 1 of 4: rotate the service account in 1Password ===
+
+In the 1Password web UI (Developer Tools -> the current SA, e.g. op-cli):
+
+  a. Rotate the token. If the old service account is unrecoverable, generate
+     a brand-new one instead -- if you do, update the op:// reference in
+       ${TPL}
+     ("onepassword.serviceAccountToken") to the new item BEFORE continuing,
+     and re-run this script (it re-reads the template each time).
+  b. Confirm the service account is granted READ on BOTH vaults:
+       - nixerator
+       - automation
+  c. Update the credential field at:
+       ${item_ref}
+     with the new token value. This is the ONLY 1Password item that needs
+     updating -- setup-op-service-account.sh reads from this same reference.
+
+Press Enter once all three are done...
+EOF
+read -r _
+
+echo
+echo "=== Step 2 of 4: install the token locally ==="
+echo
+"${SCRIPT_DIR}/setup-op-service-account.sh" --force "${PASSTHROUGH_ARGS[@]}"
+
+if [[ ! -f "${CANONICAL}" ]]; then
+  echo "rotate-op-service-account: ${CANONICAL} still missing after install -- aborting." >&2
+  exit 1
+fi
+
+echo
+echo "=== Step 3 of 4: render secrets.json (explicit token, bypassing op-toggle) ==="
+echo
+if ! command -v render-secrets >/dev/null 2>&1; then
+  echo "rotate-op-service-account: 'render-secrets' not on PATH." >&2
+  echo "  On a fresh host before the first rebuild, use render-secrets-bootstrap.sh instead." >&2
+  exit 1
+fi
+OP_SERVICE_ACCOUNT_TOKEN="$(<"${CANONICAL}")" render-secrets
+
+echo
+echo "=== Step 4 of 4: verify ==="
+echo
+OP_SERVICE_ACCOUNT_TOKEN="$(<"${CANONICAL}")" op whoami
+echo
+echo "Vaults visible to this token:"
+OP_SERVICE_ACCOUNT_TOKEN="$(<"${CANONICAL}")" op vault list
+
+missing=()
+for key in .grafana.dashboardsToken .onepassword.serviceAccountToken; do
+  present="$(jq -r "(${key} // \"\") != \"\"" "${SECRETS_FILE}" 2>/dev/null || echo false)"
+  [[ "${present}" == "true" ]] || missing+=("${key}")
+done
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo
+  echo "WARNING: these fields are empty in ${SECRETS_FILE}: ${missing[*]}" >&2
+  echo "  (values not shown -- checked for presence only)" >&2
+fi
+
+cat <<EOF
+
+Rotation complete on this host. op-toggle should now work normally -- it
+reads its "back to service-account" token from the secrets.json we just
+re-rendered.
+
+Next: propagate to the rest of the fleet, e.g.:
+  just push-secrets donkeykong srv clanker
+(this script does not push automatically -- run that yourself once you're
+happy with the verification above.)
+EOF

--- a/extras/helpers/setup-op-service-account.sh
+++ b/extras/helpers/setup-op-service-account.sh
@@ -13,17 +13,26 @@
 # auto-source from the file with NO further biometric prompts -- this
 # helper's one `op read` is the only biometric you'll see.
 #
-# How it works: the SA token itself is stored in your Personal 1Password
-# vault. We use `op read` to fetch it via the desktop biometric session,
-# then atomically install it at the canonical path with 0600 perms.
+# How it works: the SA token itself is stored in 1Password at the SAME
+# item secrets.json.tpl's onepassword.serviceAccountToken reads from --
+# this script extracts that op:// reference from the template rather than
+# hardcoding its own copy, so there's one place to update when the item
+# changes (e.g. a full SA regeneration, not just a token rotation). We use
+# `op read` to fetch it via the desktop biometric session, then atomically
+# install it at the canonical path with 0600 perms.
+#
+# Rotating the token? Use `just rotate-op-token` instead of running this
+# script by hand -- it walks the full sequence (1Password steps, install,
+# an explicit-token render that bypasses op-toggle's chicken-and-egg
+# fallback, and verification) end to end.
 #
 # Usage (preferred path):
 #   ./extras/helpers/setup-op-service-account.sh
 #     Requires: 1Password CLI on PATH (nix-shell pulls it), signed-in
-#     desktop session (`op signin`), read access to the Personal vault
-#     item below.
+#     desktop session (`op signin`), read access to the item
+#     secrets.json.tpl's onepassword.serviceAccountToken points at.
 #
-# Override the source reference (e.g. token moved to another vault):
+# Override the source reference (e.g. testing against a different item):
 #   OP_TOKEN_REF=op://Vault/Item/field ./extras/helpers/setup-op-service-account.sh
 #
 # Bypass `op read` and paste / pipe / env-supply the token directly --
@@ -46,10 +55,17 @@ set -euo pipefail
 # --dest for live-USB bootstrap (writing into /home/dustin/... from root).
 DEST="${HOME}/.config/op/service-account-token"
 
-# Canonical reference for the SA token in 1Password. Pinned to the item ID
-# (not name) so renames don't break this script.
-TOKEN_REF_DEFAULT="op://Personal/r6auiogd4j3xaapmfn6bh7ul6m/credential"
-TOKEN_REF="${OP_TOKEN_REF:-${TOKEN_REF_DEFAULT}}"
+# Canonical reference for the SA token in 1Password. Derived from
+# secrets.json.tpl's own onepassword.serviceAccountToken entry (pinned to
+# an item ID there, not a name) so this script and the template can never
+# drift to two different items. OP_TOKEN_REF still overrides explicitly.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TPL_DEFAULT="${SCRIPT_DIR}/../../secrets.json.tpl"
+TOKEN_REF_FROM_TPL=""
+if [[ -f "${TPL_DEFAULT}" ]]; then
+  TOKEN_REF_FROM_TPL="$(sed -n 's#.*"serviceAccountToken": *"{{ *\(op://[^ ]*\) *}}".*#\1#p' "${TPL_DEFAULT}")"
+fi
+TOKEN_REF="${OP_TOKEN_REF:-${TOKEN_REF_FROM_TPL}}"
 
 MANUAL=0
 FORCE=0
@@ -73,7 +89,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     -h | --help)
-      sed -n '4,38p' "$0"
+      sed -n '4,50p' "$0"
       exit 0
       ;;
     *)
@@ -109,6 +125,11 @@ read_token() {
     read -r t
   else
     # Default: fetch via `op read` (one biometric prompt on the desktop).
+    if [[ -z "${TOKEN_REF}" ]]; then
+      echo "setup-op-service-account: couldn't find onepassword.serviceAccountToken in ${TPL_DEFAULT}" >&2
+      echo "  Set OP_TOKEN_REF=op://Vault/Item/field explicitly, or use --manual / OP_TOKEN= / stdin." >&2
+      exit 1
+    fi
     if ! op whoami >/dev/null 2>&1; then
       echo "setup-op-service-account: 'op' not signed in." >&2
       echo "  Run:  op signin" >&2

--- a/justfile
+++ b/justfile
@@ -891,18 +891,36 @@ check-secrets:
 # (0600), so render-secrets / push-secrets / check-secrets run with zero
 # biometric prompts thereafter. One-time per host.
 #
-# Default behaviour: `op read` fetches the token from your Personal vault
-# (one biometric on the desktop). Pass-through args support the helper's
-# alternate inputs:
+# Default behaviour: `op read` fetches the token from the same 1Password item
+# secrets.json.tpl's onepassword.serviceAccountToken points at (one biometric
+# on the desktop). Pass-through args support the helper's alternate inputs:
 #
 #   just setup-op-token                            # op read (default, preferred)
 #   just setup-op-token --manual                   # interactive paste
 #   just setup-op-token --force                    # overwrite an existing different token
 #   OP_TOKEN=ops_... just setup-op-token           # from env var (no prompts)
 #
+# Rotating the token, not just re-installing it on a new host? Use
+# `just rotate-op-token` instead -- see below.
+#
 # See extras/docs/helpers.md for the full helper docs.
 setup-op-token *args:
     @./extras/helpers/setup-op-service-account.sh {{args}}
+
+# Walks through rotating the nixerator 1Password service-account token,
+# end to end, on this host: prints the manual 1Password steps and waits,
+# installs the new token locally, renders secrets.json with an EXPLICIT
+# token override (bypassing op-toggle's chicken-and-egg fallback to a
+# stale render), then verifies auth and reports which vaults are visible.
+# Does NOT push to the fleet automatically -- it prints that command for
+# you to run once you're happy with the verification output.
+#
+#   just rotate-op-token             # op read (default, preferred)
+#   just rotate-op-token --manual    # interactive paste
+#
+# See extras/docs/helpers.md for the full helper docs.
+rotate-op-token *args:
+    @./extras/helpers/rotate-op-service-account.sh {{args}}
 
 # Pre-rebuild bootstrap render: writes ~/.config/nixos-secrets/secrets.json
 # WITHOUT needing render-secrets on PATH yet. Use ONLY on a fresh machine
@@ -954,6 +972,7 @@ alias rs := render-secrets
 alias ps := push-secrets
 alias cs := check-secrets
 alias fs := fetch-signatures
+alias rot := rotate-op-token
 alias fgc := fetch-gmailctl-creds
 alias fgck := fetch-gmailctl-creds-kong
 alias gen := generations


### PR DESCRIPTION
## Summary
- Today's SA rotation took hours because the token has to agree across three places (SA vault grants, the 1Password item the template reads from, and the local file on each host), and `op-toggle`'s service-account fallback reads from the *rendered* `secrets.json` rather than that local file — so a fixed token still threw `403 Forbidden (Service Account Deleted)` until an explicit-token render happened, with nothing prompting for it.
- Adds `extras/helpers/rotate-op-service-account.sh`, wired up as `just rotate-op-token` (alias `rot`): prints the manual 1Password steps and waits, installs the token locally, renders once with an explicit token override (bypassing `op-toggle`), verifies auth + vault visibility (metadata only, never prints secret values), and prints — without running — the `push-secrets` command for the fleet.
- Consolidates `setup-op-service-account.sh`'s default token source: it previously hardcoded a separate `Personal`-vault item that could (and did) drift from the item `secrets.json.tpl` actually uses. It now extracts the `op://` reference from `secrets.json.tpl` directly, so there's one place to update instead of two.
- Updates `extras/docs/helpers.md` and `extras/docs/secrets.md` accordingly.

## Test plan
- [x] `bash -n` on both scripts
- [x] `just --list` shows the new recipe/alias and parses cleanly
- [x] Manually verified the `sed` extraction against the live `secrets.json.tpl` returns the correct current item reference
- [ ] Run `just rotate-op-token` for a real rotation on a second host to confirm the end-to-end flow