### PR TITLE
fix(justfile): gate bump-recipe success on system profile advancing

### DIFF
--- a/justfile
+++ b/justfile
@@ -704,7 +704,6 @@ bump-upsight:
     # Back up the lock so a failed bump reverts cleanly and never leaves the tree
     # pinned to a broken upsight commit (an un-buildable next rebuild).
     cp flake.lock flake.lock-backup-bump
-    before_system="$(readlink -f /run/current-system)"
     rc=0
     # &&-chain so a failed input update aborts instead of rebuilding on the old
     # lock (a bare `;` group would mask its exit status).
@@ -717,11 +716,12 @@ bump-upsight:
     } &> {{rebuild_log}} || rc=$?
     # `nixos-rebuild switch` exits non-zero when a unit fails to (re)start during
     # activation (e.g. systemd-bless-boot on a boot entry without a counter) even
-    # though the new system WAS activated. Reverting the lock then would strand it
-    # behind the running system. Treat the switch as good when the profile actually
-    # advanced, regardless of the exit code.
-    after_system="$(readlink -f /run/current-system)"
-    if [[ "$rc" -eq 0 || "$after_system" != "$before_system" ]]; then
+    # though the new system built and activated fine. Only revert when the build
+    # never reached activation (a genuinely un-buildable pin). A non-zero exit that
+    # still printed "activating the configuration" is unit-restart noise — an
+    # idempotent re-run advances no profile either, so gate on activation, not on
+    # the exit code or a profile diff.
+    if [[ "$rc" -eq 0 ]] || grep -qF 'activating the configuration' {{rebuild_log}}; then
         if [[ "$rc" -ne 0 ]]; then
             echo "⚠ New config activated but a unit failed to (re)start (exit $rc). Review {{rebuild_log}}."
         fi
@@ -778,7 +778,6 @@ bump-hyprflake hyprflake_path="/home/dustin/git/hyprflake":
     # Back up the lock so a failed bump reverts cleanly and never leaves the tree
     # pinned to an un-buildable hyprflake commit.
     cp flake.lock flake.lock-backup-bump
-    before_system="$(readlink -f /run/current-system)"
     rc=0
     {
         # --refresh bypasses Nix's tarball-ttl so the just-pushed hyprflake HEAD
@@ -788,11 +787,12 @@ bump-hyprflake hyprflake_path="/home/dustin/git/hyprflake":
     } &> {{rebuild_log}} || rc=$?
     # `nixos-rebuild switch` exits non-zero when a unit fails to (re)start during
     # activation (e.g. systemd-bless-boot on a boot entry without a counter) even
-    # though the new system WAS activated. Reverting the lock then would strand it
-    # behind the running system. Treat the switch as good when the profile actually
-    # advanced, regardless of the exit code.
-    after_system="$(readlink -f /run/current-system)"
-    if [[ "$rc" -eq 0 || "$after_system" != "$before_system" ]]; then
+    # though the new system built and activated fine. Only revert when the build
+    # never reached activation (a genuinely un-buildable pin). A non-zero exit that
+    # still printed "activating the configuration" is unit-restart noise — an
+    # idempotent re-run advances no profile either, so gate on activation, not on
+    # the exit code or a profile diff.
+    if [[ "$rc" -eq 0 ]] || grep -qF 'activating the configuration' {{rebuild_log}}; then
         if [[ "$rc" -ne 0 ]]; then
             echo "⚠ New config activated but a unit failed to (re)start (exit $rc). Review {{rebuild_log}}."
         fi

--- a/justfile
+++ b/justfile
@@ -704,6 +704,7 @@ bump-upsight:
     # Back up the lock so a failed bump reverts cleanly and never leaves the tree
     # pinned to a broken upsight commit (an un-buildable next rebuild).
     cp flake.lock flake.lock-backup-bump
+    before_system="$(readlink -f /run/current-system)"
     rc=0
     # &&-chain so a failed input update aborts instead of rebuilding on the old
     # lock (a bare `;` group would mask its exit status).
