### PR TITLE
style(nix): merge repeated attr-set keys flagged by statix (W20)

### DIFF
--- a/lib/mkHost.nix
+++ b/lib/mkHost.nix
@@ -32,141 +32,145 @@
         # Home Manager integration
         inputs.home-manager.nixosModules.home-manager
         {
-          # Allow unfree packages (e.g., Google Chrome)
-          nixpkgs.config.allowUnfree = true;
+          nixpkgs = {
+            config = {
+              # Allow unfree packages (e.g., Google Chrome)
+              allowUnfree = true;
 
-          # TEMPORARY insecure-package permit. pnpm 10.29.2 (pulled by
-          # apps.cli.pnpm in suites.dev on the workstations) is flagged by
-          # nixpkgs for CVE-2026-48995 / 50014 / 50015 / 50016 (plus 50017 /
-          # 50573 / 55699 in newer revs), so every workstation rebuild fails
-          # without this. srv never evaluates pnpm, so the entry is inert
-          # there. nixpkgs already ships secure pnpm_10 (10.34.4) and pnpm_11
-          # (11.9.0); the real fix is letting the default `pnpm` alias advance
-          # past 10.29.2 on the next `just qu` (flake update), then deleting this
-          # (or, sooner, pointing apps.cli.pnpm at pkgs.pnpm_11).
-          #
-          # REVISIT after any nixpkgs bump: remove this line and run
-          # `just build-host qbert` WITHOUT NIXPKGS_ALLOW_INSECURE. If it builds,
-          # the permit is stale and stays gone. The exact version string is
-          # deliberate: if pnpm bumps to another flagged version this stops
-          # matching and the build fails, forcing a fresh look instead of an
-          # ever-growing allowlist.
-          nixpkgs.config.permittedInsecurePackages = [
-            "pnpm-10.29.2"
-          ];
-
-          # Apply custom package overlays
-          nixpkgs.overlays = [
-            # llm-agents packages (exposes pkgs.llm-agents.<name>).
-            # Upstream dropped its `overlays` flake output (as of rev
-            # eacaf2df, 2026-07-12) in favor of exposing packages.<system>
-            # directly, so we wire it back into an overlay ourselves rather
-            # than touching every pkgs.llm-agents.<name> call site.
-            (final: _prev: {
-              llm-agents = inputs.llm-agents.packages.${final.system};
-            })
-
-            # Work around a nixpkgs bug that breaks `google-cloud-sdk.withExtraComponents`.
-            #
-            # Background: `package.nix` builds gcloud against Python 3.14, and the
-            # Google-shipped `bundled-python3-unix-linux-x86_64` component ships a
-            # `_tkinter` extension linked against tcl/tk *9.0*
-            # (`libtcl9.0.so` / `libtcl9tk9.0.so`). But `components.nix` `mkComponent`
-            # hardcodes `buildInputs = [ libxcrypt-legacy tcl-8_6 tclPackages.tk ]`,
-            # i.e. only tcl/tk *8.6*. This nixpkgs revision has no tk built against
-            # tcl 9, so auto-patchelf cannot satisfy the tcl9 sonames and the
-            # component build fails. (`libpython3.14.so.1.0` resolves at runtime via
-            # `$ORIGIN` and is a benign secondary failure.) Plain `google-cloud-sdk`
-            # substitutes from cache.nixos.org and is unaffected; only the local
-            # component build triggered by `withExtraComponents` (used in
-            # modules/suites/infrastructure for the gke-gcloud-auth-plugin) hits this.
-            #
-            # gcloud never invokes tkinter, so we tell auto-patchelf to ignore exactly
-            # the three missing libraries rather than packaging tk9 ourselves. We
-            # rebuild the entire component fixed-point so that every component — and
-            # every transitive `passthru.dependencies` edge walked by
-            # `findDepsRecursive` in withExtraComponents.nix — points at the patched
-            # derivations, then re-expose the fixed `components` set and a
-            # `withExtraComponents` that closes over it.
-            #
-            # Remove this overlay once nixpkgs gives gcloud components a tcl9-linked tk
-            # (or otherwise fixes the tcl 8.6 vs Python 3.14 tkinter mismatch).
-            (_final: prev: {
-              google-cloud-sdk =
-                let
-                  gcloudDir = "${prev.path}/pkgs/by-name/go/google-cloud-sdk";
-
-                  # auto-patchelf cannot satisfy these for the bundled python 3.14
-                  # component; none are used by gcloud at runtime.
-                  ignoreLibs = [
-                    "libtcl9.0.so"
-                    "libtcl9tk9.0.so"
-                    "libpython3.14.so.1.0"
-                  ];
-
-                  # Re-derive the raw component set from this nixpkgs revision.
-                  rawComponents = prev.callPackage "${gcloudDir}/components.nix" {
-                    snapshotPath = "${gcloudDir}/components.json";
-                  };
-
-                  # Rebuild the fixed-point so each component ignores the missing libs
-                  # AND its dependency edges reference the patched components (matched
-                  # by pname, which equals the component id / attr name).
-                  fixedComponents = prev.lib.fix (
-                    self:
-                    prev.lib.mapAttrs (
-                      _name: drv:
-                      drv.overrideAttrs (old: {
-                        autoPatchelfIgnoreMissingDeps = (old.autoPatchelfIgnoreMissingDeps or [ ]) ++ ignoreLibs;
-                        passthru = (old.passthru or { }) // {
-                          dependencies = map (d: self.${d.pname}) (old.passthru.dependencies or [ ]);
-                        };
-                      })
-                    ) rawComponents
-                  );
-
-                  fixedWithExtraComponents = prev.callPackage "${gcloudDir}/withExtraComponents.nix" {
-                    components = fixedComponents;
-                  };
-                in
-                prev.google-cloud-sdk.overrideAttrs (old: {
-                  passthru = (old.passthru or { }) // {
-                    components = fixedComponents;
-                    withExtraComponents = fixedWithExtraComponents;
-                  };
-                });
-            })
-
-            # Work around a broken pytest check in python3.14Packages.click-threading.
-            #
-            # click-threading's own test suite collects docs/conf.py as a test
-            # module (a stray sphinx config picked up by pytest's default
-            # collection), which imports pkg_resources. This nixpkgs revision's
-            # python3.14 doesn't propagate setuptools' pkg_resources by default,
-            # so collection errors out with ModuleNotFoundError and the whole
-            # build fails -- even though click-threading itself works fine.
-            # vdirsyncer depends on it (pulled in transitively by hyprflake's
-            # desktop.dank.calendar module on the workstations), so this broke
-            # every donkeykong/qbert rebuild.
-            #
-            # Remove once nixpkgs fixes click-threading's pytest collection (or
-            # adds setuptools as a checkInput upstream).
-            #
-            # Uses `pythonPackagesExtensions` (folded into every interpreter's
-            # package set, e.g. python314Packages) rather than overriding the
-            # `python3` alias directly -- vdirsyncer/khal may resolve
-            # click-threading through the version-numbered set, which a
-            # `python3.override` wouldn't reach.
-            (_final: prev: {
-              pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
-                (_pyFinal: pyPrev: {
-                  click-threading = pyPrev.click-threading.overridePythonAttrs (_old: {
-                    doCheck = false;
-                  });
-                })
+              # TEMPORARY insecure-package permit. pnpm 10.29.2 (pulled by
+              # apps.cli.pnpm in suites.dev on the workstations) is flagged by
+              # nixpkgs for CVE-2026-48995 / 50014 / 50015 / 50016 (plus 50017 /
+              # 50573 / 55699 in newer revs), so every workstation rebuild fails
+              # without this. srv never evaluates pnpm, so the entry is inert
+              # there. nixpkgs already ships secure pnpm_10 (10.34.4) and pnpm_11
+              # (11.9.0); the real fix is letting the default `pnpm` alias advance
+              # past 10.29.2 on the next `just qu` (flake update), then deleting this
+              # (or, sooner, pointing apps.cli.pnpm at pkgs.pnpm_11).
+              #
+              # REVISIT after any nixpkgs bump: remove this line and run
+              # `just build-host qbert` WITHOUT NIXPKGS_ALLOW_INSECURE. If it builds,
+              # the permit is stale and stays gone. The exact version string is
+              # deliberate: if pnpm bumps to another flagged version this stops
+              # matching and the build fails, forcing a fresh look instead of an
+              # ever-growing allowlist.
+              permittedInsecurePackages = [
+                "pnpm-10.29.2"
               ];
-            })
-          ];
+            };
+
+            # Apply custom package overlays
+            overlays = [
+              # llm-agents packages (exposes pkgs.llm-agents.<name>).
+              # Upstream dropped its `overlays` flake output (as of rev
+              # eacaf2df, 2026-07-12) in favor of exposing packages.<system>
+              # directly, so we wire it back into an overlay ourselves rather
+              # than touching every pkgs.llm-agents.<name> call site.
+              (final: _prev: {
+                llm-agents = inputs.llm-agents.packages.${final.system};
+              })
+
+              # Work around a nixpkgs bug that breaks `google-cloud-sdk.withExtraComponents`.
+              #
+              # Background: `package.nix` builds gcloud against Python 3.14, and the
+              # Google-shipped `bundled-python3-unix-linux-x86_64` component ships a
+              # `_tkinter` extension linked against tcl/tk *9.0*
+              # (`libtcl9.0.so` / `libtcl9tk9.0.so`). But `components.nix` `mkComponent`
+              # hardcodes `buildInputs = [ libxcrypt-legacy tcl-8_6 tclPackages.tk ]`,
+              # i.e. only tcl/tk *8.6*. This nixpkgs revision has no tk built against
+              # tcl 9, so auto-patchelf cannot satisfy the tcl9 sonames and the
+              # component build fails. (`libpython3.14.so.1.0` resolves at runtime via
+              # `$ORIGIN` and is a benign secondary failure.) Plain `google-cloud-sdk`
+              # substitutes from cache.nixos.org and is unaffected; only the local
+              # component build triggered by `withExtraComponents` (used in
+              # modules/suites/infrastructure for the gke-gcloud-auth-plugin) hits this.
+              #
+              # gcloud never invokes tkinter, so we tell auto-patchelf to ignore exactly
+              # the three missing libraries rather than packaging tk9 ourselves. We
+              # rebuild the entire component fixed-point so that every component — and
+              # every transitive `passthru.dependencies` edge walked by
+              # `findDepsRecursive` in withExtraComponents.nix — points at the patched
+              # derivations, then re-expose the fixed `components` set and a
+              # `withExtraComponents` that closes over it.
+              #
+              # Remove this overlay once nixpkgs gives gcloud components a tcl9-linked tk
+              # (or otherwise fixes the tcl 8.6 vs Python 3.14 tkinter mismatch).
+              (_final: prev: {
+                google-cloud-sdk =
+                  let
+                    gcloudDir = "${prev.path}/pkgs/by-name/go/google-cloud-sdk";
+
+                    # auto-patchelf cannot satisfy these for the bundled python 3.14
+                    # component; none are used by gcloud at runtime.
+                    ignoreLibs = [
+                      "libtcl9.0.so"
+                      "libtcl9tk9.0.so"
+                      "libpython3.14.so.1.0"
+                    ];
+
+                    # Re-derive the raw component set from this nixpkgs revision.
+                    rawComponents = prev.callPackage "${gcloudDir}/components.nix" {
+                      snapshotPath = "${gcloudDir}/components.json";
+                    };
+
+                    # Rebuild the fixed-point so each component ignores the missing libs
+                    # AND its dependency edges reference the patched components (matched
+                    # by pname, which equals the component id / attr name).
+                    fixedComponents = prev.lib.fix (
+                      self:
+                      prev.lib.mapAttrs (
+                        _name: drv:
+                        drv.overrideAttrs (old: {
+                          autoPatchelfIgnoreMissingDeps = (old.autoPatchelfIgnoreMissingDeps or [ ]) ++ ignoreLibs;
+                          passthru = (old.passthru or { }) // {
+                            dependencies = map (d: self.${d.pname}) (old.passthru.dependencies or [ ]);
+                          };
+                        })
+                      ) rawComponents
+                    );
+
+                    fixedWithExtraComponents = prev.callPackage "${gcloudDir}/withExtraComponents.nix" {
+                      components = fixedComponents;
+                    };
+                  in
+                  prev.google-cloud-sdk.overrideAttrs (old: {
+                    passthru = (old.passthru or { }) // {
+                      components = fixedComponents;
+                      withExtraComponents = fixedWithExtraComponents;
+                    };
+                  });
+              })
+
+              # Work around a broken pytest check in python3.14Packages.click-threading.
+              #
+              # click-threading's own test suite collects docs/conf.py as a test
+              # module (a stray sphinx config picked up by pytest's default
+              # collection), which imports pkg_resources. This nixpkgs revision's
+              # python3.14 doesn't propagate setuptools' pkg_resources by default,
+              # so collection errors out with ModuleNotFoundError and the whole
+              # build fails -- even though click-threading itself works fine.
+              # vdirsyncer depends on it (pulled in transitively by hyprflake's
+              # desktop.dank.calendar module on the workstations), so this broke
+              # every donkeykong/qbert rebuild.
+              #
+              # Remove once nixpkgs fixes click-threading's pytest collection (or
+              # adds setuptools as a checkInput upstream).
+              #
+              # Uses `pythonPackagesExtensions` (folded into every interpreter's
+              # package set, e.g. python314Packages) rather than overriding the
+              # `python3` alias directly -- vdirsyncer/khal may resolve
+              # click-threading through the version-numbered set, which a
+              # `python3.override` wouldn't reach.
+              (_final: prev: {
+                pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
+                  (_pyFinal: pyPrev: {
+                    click-threading = pyPrev.click-threading.overridePythonAttrs (_old: {
+                      doCheck = false;
+                    });
+                  })
+                ];
+              })
+            ];
+          };
 
           nix = {
             settings.experimental-features = [

--- a/modules/archive/server/incus/default.nix
+++ b/modules/archive/server/incus/default.nix
@@ -190,11 +190,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    # Incus on NixOS is unsupported on iptables; the upstream module asserts
-    # nftables. Switch the host firewall backend here so enabling this module is
-    # self-contained. mkDefault lets a host that manages nftables elsewhere win.
-    networking.nftables.enable = lib.mkDefault true;
-
     virtualisation.incus = {
       enable = true;
       ui.enable = cfg.ui.enable;
@@ -289,25 +284,34 @@ in
       exit 0
     '';
 
-    # Open the Incus API/UI port on all interfaces. The daemon already binds
-    # all interfaces (core.https_address above), so this makes it reachable
-    # on LAN, Tailscale, and loopback without per-host firewall overrides.
-    networking.firewall.allowedTCPPorts = lib.mkIf cfg.ui.enable [ cfg.ui.port ];
+    networking = {
+      # Incus on NixOS is unsupported on iptables; the upstream module asserts
+      # nftables. Switch the host firewall backend here so enabling this module is
+      # self-contained. mkDefault lets a host that manages nftables elsewhere win.
+      nftables.enable = lib.mkDefault true;
 
-    # Trust the Incus NAT bridges so instances can reach the host's dnsmasq for
-    # DHCP/DNS. Without this the nixos-fw input chain (policy drop) silently eats
-    # the instances' DHCP requests even though Incus's own nftables table accepts
-    # them, and instances boot but never get an address. Covers the managed
-    # bridge plus any explicitly-named Terraform bridges (trustedBridges).
-    networking.firewall.trustedInterfaces = [ cfg.network.name ] ++ cfg.trustedBridges;
+      firewall = {
+        # Open the Incus API/UI port on all interfaces. The daemon already binds
+        # all interfaces (core.https_address above), so this makes it reachable
+        # on LAN, Tailscale, and loopback without per-host firewall overrides.
+        allowedTCPPorts = lib.mkIf cfg.ui.enable [ cfg.ui.port ];
 
-    # And trust every per-cluster bridge sharing the naming convention with one
-    # wildcard rule, so a new Terraform cluster (e.g. tbr-darkstar) works without
-    # editing this module. trustedInterfaces can't express a wildcard, so this
-    # goes in as a raw input rule.
-    networking.firewall.extraInputRules = lib.optionalString (cfg.trustedBridgePrefix != "") ''
-      iifname "${cfg.trustedBridgePrefix}*" accept comment "trust Incus per-cluster bridges"
-    '';
+        # Trust the Incus NAT bridges so instances can reach the host's dnsmasq for
+        # DHCP/DNS. Without this the nixos-fw input chain (policy drop) silently eats
+        # the instances' DHCP requests even though Incus's own nftables table accepts
+        # them, and instances boot but never get an address. Covers the managed
+        # bridge plus any explicitly-named Terraform bridges (trustedBridges).
+        trustedInterfaces = [ cfg.network.name ] ++ cfg.trustedBridges;
+
+        # And trust every per-cluster bridge sharing the naming convention with one
+        # wildcard rule, so a new Terraform cluster (e.g. tbr-darkstar) works without
+        # editing this module. trustedInterfaces can't express a wildcard, so this
+        # goes in as a raw input rule.
+        extraInputRules = lib.optionalString (cfg.trustedBridgePrefix != "") ''
+          iifname "${cfg.trustedBridgePrefix}*" accept comment "trust Incus per-cluster bridges"
+        '';
+      };
+    };
 
     # Desktop launchers for the web UI. The local entry opens this host's daemon
     # over loopback (always works on the host). Each ui.remotes entry adds a


### PR DESCRIPTION
Runs statix across the flake and fixes the two `W20` "avoid repeated keys in attribute sets" findings.

- **lib/mkHost.nix** — the three `nixpkgs.*` assignments (`config.allowUnfree`, `config.permittedInsecurePackages`, `overlays`) are folded into one `nixpkgs = { config = {...}; overlays = [...]; }` block. The shared `config` key is nested too, so the merge doesn't just push the warning down a level.
- **modules/archive/server/incus/default.nix** — the scattered `networking.nftables.enable` and `networking.firewall.*` keys collapse into a single `networking = { firewall = {...}; }` block. The `firewall` keys share a nested block for the same reason. The firewall comments reference `core.https_address above`, so the merged block stays at the lower position and `nftables.enable` moves down to join it.

Pure restructuring — NixOS merges nested attrs identically to dotted paths, so evaluation is unchanged.

Verified: statix clean (2 → 0 warnings) across all 194 nix files, `nix fmt` idempotent on both files, diffs are brace-only ignoring whitespace.