### PR TITLE
feat(rotate-op-token): sync token to 1Password item + self-check op-toggle

### DIFF
--- a/extras/docs/helpers.md
+++ b/extras/docs/helpers.md
@@ -161,6 +161,11 @@ because rotating by hand is failure-prone in a specific, non-obvious way:
   still looks broken — every command keeps re-loading the stale, dead
   token baked into the old render, and the error ("Service Account
   Deleted") gives no hint that the fix already worked.
+- The nastiest variant is **drift** between the 1Password item and the local
+  file: update one but not the other (easy across several rotations) and
+  op-toggle / `push-secrets` read the dead token forever, silently. The
+  script now writes the token to both itself and self-checks the op-toggle
+  path, so this can't pass unnoticed.
 
 ```bash
 just rotate-op-token             # op read (default, preferred)
@@ -172,17 +177,25 @@ just rotate-op-token --manual    # interactive paste
 What it does:
 
 1. Prints the manual 1Password steps (rotate/regenerate the SA, confirm
-   both vault grants, update the credential item) and waits for Enter.
+   both vault grants) and waits for Enter. You no longer update the
+   credential item by hand — step 3 does it.
 2. Installs the token locally via `setup-op-service-account.sh --force`.
-3. Renders `secrets.json` with `OP_SERVICE_ACCOUNT_TOKEN` set explicitly
+3. Writes that same token into the 1Password item the template reads from,
+   using your desktop session (one biometric prompt) — a blind copy, so the
+   value never hits stdout. Keeps the item and the local file in lockstep.
+   Warns (and prints the manual `op item edit` one-liner) if the desktop
+   session isn't signed in or lacks write access.
+4. Renders `secrets.json` with `OP_SERVICE_ACCOUNT_TOKEN` set explicitly
    from the just-installed file — bypassing `op-toggle` entirely, so the
    fresh token is what actually lands in the render.
-4. Verifies with `op whoami` / `op vault list` (metadata only, never prints
-   the token) and warns if any secrets.json field known to need the
-   `automation` vault came back empty.
-5. Prints — but does not run — the `just push-secrets <hosts>` command to
-   propagate to the rest of the fleet. Fleet propagation is left as a
-   deliberate manual step.
+5. Verifies with `op whoami` / `op vault list` (metadata only, never prints
+   the token), warns if any secrets.json field known to need the
+   `automation` vault came back empty, and runs a bare `render-secrets
+   --check` (the op-toggle path) to confirm the token embedded in
+   `secrets.json` authenticates. If it doesn't, the rotation **exits
+   non-zero** with the exact `op item edit` fix — the item still holds the
+   wrong token. On success it prints (but does not run) the
+   `just push-secrets <hosts>` command for the rest of the fleet.
 
 If a full SA regeneration produced a *new* 1Password item (not just a new
 token value in the existing item), update `secrets.json.tpl`'s

--- a/extras/docs/secrets.md
+++ b/extras/docs/secrets.md
@@ -82,12 +82,22 @@ Deleted)` even though the new token is fine).
 
 ```bash
 just rotate-op-token             # walks the full sequence, one host
+just rotate-op-token --manual    # paste the token instead of op read
 ```
 
+The script writes the new token to **both** the local file and the
+1Password item (step 3, via your desktop session — one biometric prompt),
+so the two can't drift. That drift is the classic silent failure: the file
+gets the new token but the item keeps the old one, and every op-toggle /
+`push-secrets` call then reads the dead token with nothing to warn you. To
+catch it regardless, step 5 runs a bare `render-secrets --check` (the
+op-toggle path) and **fails the rotation** if the embedded token doesn't
+authenticate, printing the exact `op item edit` one-liner to fix it.
+
 See `extras/docs/helpers.md`'s `rotate-op-service-account.sh` section for
-what it does step by step. It prints — but does not run — the
-`push-secrets` command for the rest of the fleet; run that yourself once
-you're happy with the verification output.
+the full step-by-step. It prints — but does not run — the `push-secrets`
+command for the rest of the fleet; run that yourself once you're happy with
+the verification output.
 
 ## Materialized host files
 

--- a/extras/helpers/rotate-op-service-account.sh
+++ b/extras/helpers/rotate-op-service-account.sh
@@ -15,14 +15,25 @@
 # looks broken (every command keeps re-loading the stale, dead token from
 # the old render).
 #
+# The classic silent failure is DRIFT between (2) and (3): the local file
+# gets the new token but the 1Password item is never updated (or updated with
+# a different token). Then op-toggle and `push-secrets` keep reading the dead
+# token from the item forever, with nothing to tell you. This script closes
+# that gap: it writes the rotated token to BOTH places itself, and verifies
+# the op-toggle path before claiming success.
+#
 # This script:
-#   1. Prints the manual 1Password steps and waits for you to do them.
+#   1. Prints the manual 1Password steps (generate/rotate the token, confirm
+#      vault grants) and waits for you.
 #   2. Installs the token locally (setup-op-service-account.sh --force).
