### PR TITLE
fix(srv): drop the defunct jellyfin-config NFS export

### DIFF
--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -252,14 +252,6 @@
           uid = 1000;
           gid = 100;
         };
-        jellyfin-config = {
-          path = "/exports/jellyfin-config";
-          bindMount = "/home/dustin/docker/jellyfin-official";
-          clients = [ "192.168.168.0/23" ];
-          squash = "root_squash";
-          uid = 1000;
-          gid = 100;
-        };
       };
       additionalPaths = [
         {


### PR DESCRIPTION
Removes the `jellyfin-config` NFS export from srv. It bind-mounted `/exports/jellyfin-config` at `/home/dustin/docker/jellyfin-official`, the retired docker container's directory, which a docker cleanup on 2026-07-10 deleted. That left the export serving a stale NFS handle and put production config on an un-backed-up path.

Jellyfin's config moves to a dynamic `nfs-darkstar` PVC (homelab PR bashfulrobot/homelab#32), which lands under `/srv/nfs/darkstar` and is covered by the restic backup, so this export has no remaining consumer.

Rebuild ordering: apply this only after homelab #32 is merged and Jellyfin is healthy on the new PVC, so nothing is still mounting the old export when it goes away.