@@ -714,7 +715,16 @@ bump-upsight:
         nix flake update upsight --refresh \
             && sudo nixos-rebuild switch --impure --flake {{host_flake}}
     } &> {{rebuild_log}} || rc=$?
-    if [[ "$rc" -eq 0 ]]; then
+    # `nixos-rebuild switch` exits non-zero when a unit fails to (re)start during
+    # activation (e.g. systemd-bless-boot on a boot entry without a counter) even
+    # though the new system WAS activated. Reverting the lock then would strand it
+    # behind the running system. Treat the switch as good when the profile actually
+    # advanced, regardless of the exit code.
+    after_system="$(readlink -f /run/current-system)"
+    if [[ "$rc" -eq 0 || "$after_system" != "$before_system" ]]; then
+        if [[ "$rc" -ne 0 ]]; then
+            echo "⚠ New config activated but a unit failed to (re)start (exit $rc). Review {{rebuild_log}}."
+        fi
         rm -f flake.lock-backup-bump
         echo "upsight bumped + rebuilt. Full log: {{rebuild_log}}"
         # Auto-commit + push the refreshed lock so it never lingers uncommitted
@@ -768,6 +778,7 @@ bump-hyprflake hyprflake_path="/home/dustin/git/hyprflake":
     # Back up the lock so a failed bump reverts cleanly and never leaves the tree
     # pinned to an un-buildable hyprflake commit.
     cp flake.lock flake.lock-backup-bump
+    before_system="$(readlink -f /run/current-system)"
     rc=0
     {
         # --refresh bypasses Nix's tarball-ttl so the just-pushed hyprflake HEAD
@@ -775,7 +786,16 @@ bump-hyprflake hyprflake_path="/home/dustin/git/hyprflake":
         nix flake update hyprflake --refresh \
             && sudo nixos-rebuild switch --impure --flake {{host_flake}}
     } &> {{rebuild_log}} || rc=$?
-    if [[ "$rc" -eq 0 ]]; then
+    # `nixos-rebuild switch` exits non-zero when a unit fails to (re)start during
+    # activation (e.g. systemd-bless-boot on a boot entry without a counter) even
+    # though the new system WAS activated. Reverting the lock then would strand it
+    # behind the running system. Treat the switch as good when the profile actually
+    # advanced, regardless of the exit code.
+    after_system="$(readlink -f /run/current-system)"
+    if [[ "$rc" -eq 0 || "$after_system" != "$before_system" ]]; then
+        if [[ "$rc" -ne 0 ]]; then
+            echo "⚠ New config activated but a unit failed to (re)start (exit $rc). Review {{rebuild_log}}."
+        fi
         rm -f flake.lock-backup-bump
         echo "hyprflake bumped + rebuilt. Full log: {{rebuild_log}}"
         # Auto-commit + push the refreshed lock, gated to main; push is non-fatal.


### PR DESCRIPTION
The `bump-hyprflake` and `bump-upsight` recipes treated any non-zero exit from `nixos-rebuild switch` as a failed rebuild and reverted `flake.lock`. But `switch-to-configuration switch` also exits non-zero when the new system activates fine and only a benign unit fails to (re)start. A live `just bump-hyprflake` run hit exactly this: the switch activated the new config, but `systemd-bless-boot.service` failed with "Can't find boot counter source file", the recipe saw exit 4, and it reverted the lock. That left the committed `flake.lock` on the old input while the running system was already on the new one.

Both recipes now revert only when the rebuild never reached activation (a genuinely un-buildable pin). Success is "exit was 0, or the log shows `activating the configuration`". A non-zero exit after activation prints a warning naming the log and continues (commit + push + post-rebuild) instead of reverting. Gating on the activation marker rather than a `/run/current-system` diff also handles an idempotent re-run, where the profile does not move even though the switch succeeded.

Scope note: `quiet` and `quiet-upgrade` share the same exit-code sensitivity but do not revert the lock, so they are lower-risk and left as-is here. The cleaner long-term fix is to stop `systemd-bless-boot` failing at the source (boot-counting config), tracked separately.