-#   3. Renders secrets.json with an EXPLICIT token override -- bypassing
-#      op-toggle entirely, so step 2's fresh token is what actually lands.
-#   4. Verifies auth and reports which vaults are visible (metadata only --
-#      never prints token/secret values).
-#   5. Prints (does not run) the push-secrets command for the fleet.
+#   3. Writes that same token into the 1Password item the template reads from
+#      (desktop session -- one biometric prompt), so the file and the item
+#      can never drift.
+#   4. Renders secrets.json with an EXPLICIT token override -- bypassing
+#      op-toggle entirely, so the fresh token is what actually lands.
+#   5. Verifies auth AND the op-toggle path (bare render-secrets --check),
+#      failing loudly if the embedded token is wrong (metadata only -- never
+#      prints token/secret values). Then prints the fleet push command.
 #
 # Usage:
 #   ./extras/helpers/rotate-op-service-account.sh            # op read (biometric)
@@ -64,31 +75,44 @@ if [[ -z "${item_ref}" ]]; then
   exit 1
 fi
 
+# Split the op:// reference into vault / item / field so step 3 can write the
+# rotated token back into the item -- keeping the 1Password item and the local
+# file in lockstep. Expected shape: op://<vault>/<item>/<field>.
+_ref_noproto="${item_ref#op://}"
+op_vault="${_ref_noproto%%/*}"
+_ref_rest="${_ref_noproto#*/}"
+op_item="${_ref_rest%%/*}"
+op_field="${_ref_rest#*/}"
+if [[ -z "${op_vault}" || -z "${op_item}" || -z "${op_field}" || "${op_item}" == "${op_field}" ]]; then
+  echo "rotate-op-service-account: couldn't parse vault/item/field from ${item_ref}" >&2
+  exit 1
+fi
+
 cat <<EOF
 
-=== Step 1 of 4: rotate the service account in 1Password ===
+=== Step 1 of 5: rotate the service account in 1Password ===
 
 In the 1Password web UI (Developer Tools -> the current SA, e.g. op-cli):
 
-  a. Rotate the token. If the old service account is unrecoverable, generate
-     a brand-new one instead -- if you do, update the op:// reference in
+  a. Rotate the token, or generate a brand-new service account if the old one
+     is unrecoverable. Copy the new token (starts with 'ops_'). If you made a
+     NEW service account, also update the op:// reference in
        ${TPL}
      ("onepassword.serviceAccountToken") to the new item BEFORE continuing,
      and re-run this script (it re-reads the template each time).
   b. Confirm the service account is granted READ on BOTH vaults:
        - nixerator
        - automation
-  c. Update the credential field at:
-       ${item_ref}
-     with the new token value. This is the ONLY 1Password item that needs
-     updating -- setup-op-service-account.sh reads from this same reference.
 
-Press Enter once all three are done...
+You do NOT need to update the item's credential field by hand -- step 3 does
+that for you, from the same token, so the file and the item can't drift.
+
+Press Enter once the token is rotated and vault grants confirmed...
 EOF
 read -r _
 
 echo
-echo "=== Step 2 of 4: install the token locally ==="
+echo "=== Step 2 of 5: install the token locally ==="
 echo
 "${SCRIPT_DIR}/setup-op-service-account.sh" --force "${PASSTHROUGH_ARGS[@]}"
 
@@ -98,7 +122,34 @@ if [[ ! -f "${CANONICAL}" ]]; then
 fi
 
 echo
-echo "=== Step 3 of 4: render secrets.json (explicit token, bypassing op-toggle) ==="
+echo "=== Step 3 of 5: sync the token into the 1Password item ==="
+echo
+echo "Writing the installed token into ${item_ref}"
+echo "(desktop 1Password session -- may prompt for biometric approval)."
+# Blind copy: the value flows file -> op arg, never to stdout. Force the
+# desktop session (unset any SA token) so this uses YOUR write access, not the
+# read-only SA. Output suppressed so a concealed field can never echo.
+item_synced=0
+if env -u OP_SERVICE_ACCOUNT_TOKEN op whoami >/dev/null 2>&1; then
+  if env -u OP_SERVICE_ACCOUNT_TOKEN op item edit "${op_item}" \
+       "${op_field}=$(<"${CANONICAL}")" --vault "${op_vault}" >/dev/null 2>&1; then
+    echo "  item updated: file and 1Password item now hold the same token."
+    item_synced=1
+  else
+    echo "  WARNING: couldn't write the item (no write access, or wrong item/field)." >&2
+  fi
+else
+  echo "  WARNING: desktop 1Password isn't signed in -- skipping the item update." >&2
+  echo "  Run 'op signin' and re-run, or update it yourself:" >&2
+fi
+if [[ "${item_synced}" -eq 0 ]]; then
+  echo "    op item edit ${op_item} \"${op_field}=\$(cat ${CANONICAL})\" --vault ${op_vault}" >&2
+  echo "  Until the item matches the file, op-toggle and push-secrets keep using" >&2
+  echo "  the OLD token (step 5 will flag this)." >&2
+fi
+
+echo
+echo "=== Step 4 of 5: render secrets.json (explicit token, bypassing op-toggle) ==="
 echo
 if ! command -v render-secrets >/dev/null 2>&1; then
   echo "rotate-op-service-account: 'render-secrets' not on PATH." >&2
