### PR TITLE
fix(srv): back up the docker-compose Caddy stack in restic

### DIFF
--- a/hosts/srv/modules.nix
+++ b/hosts/srv/modules.nix
@@ -290,7 +290,20 @@
     backup = {
       enable = true;
       secretsProfile = "srv";
-      backupPaths = [ "/srv/nfs" ];
+      backupPaths = [
+        "/srv/nfs"
+        # caddy is the only hand-authored config still live under ~/docker after
+        # forgejo/jellyfin/uptime-kuma moved to the k8s cluster (nixerator#174).
+        # Back up its reverse-proxy config, runtime config, TLS data, static
+        # site, and the compose file that defines the stack. caddy_data (certs)
+        # is regenerable from Let's Encrypt, so it is optional, kept only for a
+        # faster restore.
+        "/home/dustin/docker/Caddyfile"
+        "/home/dustin/docker/caddy_config"
+        "/home/dustin/docker/caddy_data"
+        "/home/dustin/docker/site"
+        "/home/dustin/docker/docker-compose.yaml"
+      ];
       restorePath = "/srv/nfs/restores";
       schedule = "*-*-* 03:00:00";
       keepDaily = 7;


### PR DESCRIPTION
## Summary

- `caddy` is the only hand-authored config still live under `~/docker` on srv after forgejo/jellyfin/uptime-kuma moved to the k8s cluster (nixerator#174).
- Add its reverse-proxy config, runtime config, TLS data, static site, and compose file to srv's restic backup paths. `caddy_data` (certs) is included only for a faster restore, not because it's load-bearing — it's regenerable from Let's Encrypt.

## Test plan

- [x] `just build-host srv` — clean
- [x] `just fmt` — no changes