### PR TITLE
chore(brave): disable Brave browser on workstations

### DIFF
--- a/modules/suites/browsers/default.nix
+++ b/modules/suites/browsers/default.nix
@@ -16,7 +16,8 @@ in
     # Browser applications
     apps.gui = {
       # Brave Origin replaces the retired stock-brave module.
-      brave-origin.enable = true;
+      # Disabled on workstations; module left importable for a quick re-enable.
+      brave-origin.enable = false;
       google-chrome.enable = true;
       # google-chrome.enableDev = true;
       helium.enable = true;


### PR DESCRIPTION
Disables the Brave browser on the workstations without archiving the module.

## What

Flips `apps.gui.brave-origin.enable` `true → false` at its source enable point — `modules/suites/browsers/default.nix`. The workstation archetype pulls in `suites.browsers`, so this affects qbert and donkeykong only; headless srv doesn't use the archetype and never pulled Brave in.

The module is left fully in place and importable (`modules/apps/gui/brave-origin/`, the version pin, and the web-app-hub references are all untouched) — nothing moved to `modules/archive/`, so re-enabling later is a one-line flip back.

## Verification

`just build-host qbert` and `just build-host donkeykong` both pass.