@@ -108,7 +159,7 @@ fi
 OP_SERVICE_ACCOUNT_TOKEN="$(<"${CANONICAL}")" render-secrets
 
 echo
-echo "=== Step 4 of 4: verify ==="
+echo "=== Step 5 of 5: verify ==="
 echo
 OP_SERVICE_ACCOUNT_TOKEN="$(<"${CANONICAL}")" op whoami
 echo
@@ -126,14 +177,37 @@ if [[ ${#missing[@]} -gt 0 ]]; then
   echo "  (values not shown -- checked for presence only)" >&2
 fi
 
-cat <<EOF
+# The critical drift check: bare render-secrets (no explicit token) uses the
+# op-toggle path, which reads the token EMBEDDED in secrets.json -- i.e. the
+# value that came from the 1Password item. If this fails, the item still holds
+# the wrong token and push-secrets / op-toggle are silently broken fleet-wide.
+echo
+echo "Checking the op-toggle path (token embedded in secrets.json)..."
+if render-secrets --check >/dev/null 2>&1; then
+  echo "  OK: the embedded token authenticates. op-toggle and push-secrets will work."
+  toggle_ok=1
+else
+  toggle_ok=0
+  echo "  FAILED: the token embedded in secrets.json does NOT authenticate." >&2
+  echo "  The 1Password item (${item_ref}) still holds the old/wrong token, so" >&2
+  echo "  op-toggle and push-secrets stay broken until it's fixed:" >&2
+  echo "    op item edit ${op_item} \"${op_field}=\$(cat ${CANONICAL})\" --vault ${op_vault}" >&2
+  echo "  then re-run this script (or just 'render-secrets' once)." >&2
+fi
 
-Rotation complete on this host. op-toggle should now work normally -- it
-reads its "back to service-account" token from the secrets.json we just
-re-rendered.
+if [[ "${toggle_ok}" -eq 1 ]]; then
+  cat <<EOF
+
+Rotation complete and self-checked on this host. Both the local file and the
+1Password item hold the new token, and op-toggle reads it correctly.
 
 Next: propagate to the rest of the fleet, e.g.:
   just push-secrets donkeykong srv clanker
 (this script does not push automatically -- run that yourself once you're
 happy with the verification above.)
 EOF
+else
+  echo >&2
+  echo "Rotation is INCOMPLETE: fix the item (above) before pushing to the fleet." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Why

This session hit a nasty silent failure: the live service-account token in the local file had drifted from the (dead) token stored in the 1Password item. Because `render-secrets` (bare), `push-secrets`, and `op-toggle` all read the token embedded in the rendered `secrets.json` (which comes from that item), every "normal" secrets command 403'd with "Service Account Deleted" while an explicit-token render worked fine. Nothing surfaced the drift.

Root cause: `rotate-op-token` updated the local token file but left "update the 1Password item" as a manual step, and its verification only checked the *file* token, never the *embedded* one. So a half-finished rotation looked complete.

## What changed

`extras/helpers/rotate-op-service-account.sh`:

1. **New step 3 keeps the item and the file in lockstep.** After installing the token locally, the script writes that same token into the 1Password item the template reads from, using your desktop session (one biometric prompt). It's a blind copy: the value goes from the file straight into the `op` argument, never to stdout. If the desktop session is signed out or lacks write access, it warns and prints the exact `op item edit` one-liner instead of failing silently.
2. **Step 5 self-checks the op-toggle path.** It runs a bare `render-secrets --check`, which reads the token embedded in `secrets.json`. If that token doesn't authenticate, the rotation exits non-zero with the fix, rather than claiming success. This is the check that would have caught today's drift immediately.

Step 1 no longer tells you to update the credential item by hand (step 3 does it). `extras/docs/secrets.md` and `extras/docs/helpers.md` rotation sections are updated to match.

## Verified

- `bash -n` clean, `shellcheck` clean.
- op:// reference parsing tested against the real item ref: `op://nixerator/<item>/credential` splits correctly into vault / item / field.
- Not runtime-tested end to end: the script is interactive and needs a biometric prompt for the item write, which can't run headless. The failure paths (signed-out desktop, no write access, embedded-token mismatch) all degrade to a warning plus the manual one-liner, so a bad environment can't produce a false "rotation complete".

## Note

This does not itself fix the current drift on the fleet (the `zm7ky…` item still holds the dead token) — that needs a signed-in `op item edit`, which is a manual step. This PR makes the *next* rotation immune to the problem.