### PR TITLE
feat(aha-fr-report): add requester Team column to Sheet and PDF

### DIFF
--- a/modules/apps/cli/aha-fr-report/scripts/fetch-ideas.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/fetch-ideas.sh
@@ -9,9 +9,10 @@
 #
 # Prints the merged ideas JSON array on stdout -- each element gains: rank,
 # production_blocker, target_release, use_case, source_url, notes,
-# internal_discussion_url, requester_name, requester_email. Every one of
-# those is independently nullable -- an untracked idea, or a customer with
-# no upsight-go data at all, just gets all-null fields, not an error.
+# internal_discussion_url, requester_name, requester_email, team_name.
+# Every one of those is independently nullable -- an untracked idea, or a
+# customer with no upsight-go data at all, just gets all-null fields, not
+# an error.
 #
 # Row order (shared by both the Sheet and the PDF, since both consume this
 # script's output directly): Open ideas first, Closed ideas last. Within
@@ -64,12 +65,13 @@ echo "$ideas_json" | jq --argjson tracking "$tracking_json" '
      target_release: (.target_release // null), use_case: (.use_case // null),
      source_url: (.source_url // null), notes: (.notes // null),
      internal_discussion_url: (.internal_discussion_url // null),
-     requester_name: (.requester_name // null), requester_email: (.requester_email // null)
+     requester_name: (.requester_name // null), requester_email: (.requester_email // null),
+     team_name: (.team_name // null)
    })) as $tracking
   | map(. + ($tracking[.ref] // {
       rank: null, production_blocker: null, target_release: null, use_case: null,
       source_url: null, notes: null, internal_discussion_url: null,
-      requester_name: null, requester_email: null
+      requester_name: null, requester_email: null, team_name: null
     }))
   | sort_by([
       (if .state == "open" then 0 else 1 end),

--- a/modules/apps/cli/aha-fr-report/scripts/idea-tracking-lookup.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/idea-tracking-lookup.sh
@@ -13,11 +13,13 @@
 #                "source_url": "https://...", "notes": "...",
 #                "internal_discussion_url": "https://kong.slack.com/...",
 #                "requester_name": "Chris Fulara",
-#                "requester_email": "chris.fulara@example.com"}, ...}
+#                "requester_email": "chris.fulara@example.com",
+#                "team_name": "Platform Engineering"}, ...}
 # Every field is independently nullable -- an idea with only a rank set (or
 # nothing at all) is just missing the other keys' values, not an error.
-# requester_name/requester_email are resolved from upsight-go's contacts
-# table via idea_ranks.requester_contact_id, not stored as free text.
+# requester_name/requester_email/team_name are resolved from upsight-go's
+# contacts (and, for team_name, teams) tables via
+# idea_ranks.requester_contact_id, not stored as free text.
 #
 # Schema dependency: this reads seven columns added to idea_ranks by
 # bashfulrobot/upsight-go#60 (requester_contact_id, production_blocker,
@@ -28,6 +30,9 @@
 # degrades to "{}" on any SQLite error (including "no such column"), same
 # as every other graceful-miss path here, so running against an
 # un-migrated database just means blank cells, not a broken report.
+# team_name has no idea_ranks column of its own -- it's derived the same way
+# upsight-go#65 derives it in the app UI: requester_contact_id ->
+# contacts.team_id -> teams.id -> teams.team_name.
 #
 # Degrades to "{}" (non-fatal) when sqlite3 isn't on PATH, the upsight
 # database doesn't exist, the schema predates upsight-go#60/#61, or none of
@@ -75,11 +80,13 @@ sqlite3 -readonly -json "$UPSIGHT_DB" "
     ir.notes                            AS notes,
     ir.internal_discussion_url          AS internal_discussion_url,
     c.first_name || ' ' || c.last_name  AS requester_name,
-    c.email                             AS requester_email
+    c.email                             AS requester_email,
+    t.team_name                         AS team_name
   FROM idea_ranks ir
   JOIN aha_idea_cache aic ON aic.id = ir.aha_idea_id
   JOIN accounts acc ON acc.id = ir.account_id
   LEFT JOIN contacts c ON c.id = ir.requester_contact_id
+  LEFT JOIN teams t ON t.id = c.team_id
   WHERE acc.aha_organization_id IN (${placeholders})
     AND (ir.rank IS NOT NULL
          OR ir.production_blocker IS NOT NULL

--- a/modules/apps/cli/aha-fr-report/scripts/render_report.py
+++ b/modules/apps/cli/aha-fr-report/scripts/render_report.py
@@ -215,6 +215,7 @@ def rows_html(items):
             f"<td>{esc(rank if rank is not None else '')}</td>"
             f"<td>{esc(it.get('use_case'))}</td>"
             f"<td>{esc(it.get('requester_name'))}</td>"
+            f"<td>{esc(it.get('team_name'))}</td>"
             f"<td>{esc(blocker_text(it.get('production_blocker')))}</td>"
             f"<td>{esc(it.get('target_release'))}</td>"
             f"<td>{esc(it.get('notes'))}</td>"
@@ -227,7 +228,7 @@ def rows_html(items):
 def section(title, items):
     if not items:
         return ""
-    headers = ("", "Ref", "Idea", "Status", "Stack Rank", "Use Case", "Requester",
+    headers = ("", "Ref", "Idea", "Status", "Stack Rank", "Use Case", "Requester", "Team",
                "Production Blocker", "Target Release", "Notes", "Total votes")
     head_html = "".join(f"<th>{esc(h)}</th>" for h in headers)
     return f"""

--- a/modules/apps/cli/aha-fr-report/scripts/write-customer-sheet.sh
+++ b/modules/apps/cli/aha-fr-report/scripts/write-customer-sheet.sh
@@ -14,7 +14,10 @@
 # Prints "sheet_id<TAB>sheet_url" on stdout when done.
 #
 # Columns written: State, Ref, Idea, Status, Stack Rank, Use Case,
-# Requester, Production Blocker, Target Release, Notes (all from
+# Requester, Team (the requester's configured team, derived from
+# upsight-go's contacts.team_id -> teams.id -> teams.team_name -- not a
+# free-text field, blank if the requester has no team set or there is no
+# requester), Production Blocker, Target Release, Notes (all from
 # upsight-go, blank if untracked -- see fetch-ideas.sh and
 # idea-tracking-lookup.sh), Aha Link (the idea's own public link, shown as
 # "View idea"), Proxy Vote Link (this customer's own org page in Aha, shown
@@ -86,7 +89,7 @@ echo "Got ${n} idea(s)." >&2
 # at the bottom, which Step 5 relies on to group/collapse them.
 timestamp="$(date -u +'%Y-%m-%d %H:%M UTC')"
 timestamp_row="$(jq -n --arg t "Last updated: ${timestamp}" '[$t]')"
-header='["State","Ref","Idea","Status","Stack Rank","Use Case","Requester","Production Blocker","Target Release","Notes","Aha Link","Proxy Vote Link","Source Link","Internal Discussion Link"]'
+header='["State","Ref","Idea","Status","Stack Rank","Use Case","Requester","Team","Production Blocker","Target Release","Notes","Aha Link","Proxy Vote Link","Source Link","Internal Discussion Link"]'
 open_count="$(echo "$ideas_json" | jq '[.[] | select(.state == "open")] | length')"
 closed_count="$(echo "$ideas_json" | jq '[.[] | select(.state != "open")] | length')"
 rows="$(echo "$ideas_json" | jq --argjson header "$header" --argjson timestamp_row "$timestamp_row" '
@@ -99,6 +102,7 @@ rows="$(echo "$ideas_json" | jq --argjson header "$header" --argjson timestamp_r
       (.rank // ""),
       (.use_case // ""),
       (.requester_name // ""),
+      (.team_name // ""),
       (if .production_blocker == 1 then "Yes" elif .production_blocker == 0 then "No" else "" end),
       (.target_release // ""),
       (.notes // ""),


### PR DESCRIPTION
## Summary

- Adds a **Team** column (after Requester) to both the internal Google Sheet and the customer-facing PDF, sourced from upsight-go.
- No idea_ranks schema change needed. Team is derived the same way upsight-go's own Org Chart does it: `idea_ranks.requester_contact_id -> contacts.team_id -> teams.id -> teams.team_name`. Verified against `internal/core/db/query.sql`'s `ListContactTeamMembers` comment, which states team_id (not the legacy free-text `contacts.team` column) is what the org chart actually uses to group people.
- Blank when the requester has no team set, or there's no requester at all -- same graceful-miss behavior as every other tracking field here.

## Test plan

- [x] `bash -n` on all three shell scripts, `python3 -m py_compile` on render_report.py
- [x] Extended the synthetic test DB with a `teams` table + `contacts.team_id`, confirmed `idea-tracking-lookup.sh` resolves `team_name` correctly for a tracked idea and stays null for an untracked one
- [x] Verified the `fetch-ideas.sh` jq merge and the Sheet row-building jq in isolation with sample data -- Team lands in the right column position
- [x] Verified `render_report.py` PDF HTML output includes the Team header and cell
- [x] Ran a full live `customer-fr-report.sh "HealthEquity"` against real Aha/Drive data end to end (11 ideas), confirmed the live Sheet header row now reads `...Requester, Team, Production Blocker...` in order
- [x] Confirmed against the real upsight.db (currently zero idea_ranks rows) that the query doesn't error on an empty result