### PR TITLE
feat(srv): enable render-secrets so srv materializes its own keys

### DIFF
--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -21,6 +21,7 @@
     ../../modules/apps/cli/graymatter
     ../../modules/apps/cli/helix
     ../../modules/apps/cli/media-rename
+    ../../modules/apps/cli/render-secrets
     ../../modules/apps/cli/restic
     ../../modules/apps/cli/skillfish
     ../../modules/apps/cli/starship
@@ -55,6 +56,11 @@
     git.enable = true;
     helix.enable = true;
     media-rename.enable = true;
+    # srv renders its own document-backed secrets (feral-arr download-sync key,
+    # incus cert, filebot license) via its 1Password CLI, rather than only
+    # receiving them by `just push-secrets srv`. Needs a valid SA token on the
+    # host; see extras/docs/secrets.md.
+    render-secrets.enable = true;
     starship.enable = true;
     tailscale.enable = true;
 

--- a/modules/apps/cli/render-secrets/render-secrets.sh
+++ b/modules/apps/cli/render-secrets/render-secrets.sh
@@ -108,9 +108,10 @@ PUSH_ALONGSIDE=(
   # store. MATERIALIZE places it locally; PUSH_ALONGSIDE carries it to peers.
   "${HOME}/.config/incus/client.crt|644"
 
-  # FileBot lifetime license: srv is headless (no 1Password CLI, never runs
-  # render-secrets directly), so it only gets the license via --push from a
-  # workstation that materialized it locally above.
+  # FileBot lifetime license: kept here as a bootstrap-safe fallback so a
+  # workstation can seed srv before srv has rendered its own copy. srv now
+  # runs render-secrets itself (it has the 1Password CLI), so it normally
+  # materializes this locally; the push is harmless and idempotent.
   "${HOME}/.local/share/filebot/data/.license|600"
 )
 


### PR DESCRIPTION
## What

Enables `apps.cli.render-secrets` on `srv` (module import + `render-secrets.enable = true`), so `srv` renders its own document-backed secrets instead of only receiving them via `just push-secrets srv`.

## Why

`srv` already has the 1Password CLI (`programs._1password`), but never imported or enabled the `render-secrets` module. So `just render-secrets` on srv failed outright:

```
render-secrets: command not found
error: recipe `render-secrets` failed on line 858 with exit code 127
```

The `feral-arr` download-sync key's MATERIALIZE guard lists `srv`, but with no `render-secrets` binary there and no `PUSH_ALONGSIDE` entry, the key had no route to srv at all. This wires it up the clean way: srv fetches its own guarded files (feral-arr key, incus cert, filebot license) directly.

Also corrects the stale "srv is headless (no 1Password CLI)" comments in `render-secrets.sh` — srv has had the CLI since it became a `claudeWorkHost`.

## Verified

- `just build-host srv` cross-evaluates cleanly.
- `render-secrets` is present in the built srv closure (`sw/bin/render-secrets`), and its wrapped payload contains both `feral-arr` rows.

## Deploy steps after merge (need a human)

1. Merge to `main`.
2. Refresh srv's SA token (dead after the recent rotation): `just push-secrets srv` from qbert (carries the fresh `secrets.json`/token), or install the token on srv directly.
3. `just remote-rebuild srv` (srv pulls main, rebuilds, gets the binary).
4. On srv: `just render-secrets` → materializes `~/.ssh/feral-arr` + `feral-arr.pub`.